### PR TITLE
fixing locales

### DIFF
--- a/_locales/am/messages.json
+++ b/_locales/am/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "የታጠቡት የመጀመሪያ ጭምርን አርምያ"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "የፈረሰኞች ዝግጅት ከስልክ ፍርቂ አውርድ"
-    }
+	"hideHomePageShorts": {
+		"message": "የታጠቡት የመጀመሪያ ጭምርን አርምያ"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "የፈረሰኞች ዝግጅት ከስልክ ፍርቂ አውርድ"
+	}
 }

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,833 +1,800 @@
 {
-    "about": {
-        "message": "حول"
-    },
-    "accept": {
-        "message": "قبول"
-    },
-    "activate": {
-        "message": "تفعيل"
-    },
-    "activateCaptions": {
-        "message": "تفعيل الترجمة"
-    },
-    "activated": {
-        "message": "مفعل"
-    },
-    "activatedFeatures": {
-        "message": "الميزات المفعلة"
-    },
-    "activateFullscreen": {
-        "message": "تفعيل ملء الشاشة"
-    },
-    "activeFeatures": {
-        "message": "الميزات النشطة"
-    },
-    "addScrollToTop": {
-        "message": "آضف الصعود لأعلى"
-    },
-    "ads": {
-        "message": "الاعلانات"
-    },
-    "all": {
-        "message": "الكل"
-    },
-    "allow": {
-        "message": "سماح"
-    },
-    "alwaysActive": {
-        "message": "دائما نشط"
-    },
-    "alwaysShowProgressBar": {
-        "message": "إظهار شريط التقدم دائمًا"
-    },
-    "amber": {
-        "message": "العنبر"
-    },
-    "analyzer": {
-        "message": "المحلل"
-    },
-    "appearance": {
-        "message": "المظهر العام"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Are you sure you want to import the data?"
-    },
-    "ARROWDOWN": {
-        "message": "⇩"
-    },
-    "ARROWLEFT": {
-        "message": "⇦"
-    },
-    "ARROWRIGHT": {
-        "message": "⇨"
-    },
-    "ARROWUP": {
-        "message": "⇧"
-    },
-    "audio": {
-        "message": "الصوت"
-    },
-    "audioFormats": {
-        "message": "تنسيقات الصوت"
-    },
-    "auto": {
-        "message": "تلقائي"
-    },
-    "autoFullscreen": {
-        "message": "ملء تلقائي للشاشة"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "إيقاف تلقائي عند التبديل بين التبويبات"
-    },
-    "autoplay": {
-        "message": "تشغيل تلقائي"
-    },
-    "backupAndReset": {
-        "message": "إعادة تعيين والنسخ الاحتياطي"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "يناء على ألوان النظام"
-    },
-    "belowPlayer": {
-        "message": "اسفل المشغل"
-    },
-    "black": {
-        "message": "اسود"
-    },
-    "blockAll": {
-        "message": "حظر الكل"
-    },
-    "blocklist": {
-        "message": "القائمة السوداء"
-    },
-    "blue": {
-        "message": "ازرق"
-    },
-    "blueGray": {
-        "message": "ازرق رمادي"
-    },
-    "bluelight": {
-        "message": "الضوء الأزرق"
-    },
-    "brown": {
-        "message": "بنى"
-    },
-    "browser": {
-        "message": "المتصفح"
-    },
-    "browserAccountSync": {
-        "message": "مزامنة (حساب المتصفح)"
-    },
-    "browserVersion": {
-        "message": "إصدار المتصفح"
-    },
-    "bubbles": {
-        "message": "فقاعات"
-    },
-    "bug": {
-        "message": "خلل برمجي"
-    },
-    "cancel": {
-        "message": "إلغاء"
-    },
-    "categories": {
-        "message": "التصنيفات"
-    },
-    "channel": {
-        "message": "قناة"
-    },
-    "channels": {
-        "message": "القنوات"
-    },
-    "clipboard": {
-        "message": "الحافظة"
-    },
-    "codecH264": {
-        "message": "h.الترميز 264"
-    },
-    "collapsed": {
-        "message": "ضغط"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "ضغط قسم الاشتراكات"
-    },
-    "comments": {
-        "message": "التعليقات"
-    },
-    "confirmationBeforeClosing": {
-        "message": "التأكيد قبل الإغلاق"
-    },
-    "cookies": {
-        "message": "ملفات تعريف الارتباط"
-    },
-    "cores": {
-        "message": "النواه"
-    },
-    "cropChapterTitles": {
-        "message": "اقتطاع عناوين الفصول"
-    },
-    "customCss": {
-        "message": "مخصص CSS"
-    },
-    "customJs": {
-        "message": "مخصص JS"
-    },
-    "customMiniPlayer": {
-        "message": "المشغل الصغير المخصص"
-    },
-    "cyan": {
-        "message": "ازرق سماوي"
-    },
-    "dark": {
-        "message": "داكن"
-    },
-    "darkTheme": {
-        "message": "مظهر داكن"
-    },
-    "dateAndTime": {
-        "message": "التاريخ والوقت"
-    },
-    "dawn": {
-        "message": "فجر"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "تقليل سرعة التشغيل"
-    },
-    "decreaseVolume": {
-        "message": "خفض الصوت"
-    },
-    "deepOrange": {
-        "message": "برتقالي داكن"
-    },
-    "deepPurple": {
-        "message": "أرجواني داكن"
-    },
-    "defaultChannelTab": {
-        "message": "علامة تبويب القناة الافتراضية"
-    },
-    "deleteYoutubeCookies": {
-        "message": "حذف ملفات تعريف الارتباط من اليوتيوب"
-    },
-    "desert": {
-        "message": "صحراء"
-    },
-    "details": {
-        "message": "التفاصيل"
-    },
-    "developerOptions": {
-        "message": "خيارات المطور"
-    },
-    "device": {
-        "message": "الجهاز"
-    },
-    "dim": {
-        "message": "داكن"
-    },
-    "disabled": {
-        "message": "معطل"
-    },
-    "dislike": {
-        "message": "لم يعجبنى"
-    },
-    "donate": {
-        "message": "تبرع"
-    },
-    "doNotChange": {
-        "message": "الإفتراضي"
-    },
-    "draggable": {
-        "message": "قابل للسحب"
-    },
-    "email": {
-        "message": "البريد الإلكتروني"
-    },
-    "empty": {
-        "message": "فارغة"
-    },
-    "enabled": {
-        "message": "ممكّن"
-    },
-    "enabledForced": {
-        "message": "ممكّن (إجباري)"
-    },
-    "expanded": {
-        "message": "موسع"
-    },
-    "exportSettings": {
-        "message": "تصدير الإعدادات"
-    },
-    "extension": {
-        "message": "الإضافة"
-    },
-    "ExtraButtons": {
-        "message": "أزرار إضافية"
-    },
-    "file": {
-        "message": "ملف"
-    },
-    "filters": {
-        "message": "مرشحات"
-    },
-    "fitToWindow": {
-        "message": "مناسب للنافذة"
-    },
-    "flash": {
-        "message": "فلاش"
-    },
-    "font": {
-        "message": "الخط"
-    },
-    "footer": {
-        "message": "الحزء السفلي"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "تثبيت سرعة التشغيل"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forced play video from the beginning"
-    },
-    "forcedTheaterMode": {
-        "message": "فرض وضع المسرح"
-    },
-    "forcedVolume": {
-        "message": "تثبيت مستوى الصوت"
-    },
-    "forceSDR": {
-        "message": "SDR فرض"
-    },
-    "foundABug": {
-        "message": "وجدت خطأ؟"
-    },
-    "fullWindow": {
-        "message": "نافذة كاملة"
-    },
-    "general": {
-        "message": "عام"
-    },
-    "github": {
-        "message": "جيتهب"
-    },
-    "goToSearchBox": {
-        "message": "انتقل إلى مربع البحث"
-    },
-    "gpu": {
-        "message": "كرت الشاشة"
-    },
-    "green": {
-        "message": "أخضر"
-    },
-    "hdThumbnail": {
-        "message": "صورة مصغرة عالية الدقة"
-    },
-    "header": {
-        "message": "الجزء العلوي"
-    },
-    "hidden": {
-        "message": "مخفي"
-    },
-    "hiddenOnVideoPage": {
-        "message": "مخفي على صفحة الفيديو"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "إخفاء الصور المصغرة المتحركة"
-    },
-    "hideAnnotations": {
-        "message": "إخفاء التعليقات التوضيحية"
-    },
-    "hideCards": {
-        "message": "إخفاء البطاقات"
-    },
-    "hideDetails": {
-        "message": "إخفاء التفاصيل"
-    },
-    "hideEndscreen": {
-        "message": "إخفاء شاشة النهاية"
-    },
-    "hideFeaturedContent": {
-        "message": "إخفاء المحتوى المميز"
-    },
-    "hideFooter": {
-        "message": "إخفاء الجزء السفلي"
-    },
-    "hideGradientBottom": {
-        "message": "إخفاء التدرج الأسود السفلي"
-    },
-    "hideHomePageShorts": {
-        "message": "إزالة الشورت من الصفحة الرئيسية"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Hide player controls bar buttons"
-    },
-    "hidePlaylist": {
-        "message": "إخفاء قائمة التشغيل"
-    },
-    "hideRightButtons": {
-        "message": "إخفاء الأزرار اليسرى"
-    },
-    "hideScrollForDetails": {
-        "message": "«إخفاء «التمرير للحصول على التفاصيل"
-    },
-    "hideViewsCount": {
-        "message": "إخفاء عدد المشاهدات"
-    },
-    "history": {
-        "message": "السجلّ"
-    },
-    "home": {
-        "message": "الصفحة الرئيسية"
-    },
-    "hover": {
-        "message": "تمرير"
-    },
-    "hoverOnVideoPage": {
-        "message": "تمرير فوق صفحة الفيديو"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "منذ متى تم تحميل الفيديو"
-    },
-    "icons": {
-        "message": "أيقونات"
-    },
-    "iconsOnly": {
-        "message": "أيقونات فقط"
-    },
-    "importSettings": {
-        "message": "استيراد الاعدادات"
-    },
-    "ImprovedTube": {
-        "message": "ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "في اليوتيوب ImprovedTube ايقونة"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube لغة"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube اصدار"
-    },
-    "improveLogo": {
-        "message": "تحسين الشعار"
-    },
-    "increasePlaybackSpeed": {
-        "message": "زيادة سرعة التشغيل"
-    },
-    "increaseVolume": {
-        "message": "زيادة الصوت"
-    },
-    "indigo": {
-        "message": "نيلي"
-    },
-    "items": {
-        "message": "العناصر"
-    },
-    "languages": {
-        "message": "اللغات"
-    },
-    "legacyYoutube": {
-        "message": "اليوتيوب القديم"
-    },
-    "light": {
-        "message": "ضوء"
-    },
-    "lightBlue": {
-        "message": "أزرق فاتح"
-    },
-    "lightGreen": {
-        "message": "اخضر فاتح"
-    },
-    "like": {
-        "message": "اعحبني"
-    },
-    "lime": {
-        "message": "جير"
-    },
-    "list": {
-        "message": "قائمة"
-    },
-    "liveChat": {
-        "message": "محادثة مباشرة"
-    },
-    "liveChatType": {
-        "message": "نوع المحادثة مباشرة"
-    },
-    "loudnessNormalization": {
-        "message": "تطبيع الإزعاج"
-    },
-    "markWatchedVideos": {
-        "message": "التعليم على الفيديو المشاهد"
-    },
-    "mixer": {
-        "message": "مهندس الصوت"
-    },
-    "myColors": {
-        "message": "ألواني"
-    },
-    "name": {
-        "message": "الاسم"
-    },
-    "nativeMiniPlayer": {
-        "message": "المشغل الافتراضي الصغير"
-    },
-    "new": {
-        "message": "جديد"
-    },
-    "nextVideo": {
-        "message": "الفيديو التالي"
-    },
-    "night": {
-        "message": "ليل"
-    },
-    "noActiveFeatures": {
-        "message": "لا يوجد ميزات نشطة"
-    },
-    "none": {
-        "message": "لاشيء"
-    },
-    "noOpenVideoTabs": {
-        "message": "لا توجد علامات تبويب فيديو مفتوحة"
-    },
-    "normal": {
-        "message": "عادي"
-    },
-    "old": {
-        "message": "قديم"
-    },
-    "onAllVideos": {
-        "message": "على جميع مقاطع الفيديو"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "نشط فقط على اليوتيوب"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "تشغيل مشغل واحد فقط"
-    },
-    "onSubscribedChannels": {
-        "message": "على القنوات المشتركة"
-    },
-    "orange": {
-        "message": "برتقالي"
-    },
-    "os": {
-        "message": "نظام التشغيل"
-    },
-    "other": {
-        "message": "آخر"
-    },
-    "permissions": {
-        "message": "الأذونات"
-    },
-    "pictureInPicture": {
-        "message": "فيديو عائم"
-    },
-    "pink": {
-        "message": "زهري"
-    },
-    "plain": {
-        "message": "عادي"
-    },
-    "platform": {
-        "message": "المنصة"
-    },
-    "playbackSpeed": {
-        "message": "سرعة التشغيل"
-    },
-    "player": {
-        "message": "المشغل"
-    },
-    "playerColor": {
-        "message": "لون المشغل"
-    },
-    "playerSize": {
-        "message": "حجم المشغل"
-    },
-    "playlist": {
-        "message": "قائمة التشغيل"
-    },
-    "playlists": {
-        "message": "قوائم التشغيل"
-    },
-    "playPause": {
-        "message": "تشغيل / ايقاف"
-    },
-    "popupPlayer": {
-        "message": "مشفل منبثق"
-    },
-    "position": {
-        "message": "التموضع"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": ".اضغط على أي مفتاح أو استخدم عجلة الماوس"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "اضغط على أي مفتاح أو استخدم عجلة الماوس"
-    },
-    "previousVideo": {
-        "message": "الفيديو السابق"
-    },
-    "primaryColor": {
-        "message": "اللون الأصلي"
-    },
-    "purple": {
-        "message": "أرجواني"
-    },
-    "quality": {
-        "message": "الجودة"
-    },
-    "qualityWithoutFocus": {
-        "message": "الجودة بدون تركيز"
-    },
-    "ram": {
-        "message": "الذاكرة العشوائية"
-    },
-    "rateUs": {
-        "message": "قيمنا"
-    },
-    "red": {
-        "message": "احمر"
-    },
-    "redDislikeButton": {
-        "message": "إظهار زر لم يعجبني باللون الأحمر"
-    },
-    "relatedVideos": {
-        "message": "فيديوهات ذات علاقة"
-    },
-    "removeRelatedSearchResults": {
-        "message": "إزالة عمليات بحث مرتبطة بـ"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "إزالة لفة Shorts من نتائج البحث"
-    },
-    "repeat": {
-        "message": "تكرار"
-    },
-    "reset": {
-        "message": "إعادة تعيين"
-    },
-    "resetAllSettings": {
-        "message": "إعادة تعيين كافة الإعدادات"
-    },
-    "resetAllShortcuts": {
-        "message": "إعادة تعيين جميع الاختصارات"
-    },
-    "reverse": {
-        "message": "عكس"
-    },
-    "rotate": {
-        "message": "استدارة"
-    },
-    "save": {
-        "message": "حفظ"
-    },
-    "saveAs": {
-        "message": "حفظ باسم"
-    },
-    "schedule": {
-        "message": "جدوله"
-    },
-    "screen": {
-        "message": "الشاشة"
-    },
-    "screenshot": {
-        "message": "لقطة شاشة"
-    },
-    "search": {
-        "message": "بحث"
-    },
-    "searchBarOnly": {
-        "message": "شريط البحث فقط"
-    },
-    "seekBackward10Seconds": {
-        "message": "إرجاع بمقدار 10 ثوانٍ"
-    },
-    "seekForward10Seconds": {
-        "message": "تقديم 10 ثوانٍ إلى الأمام"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "الإعدادات"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "تم استيراد الإعدادات بنجاح"
-    },
-    "shortcuts": {
-        "message": "اختصارات"
-    },
-    "showCardsOnMouseHover": {
-        "message": "عرض البطاقات عند تمرير الماوس"
-    },
-    "showChannelVideosCount": {
-        "message": "إظهار عدد مقاطع الفيديو للقناة"
-    },
-    "shuffle": {
-        "message": "عشوائي"
-    },
-    "sidebar": {
-        "message": "الشريط الجانبي"
-    },
-    "spacebar": {
-        "message": "مفتاح المسافة"
-    },
-    "squaredUserImages": {
-        "message": "صور المستخدمين مربعة"
-    },
-    "static": {
-        "message": "ثابت"
-    },
-    "statsForNerds": {
-        "message": "عرض الإحصاءات المفصلة"
-    },
-    "step": {
-        "message": "خطوة"
-    },
-    "stop": {
-        "message": "ايقاف"
-    },
-    "style": {
-        "message": "نمط"
-    },
-    "styles": {
-        "message": "الأنماط"
-    },
-    "subscriptions": {
-        "message": "الاشتراكات"
-    },
-    "subtitles": {
-        "message": "الترجمات"
-    },
-    "sunset": {
-        "message": "غروب الشمس"
-    },
-    "sunsetToSunrise": {
-        "message": "من غروب الشمس إلى شروقها"
-    },
-    "systemPeferenceDark": {
-        "message": "تفضيل النظام: داكن"
-    },
-    "systemPeferenceLight": {
-        "message": "تفضيل النظام: فاتح"
-    },
-    "teal": {
-        "message": "أزرق مخضر"
-    },
-    "textColor": {
-        "message": "لون النص"
-    },
-    "themes": {
-        "message": "المظاهر"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": ".سيؤدي هذا إلى إزالة كافة ملفات تعريف الارتباط"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "سيؤدي هذا إلى إزالة جميع ملفات تعريف ارتباط اليوتيوب"
-    },
-    "thisWillResetAllSettings": {
-        "message": ".سيؤدي هذا إلى إعادة تعيين جميع الإعدادات"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "سيؤدي هذا إلى إعادة تعيين جميع الاختصارات"
-    },
-    "thumbnails": {
-        "message": "الصور المصغرة"
-    },
-    "timeFrom": {
-        "message": "الوقت من"
-    },
-    "timeTo": {
-        "message": "وقت ل"
-    },
-    "todayAt": {
-        "message": "اليوم عند الساعة"
-    },
-    "toggleCards": {
-        "message": "تبديل وضع البطاقات"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "رسائل المحادثة الهامّة"
-    },
-    "trailerAutoplay": {
-        "message": "التشغيل التلقائي للفيديو الدعائي"
-    },
-    "translations": {
-        "message": "الترجمات"
-    },
-    "transparentBackground": {
-        "message": "خلفية شفافة"
-    },
-    "transparentColor": {
-        "message": "شفاف"
-    },
-    "trending": {
-        "message": "المحتوى الرائج"
-    },
-    "tryToReloadThePage": {
-        "message": "حاول إعادة تحميل الصفحة"
-    },
-    "type": {
-        "message": "النوع"
-    },
-    "upNextAutoplay": {
-        "message": "تشغيل التالي تلقائيا"
-    },
-    "use24HourFormat": {
-        "message": "استخدم تنسيق 24 ساعة"
-    },
-    "version": {
-        "message": "الإصدار"
-    },
-    "video": {
-        "message": "الفيديو"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "سيتم توسيع وصف الفيديو للحصول على اسم الفئة"
-    },
-    "videoFormats": {
-        "message": "تنسيقات الفيديو"
-    },
-    "videos": {
-        "message": "الفيديوهات"
-    },
-    "volume": {
-        "message": "الصوت"
-    },
-    "watchLater": {
-        "message": "المشاهدة لاحقا"
-    },
-    "watchTime": {
-        "message": "وقت المشاهدة"
-    },
-    "whenTabIsChanged": {
-        "message": "عندما يتم تغيير علامة التبويب"
-    },
-    "white": {
-        "message": "أبيض"
-    },
-    "yellow": {
-        "message": "أصفر"
-    },
-    "youtubeHeaderLeft": {
-        "message": "جزء اليوتيوب العلوي  (يسار) "
-    },
-    "youtubeHeaderRight": {
-        "message": "جزء اليوتيوب العلوي (يمين)"
-    },
-    "youtubeHomePage": {
-        "message": "صفحة اليوتيوب الرئيسية"
-    },
-    "youtubeLanguage": {
-        "message": "لغة اليوتيوب"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "h.264 يحد اليوتيوب من جودة الفيديو الى ١٠٨٠ لـ الترميز"
-    }
+	"about": {
+		"message": "حول"
+	},
+	"accept": {
+		"message": "قبول"
+	},
+	"activate": {
+		"message": "تفعيل"
+	},
+	"activateCaptions": {
+		"message": "تفعيل الترجمة"
+	},
+	"activated": {
+		"message": "مفعل"
+	},
+	"activatedFeatures": {
+		"message": "الميزات المفعلة"
+	},
+	"activateFullscreen": {
+		"message": "تفعيل ملء الشاشة"
+	},
+	"activeFeatures": {
+		"message": "الميزات النشطة"
+	},
+	"addScrollToTop": {
+		"message": "آضف الصعود لأعلى"
+	},
+	"ads": {
+		"message": "الاعلانات"
+	},
+	"all": {
+		"message": "الكل"
+	},
+	"allow": {
+		"message": "سماح"
+	},
+	"alwaysActive": {
+		"message": "دائما نشط"
+	},
+	"alwaysShowProgressBar": {
+		"message": "إظهار شريط التقدم دائمًا"
+	},
+	"amber": {
+		"message": "العنبر"
+	},
+	"analyzer": {
+		"message": "المحلل"
+	},
+	"appearance": {
+		"message": "المظهر العام"
+	},
+	"audio": {
+		"message": "الصوت"
+	},
+	"audioFormats": {
+		"message": "تنسيقات الصوت"
+	},
+	"auto": {
+		"message": "تلقائي"
+	},
+	"autoFullscreen": {
+		"message": "ملء تلقائي للشاشة"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "إيقاف تلقائي عند التبديل بين التبويبات"
+	},
+	"autoplay": {
+		"message": "تشغيل تلقائي"
+	},
+	"backupAndReset": {
+		"message": "إعادة تعيين والنسخ الاحتياطي"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "يناء على ألوان النظام"
+	},
+	"belowPlayer": {
+		"message": "اسفل المشغل"
+	},
+	"black": {
+		"message": "اسود"
+	},
+	"blockAll": {
+		"message": "حظر الكل"
+	},
+	"blocklist": {
+		"message": "القائمة السوداء"
+	},
+	"blue": {
+		"message": "ازرق"
+	},
+	"blueGray": {
+		"message": "ازرق رمادي"
+	},
+	"bluelight": {
+		"message": "الضوء الأزرق"
+	},
+	"brown": {
+		"message": "بنى"
+	},
+	"browser": {
+		"message": "المتصفح"
+	},
+	"browserAccountSync": {
+		"message": "مزامنة (حساب المتصفح)"
+	},
+	"browserVersion": {
+		"message": "إصدار المتصفح"
+	},
+	"bubbles": {
+		"message": "فقاعات"
+	},
+	"bug": {
+		"message": "خلل برمجي"
+	},
+	"cancel": {
+		"message": "إلغاء"
+	},
+	"categories": {
+		"message": "التصنيفات"
+	},
+	"channel": {
+		"message": "قناة"
+	},
+	"channels": {
+		"message": "القنوات"
+	},
+	"clipboard": {
+		"message": "الحافظة"
+	},
+	"codecH264": {
+		"message": "h.الترميز 264"
+	},
+	"collapsed": {
+		"message": "ضغط"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "ضغط قسم الاشتراكات"
+	},
+	"comments": {
+		"message": "التعليقات"
+	},
+	"confirmationBeforeClosing": {
+		"message": "التأكيد قبل الإغلاق"
+	},
+	"cookies": {
+		"message": "ملفات تعريف الارتباط"
+	},
+	"cores": {
+		"message": "النواه"
+	},
+	"cropChapterTitles": {
+		"message": "اقتطاع عناوين الفصول"
+	},
+	"customCss": {
+		"message": "مخصص CSS"
+	},
+	"customJs": {
+		"message": "مخصص JS"
+	},
+	"customMiniPlayer": {
+		"message": "المشغل الصغير المخصص"
+	},
+	"cyan": {
+		"message": "ازرق سماوي"
+	},
+	"dark": {
+		"message": "داكن"
+	},
+	"darkTheme": {
+		"message": "مظهر داكن"
+	},
+	"dateAndTime": {
+		"message": "التاريخ والوقت"
+	},
+	"dawn": {
+		"message": "فجر"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "تقليل سرعة التشغيل"
+	},
+	"decreaseVolume": {
+		"message": "خفض الصوت"
+	},
+	"deepOrange": {
+		"message": "برتقالي داكن"
+	},
+	"deepPurple": {
+		"message": "أرجواني داكن"
+	},
+	"defaultChannelTab": {
+		"message": "علامة تبويب القناة الافتراضية"
+	},
+	"deleteYoutubeCookies": {
+		"message": "حذف ملفات تعريف الارتباط من اليوتيوب"
+	},
+	"desert": {
+		"message": "صحراء"
+	},
+	"details": {
+		"message": "التفاصيل"
+	},
+	"developerOptions": {
+		"message": "خيارات المطور"
+	},
+	"device": {
+		"message": "الجهاز"
+	},
+	"dim": {
+		"message": "داكن"
+	},
+	"disabled": {
+		"message": "معطل"
+	},
+	"dislike": {
+		"message": "لم يعجبنى"
+	},
+	"donate": {
+		"message": "تبرع"
+	},
+	"doNotChange": {
+		"message": "الإفتراضي"
+	},
+	"draggable": {
+		"message": "قابل للسحب"
+	},
+	"email": {
+		"message": "البريد الإلكتروني"
+	},
+	"empty": {
+		"message": "فارغة"
+	},
+	"enabled": {
+		"message": "ممكّن"
+	},
+	"enabledForced": {
+		"message": "ممكّن (إجباري)"
+	},
+	"expanded": {
+		"message": "موسع"
+	},
+	"exportSettings": {
+		"message": "تصدير الإعدادات"
+	},
+	"extension": {
+		"message": "الإضافة"
+	},
+	"ExtraButtons": {
+		"message": "أزرار إضافية"
+	},
+	"file": {
+		"message": "ملف"
+	},
+	"filters": {
+		"message": "مرشحات"
+	},
+	"fitToWindow": {
+		"message": "مناسب للنافذة"
+	},
+	"flash": {
+		"message": "فلاش"
+	},
+	"font": {
+		"message": "الخط"
+	},
+	"footer": {
+		"message": "الحزء السفلي"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "تثبيت سرعة التشغيل"
+	},
+	"forcedTheaterMode": {
+		"message": "فرض وضع المسرح"
+	},
+	"forcedVolume": {
+		"message": "تثبيت مستوى الصوت"
+	},
+	"forceSDR": {
+		"message": "SDR فرض"
+	},
+	"foundABug": {
+		"message": "وجدت خطأ؟"
+	},
+	"fullWindow": {
+		"message": "نافذة كاملة"
+	},
+	"general": {
+		"message": "عام"
+	},
+	"github": {
+		"message": "جيتهب"
+	},
+	"goToSearchBox": {
+		"message": "انتقل إلى مربع البحث"
+	},
+	"gpu": {
+		"message": "كرت الشاشة"
+	},
+	"green": {
+		"message": "أخضر"
+	},
+	"hdThumbnail": {
+		"message": "صورة مصغرة عالية الدقة"
+	},
+	"header": {
+		"message": "الجزء العلوي"
+	},
+	"hidden": {
+		"message": "مخفي"
+	},
+	"hiddenOnVideoPage": {
+		"message": "مخفي على صفحة الفيديو"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "إخفاء الصور المصغرة المتحركة"
+	},
+	"hideAnnotations": {
+		"message": "إخفاء التعليقات التوضيحية"
+	},
+	"hideCards": {
+		"message": "إخفاء البطاقات"
+	},
+	"hideDetails": {
+		"message": "إخفاء التفاصيل"
+	},
+	"hideEndscreen": {
+		"message": "إخفاء شاشة النهاية"
+	},
+	"hideFeaturedContent": {
+		"message": "إخفاء المحتوى المميز"
+	},
+	"hideFooter": {
+		"message": "إخفاء الجزء السفلي"
+	},
+	"hideGradientBottom": {
+		"message": "إخفاء التدرج الأسود السفلي"
+	},
+	"hideHomePageShorts": {
+		"message": "إزالة الشورت من الصفحة الرئيسية"
+	},
+	"hidePlaylist": {
+		"message": "إخفاء قائمة التشغيل"
+	},
+	"hideRightButtons": {
+		"message": "إخفاء الأزرار اليسرى"
+	},
+	"hideScrollForDetails": {
+		"message": "«إخفاء «التمرير للحصول على التفاصيل"
+	},
+	"hideViewsCount": {
+		"message": "إخفاء عدد المشاهدات"
+	},
+	"history": {
+		"message": "السجلّ"
+	},
+	"home": {
+		"message": "الصفحة الرئيسية"
+	},
+	"hover": {
+		"message": "تمرير"
+	},
+	"hoverOnVideoPage": {
+		"message": "تمرير فوق صفحة الفيديو"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "منذ متى تم تحميل الفيديو"
+	},
+	"icons": {
+		"message": "أيقونات"
+	},
+	"iconsOnly": {
+		"message": "أيقونات فقط"
+	},
+	"importSettings": {
+		"message": "استيراد الاعدادات"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "في اليوتيوب ImprovedTube ايقونة"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube لغة"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube اصدار"
+	},
+	"improveLogo": {
+		"message": "تحسين الشعار"
+	},
+	"increasePlaybackSpeed": {
+		"message": "زيادة سرعة التشغيل"
+	},
+	"increaseVolume": {
+		"message": "زيادة الصوت"
+	},
+	"indigo": {
+		"message": "نيلي"
+	},
+	"items": {
+		"message": "العناصر"
+	},
+	"languages": {
+		"message": "اللغات"
+	},
+	"legacyYoutube": {
+		"message": "اليوتيوب القديم"
+	},
+	"light": {
+		"message": "ضوء"
+	},
+	"lightBlue": {
+		"message": "أزرق فاتح"
+	},
+	"lightGreen": {
+		"message": "اخضر فاتح"
+	},
+	"like": {
+		"message": "اعحبني"
+	},
+	"lime": {
+		"message": "جير"
+	},
+	"list": {
+		"message": "قائمة"
+	},
+	"liveChat": {
+		"message": "محادثة مباشرة"
+	},
+	"liveChatType": {
+		"message": "نوع المحادثة مباشرة"
+	},
+	"loudnessNormalization": {
+		"message": "تطبيع الإزعاج"
+	},
+	"markWatchedVideos": {
+		"message": "التعليم على الفيديو المشاهد"
+	},
+	"mixer": {
+		"message": "مهندس الصوت"
+	},
+	"myColors": {
+		"message": "ألواني"
+	},
+	"name": {
+		"message": "الاسم"
+	},
+	"nativeMiniPlayer": {
+		"message": "المشغل الافتراضي الصغير"
+	},
+	"new": {
+		"message": "جديد"
+	},
+	"nextVideo": {
+		"message": "الفيديو التالي"
+	},
+	"night": {
+		"message": "ليل"
+	},
+	"noActiveFeatures": {
+		"message": "لا يوجد ميزات نشطة"
+	},
+	"none": {
+		"message": "لاشيء"
+	},
+	"noOpenVideoTabs": {
+		"message": "لا توجد علامات تبويب فيديو مفتوحة"
+	},
+	"normal": {
+		"message": "عادي"
+	},
+	"old": {
+		"message": "قديم"
+	},
+	"onAllVideos": {
+		"message": "على جميع مقاطع الفيديو"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "نشط فقط على اليوتيوب"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "تشغيل مشغل واحد فقط"
+	},
+	"onSubscribedChannels": {
+		"message": "على القنوات المشتركة"
+	},
+	"orange": {
+		"message": "برتقالي"
+	},
+	"os": {
+		"message": "نظام التشغيل"
+	},
+	"other": {
+		"message": "آخر"
+	},
+	"permissions": {
+		"message": "الأذونات"
+	},
+	"pictureInPicture": {
+		"message": "فيديو عائم"
+	},
+	"pink": {
+		"message": "زهري"
+	},
+	"plain": {
+		"message": "عادي"
+	},
+	"platform": {
+		"message": "المنصة"
+	},
+	"playbackSpeed": {
+		"message": "سرعة التشغيل"
+	},
+	"player": {
+		"message": "المشغل"
+	},
+	"playerColor": {
+		"message": "لون المشغل"
+	},
+	"playerSize": {
+		"message": "حجم المشغل"
+	},
+	"playlist": {
+		"message": "قائمة التشغيل"
+	},
+	"playlists": {
+		"message": "قوائم التشغيل"
+	},
+	"playPause": {
+		"message": "تشغيل / ايقاف"
+	},
+	"popupPlayer": {
+		"message": "مشفل منبثق"
+	},
+	"position": {
+		"message": "التموضع"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": ".اضغط على أي مفتاح أو استخدم عجلة الماوس"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "اضغط على أي مفتاح أو استخدم عجلة الماوس"
+	},
+	"previousVideo": {
+		"message": "الفيديو السابق"
+	},
+	"primaryColor": {
+		"message": "اللون الأصلي"
+	},
+	"purple": {
+		"message": "أرجواني"
+	},
+	"quality": {
+		"message": "الجودة"
+	},
+	"qualityWithoutFocus": {
+		"message": "الجودة بدون تركيز"
+	},
+	"ram": {
+		"message": "الذاكرة العشوائية"
+	},
+	"rateUs": {
+		"message": "قيمنا"
+	},
+	"red": {
+		"message": "احمر"
+	},
+	"redDislikeButton": {
+		"message": "إظهار زر لم يعجبني باللون الأحمر"
+	},
+	"relatedVideos": {
+		"message": "فيديوهات ذات علاقة"
+	},
+	"removeRelatedSearchResults": {
+		"message": "إزالة عمليات بحث مرتبطة بـ"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "إزالة لفة Shorts من نتائج البحث"
+	},
+	"repeat": {
+		"message": "تكرار"
+	},
+	"reset": {
+		"message": "إعادة تعيين"
+	},
+	"resetAllSettings": {
+		"message": "إعادة تعيين كافة الإعدادات"
+	},
+	"resetAllShortcuts": {
+		"message": "إعادة تعيين جميع الاختصارات"
+	},
+	"reverse": {
+		"message": "عكس"
+	},
+	"rotate": {
+		"message": "استدارة"
+	},
+	"save": {
+		"message": "حفظ"
+	},
+	"saveAs": {
+		"message": "حفظ باسم"
+	},
+	"schedule": {
+		"message": "جدوله"
+	},
+	"screen": {
+		"message": "الشاشة"
+	},
+	"screenshot": {
+		"message": "لقطة شاشة"
+	},
+	"search": {
+		"message": "بحث"
+	},
+	"searchBarOnly": {
+		"message": "شريط البحث فقط"
+	},
+	"seekBackward10Seconds": {
+		"message": "إرجاع بمقدار 10 ثوانٍ"
+	},
+	"seekForward10Seconds": {
+		"message": "تقديم 10 ثوانٍ إلى الأمام"
+	},
+	"settings": {
+		"message": "الإعدادات"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "تم استيراد الإعدادات بنجاح"
+	},
+	"shortcuts": {
+		"message": "اختصارات"
+	},
+	"showCardsOnMouseHover": {
+		"message": "عرض البطاقات عند تمرير الماوس"
+	},
+	"showChannelVideosCount": {
+		"message": "إظهار عدد مقاطع الفيديو للقناة"
+	},
+	"shuffle": {
+		"message": "عشوائي"
+	},
+	"sidebar": {
+		"message": "الشريط الجانبي"
+	},
+	"spacebar": {
+		"message": "مفتاح المسافة"
+	},
+	"squaredUserImages": {
+		"message": "صور المستخدمين مربعة"
+	},
+	"static": {
+		"message": "ثابت"
+	},
+	"statsForNerds": {
+		"message": "عرض الإحصاءات المفصلة"
+	},
+	"step": {
+		"message": "خطوة"
+	},
+	"stop": {
+		"message": "ايقاف"
+	},
+	"style": {
+		"message": "نمط"
+	},
+	"styles": {
+		"message": "الأنماط"
+	},
+	"subscriptions": {
+		"message": "الاشتراكات"
+	},
+	"subtitles": {
+		"message": "الترجمات"
+	},
+	"sunset": {
+		"message": "غروب الشمس"
+	},
+	"sunsetToSunrise": {
+		"message": "من غروب الشمس إلى شروقها"
+	},
+	"systemPeferenceDark": {
+		"message": "تفضيل النظام: داكن"
+	},
+	"systemPeferenceLight": {
+		"message": "تفضيل النظام: فاتح"
+	},
+	"teal": {
+		"message": "أزرق مخضر"
+	},
+	"textColor": {
+		"message": "لون النص"
+	},
+	"themes": {
+		"message": "المظاهر"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": ".سيؤدي هذا إلى إزالة كافة ملفات تعريف الارتباط"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "سيؤدي هذا إلى إزالة جميع ملفات تعريف ارتباط اليوتيوب"
+	},
+	"thisWillResetAllSettings": {
+		"message": ".سيؤدي هذا إلى إعادة تعيين جميع الإعدادات"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "سيؤدي هذا إلى إعادة تعيين جميع الاختصارات"
+	},
+	"thumbnails": {
+		"message": "الصور المصغرة"
+	},
+	"timeFrom": {
+		"message": "الوقت من"
+	},
+	"timeTo": {
+		"message": "وقت ل"
+	},
+	"todayAt": {
+		"message": "اليوم عند الساعة"
+	},
+	"toggleCards": {
+		"message": "تبديل وضع البطاقات"
+	},
+	"topChat": {
+		"message": "رسائل المحادثة الهامّة"
+	},
+	"trailerAutoplay": {
+		"message": "التشغيل التلقائي للفيديو الدعائي"
+	},
+	"translations": {
+		"message": "الترجمات"
+	},
+	"transparentBackground": {
+		"message": "خلفية شفافة"
+	},
+	"transparentColor": {
+		"message": "شفاف"
+	},
+	"trending": {
+		"message": "المحتوى الرائج"
+	},
+	"tryToReloadThePage": {
+		"message": "حاول إعادة تحميل الصفحة"
+	},
+	"type": {
+		"message": "النوع"
+	},
+	"upNextAutoplay": {
+		"message": "تشغيل التالي تلقائيا"
+	},
+	"use24HourFormat": {
+		"message": "استخدم تنسيق 24 ساعة"
+	},
+	"version": {
+		"message": "الإصدار"
+	},
+	"video": {
+		"message": "الفيديو"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "سيتم توسيع وصف الفيديو للحصول على اسم الفئة"
+	},
+	"videoFormats": {
+		"message": "تنسيقات الفيديو"
+	},
+	"videos": {
+		"message": "الفيديوهات"
+	},
+	"volume": {
+		"message": "الصوت"
+	},
+	"watchLater": {
+		"message": "المشاهدة لاحقا"
+	},
+	"watchTime": {
+		"message": "وقت المشاهدة"
+	},
+	"whenTabIsChanged": {
+		"message": "عندما يتم تغيير علامة التبويب"
+	},
+	"white": {
+		"message": "أبيض"
+	},
+	"yellow": {
+		"message": "أصفر"
+	},
+	"youtubeHeaderLeft": {
+		 "message": "جزء اليوتيوب العلوي  (يسار) "
+	},
+	"youtubeHeaderRight": {
+		"message": "جزء اليوتيوب العلوي (يمين)"
+	},
+	"youtubeHomePage": {
+		"message": "صفحة اليوتيوب الرئيسية"
+	},
+	"youtubeLanguage": {
+		"message": "لغة اليوتيوب"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "h.264 يحد اليوتيوب من جودة الفيديو الى ١٠٨٠ لـ الترميز"
+	}
 }

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -1,11 +1,11 @@
 {
-    "hideHomePageShorts": {
-        "message": "Премахни Shorts от началната страница"
-    },
-    "qualityWithoutFocus": {
-        "message": "Качество без фокус"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Премахнете ролката Shorts от резултатите от търсенето"
-    }
+	"hideHomePageShorts": {
+		"message": "Премахни Shorts от началната страница"
+	},
+	"qualityWithoutFocus": {
+		"message": "Качество без фокус"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Премахнете ролката Shorts от резултатите от търсенето"
+	}
 }

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -1,872 +1,866 @@
 {
-    "about": {
-        "message": "সম্পর্কিত"
-    },
-    "accept": {
-        "message": "গ্রহণ করুন"
-    },
-    "activate": {
-        "message": "সক্রিয় করুন"
-    },
-    "activateCaptions": {
-        "message": "ক্যাপশন সক্রিয় করুন"
-    },
-    "activated": {
-        "message": "সক্রিয়"
-    },
-    "activatedFeatures": {
-        "message": "বৈশিষ্ট্য সক্রিয় করুন"
-    },
-    "activateFullscreen": {
-        "message": "পূর্ণ পর্দা সক্রিয় করুন"
-    },
-    "activeFeatures": {
-        "message": "সক্রিয় বৈশিষ্"
-    },
-    "addScrollToTop": {
-        "message": "«উপরে যাবার বাটন» যোগ করুন"
-    },
-    "ads": {
-        "message": "বিজ্ঞাপন"
-    },
-    "all": {
-        "message": "সব"
-    },
-    "allow": {
-        "message": "অনুমতি দিন"
-    },
-    "alwaysActive": {
-        "message": "সর্বদা সক্রিয়"
-    },
-    "alwaysShowProgressBar": {
-        "message": "সর্বদা অগ্রগতি বার প্রদর্শন করুন"
-    },
-    "amber": {
-        "message": "অ্যাম্বার"
-    },
-    "analyzer": {
-        "message": "বিশ্লেষক"
-    },
-    "appearance": {
-        "message": "উপস্থিতি"
-    },
-    "audio": {
-        "message": "শ্রুতি"
-    },
-    "audioFormats": {
-        "message": "শ্রুতি ফর্ম্যাট"
-    },
-    "auto": {
-        "message": "অটো"
-    },
-    "autoFullscreen": {
-        "message": "স্বতঃ পূর্ণস্ক্রীন"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "ট্যাবগুলি স্যুইচ করার সময় অটো বিরাম দিন"
-    },
-    "autoplay": {
-        "message": "স্বয়ংক্রিয় চালু"
-    },
-    "backgroundColor": {
-        "message": "পটভূমির রং"
-    },
-    "backgroundOpacity": {
-        "message": "পটভূমি অস্বচ্ছতা"
-    },
-    "backupAndReset": {
-        "message": "ব্যাকআপ এবং পুনরায় সেট করুন"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "সিস্টেম রঙের স্কিমের ভিত্তিতে"
-    },
-    "belowPlayer": {
-        "message": "প্লেয়ারের নিচে"
-    },
-    "black": {
-        "message": "কালো"
-    },
-    "blockAll": {
-        "message": "সবাইকে ব্লক"
-    },
-    "blocklist": {
-        "message": "কালো তালিকা"
-    },
-    "blue": {
-        "message": "নীল"
-    },
-    "blueGray": {
-        "message": "নীল ধূসর"
-    },
-    "bluelight": {
-        "message": "নীল আলো"
-    },
-    "brown": {
-        "message": "বাদামী"
-    },
-    "browser": {
-        "message": "ব্রাউজার"
-    },
-    "browserVersion": {
-        "message": "ব্রাউজার মারজান"
-    },
-    "bubbles": {
-        "message": "বুলবুলা"
-    },
-    "bug": {
-        "message": "বাগ"
-    },
-    "buttons": {
-        "message": "বোতাম"
-    },
-    "cancel": {
-        "message": "বাতিল"
-    },
-    "categories": {
-        "message": "বিভাগসমূহ"
-    },
-    "channel": {
-        "message": "চ্যানেল"
-    },
-    "channels": {
-        "message": "চ্যানেলগুলি"
-    },
-    "characterEdgeStyle": {
-        "message": "ক্যারেক্টার এজ স্টাইল"
-    },
-    "clipboard": {
-        "message": "ক্লিপবোর্ড"
-    },
-    "codecH264": {
-        "message": "কোডেক h.264"
-    },
-    "collapsed": {
-        "message": "ভেঙে দেবো"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "সাবস্ক্রিপশন বিভাগ ভেঙে দেবো"
-    },
-    "comments": {
-        "message": "মন্তব্য"
-    },
-    "confirmationBeforeClosing": {
-        "message": "বন্ধ হওয়ার আগে নিশ্চিতকরণ"
-    },
-    "cookies": {
-        "message": "কুকিজ"
-    },
-    "cores": {
-        "message": "কোর"
-    },
-    "cropChapterTitles": {
-        "message": "অধ্যায়ের শিরোনাম হ্রাস করুন"
-    },
-    "customCss": {
-        "message": "কাস্টম CSS"
-    },
-    "customJs": {
-        "message": "কাস্টম JS"
-    },
-    "customMiniPlayer": {
-        "message": "কাস্টম মিনি প্লেয়ার"
-    },
-    "cyan": {
-        "message": "হালকা নীল"
-    },
-    "dark": {
-        "message": "গা .়"
-    },
-    "darkTheme": {
-        "message": "গা .় থিম"
-    },
-    "dateAndTime": {
-        "message": "তারিখ আর সময়"
-    },
-    "dawn": {
-        "message": "ভোর"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "প্লেব্যাকের গতি হ্রাস করুন"
-    },
-    "decreaseVolume": {
-        "message": "শব্দ হ্রাস করুন"
-    },
-    "deepOrange": {
-        "message": "গভীর কমলা"
-    },
-    "deepPurple": {
-        "message": "গভীর বেগুনি"
-    },
-    "defaultChannelTab": {
-        "message": "ডিফল্ট চ্যানেল ট্যাব"
-    },
-    "defaultContentCountry": {
-        "message": "ডিফল্ট বিষয়বস্তুর দেশ"
-    },
-    "deleteYoutubeCookies": {
-        "message": "ইউটিউব এর কুকি ডিলিট করুন"
-    },
-    "depressed": {
-        "message": "বিষণ্ণ"
-    },
-    "description_ext": {
-        "message": "ইউটিউব পরিপাটি+স্মার্ট করুন! ইউটিউব ভিডিও কালার অ্যাড স্কিপ ভলিউম স্পিড চ্যানেল টুল স্টাইল এইচডি বিজ্ঞাপন অ্যাডব্লক অ্যাডব্লকার ট্যাগ কীওয়ার্ড প্লেলিস্ট"
-    },
-    "desert": {
-        "message": "মরুভূমি"
-    },
-    "details": {
-        "message": "বিশদ"
-    },
-    "developerOptions": {
-        "message": "বিকাশকারী বিকল্পসমূহ"
-    },
-    "device": {
-        "message": "যন্ত্র"
-    },
-    "dim": {
-        "message": "ম্লান"
-    },
-    "disabled": {
-        "message": "অক্ষম"
-    },
-    "dislike": {
-        "message": "অপছন্দ"
-    },
-    "donate": {
-        "message": "দান করুন"
-    },
-    "doNotChange": {
-        "message": "পরিবর্তন করবেন না"
-    },
-    "draggable": {
-        "message": "টেনে আনে"
-    },
-    "dropShadow": {
-        "message": "ছায়া ফেলে দিন"
-    },
-    "email": {
-        "message": "ইমেল"
-    },
-    "empty": {
-        "message": "খালি"
-    },
-    "enabled": {
-        "message": "সক্ষম"
-    },
-    "enabledForced": {
-        "message": "সক্ষম (জোরপূর্বক)"
-    },
-    "expanded": {
-        "message": "প্রসারিত"
-    },
-    "exportSettings": {
-        "message": "সেটিংস রফতানি করুন"
-    },
-    "extension": {
-        "message": "এক্সটেনশন"
-    },
-    "file": {
-        "message": "ফাইল"
-    },
-    "filters": {
-        "message": "ফিল্টার"
-    },
-    "fitToWindow": {
-        "message": "উইন্ডোতে ফিট করুন"
-    },
-    "flash": {
-        "message": "ফ্ল্যাশ"
-    },
-    "font": {
-        "message": "হরফ"
-    },
-    "fontColor": {
-        "message": "অক্ষরের রং"
-    },
-    "fontFamily": {
-        "message": "হরফ সংগ্রহ"
-    },
-    "fontOpacity": {
-        "message": "হরফের অস্বচ্ছতা"
-    },
-    "fontSize": {
-        "message": "অক্ষরের আকার"
-    },
-    "footer": {
-        "message": "পাদচরণ"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "জোর করে প্লেব্যাক গতি"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "জোর করে শুরু থেকে ভিডিও চালান"
-    },
-    "forcedTheaterMode": {
-        "message": "জোর করে থিয়েটার মোড"
-    },
-    "forcedVolume": {
-        "message": "জোর করে শব্দ"
-    },
-    "foundABug": {
-        "message": "একটি বাগ খুঁজে পেয়েছি?"
-    },
-    "fullWindow": {
-        "message": "পুরো উইন্ডো"
-    },
-    "general": {
-        "message": "সাধারণ"
-    },
-    "github": {
-        "message": "গিটহাব"
-    },
-    "goToSearchBox": {
-        "message": "অনুসন্ধান বাক্সে যান"
-    },
-    "gpu": {
-        "message": "জিপিইউ"
-    },
-    "green": {
-        "message": "সবুজ"
-    },
-    "hdThumbnail": {
-        "message": "এইচডি থাম্বনেল"
-    },
-    "header": {
-        "message": "শিরোনাম"
-    },
-    "hidden": {
-        "message": "গোপন"
-    },
-    "hiddenOnVideoPage": {
-        "message": "ভিডিও পৃষ্ঠায় লুকানো"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "অ্যানিমেটেড থাম্বনেলগুলি লুকান"
-    },
-    "hideAnnotations": {
-        "message": "টীকাগুলি লুকান"
-    },
-    "hideCards": {
-        "message": "কার্ড লুকান"
-    },
-    "hideCountryCode": {
-        "message": "কান্ট্রি কোড লুকান"
-    },
-    "hideDate": {
-        "message": "তারিখ লুকান"
-    },
-    "hideDetails": {
-        "message": "আড়াল বিস্তারিত"
-    },
-    "hideEndscreen": {
-        "message": "এন্ডস্ক্রিন লুকান"
-    },
-    "hideFeaturedContent": {
-        "message": "বৈশিষ্ট্যযুক্ত সামগ্রী লুকান"
-    },
-    "hideFooter": {
-        "message": "পাদলেখ লুকান"
-    },
-    "hideGradientBottom": {
-        "message": "গ্রেডিয়েন্ট নীচে লুকান"
-    },
-    "hideHomePageShorts": {
-        "message": "মুখপৃষ্ঠের শর্ট মুছে দিন"
-    },
-    "hidePlaylist": {
-        "message": "প্লেলিস্ট লুকান"
-    },
-    "hideRightButtons": {
-        "message": "ডান বোতামগুলি লুকান"
-    },
-    "hideScrollForDetails": {
-        "message": "«বিশদ জন্য স্ক্রোলs» লুকান"
-    },
-    "hideSkipOverlay": {
-        "message": "স্কিপ ওভারলে লুকান"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "দর্শন গণনা লুকান"
-    },
-    "hideVoiceSearchButton": {
-        "message": "বক্তৃতা সার্চ বাটন লুকান"
-    },
-    "history": {
-        "message": "ইতিহাস"
-    },
-    "home": {
-        "message": "প্রধান"
-    },
-    "hover": {
-        "message": "ঘোরা"
-    },
-    "hoverOnVideoPage": {
-        "message": "ভিডিও পৃষ্ঠায় ঘোরা"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "ভিডিওটি কত আগে আপলোড হয়েছিল"
-    },
-    "icons": {
-        "message": "আইকন"
-    },
-    "iconsOnly": {
-        "message": "আইকন"
-    },
-    "importSettings": {
-        "message": "সেটিংস আমদানি করুন"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ইউটিউবে উন্নত আইকন"
-    },
-    "improvedtubeLanguage": {
-        "message": "উন্নত ইউটিউব ভাষা"
-    },
-    "improvedtubeVersion": {
-        "message": "উন্নত YouTube সংস্করণ"
-    },
-    "improveLogo": {
-        "message": "লোগো উন্নত করুন"
-    },
-    "increasePlaybackSpeed": {
-        "message": "প্লেব্যাকের গতি বাড়ান"
-    },
-    "increaseVolume": {
-        "message": "শব্দ বৃদ্ধি"
-    },
-    "indigo": {
-        "message": "নীল"
-    },
-    "items": {
-        "message": "আইটেম"
-    },
-    "language": {
-        "message": "ভাষা"
-    },
-    "languages": {
-        "message": "ভাষা"
-    },
-    "legacyYoutube": {
-        "message": "উত্তরাধিকার ইউটিউব"
-    },
-    "light": {
-        "message": "হালকাো"
-    },
-    "lightBlue": {
-        "message": "হালকা নীল"
-    },
-    "lightGreen": {
-        "message": "হালকা সবুজ"
-    },
-    "like": {
-        "message": "লাইক"
-    },
-    "lime": {
-        "message": "চুন"
-    },
-    "limitPageWidth": {
-        "message": "পৃষ্ঠার প্রস্থ সীমিত করুন"
-    },
-    "list": {
-        "message": "তালিকা"
-    },
-    "liveChat": {
-        "message": "সরাসরি কথোপকথন"
-    },
-    "liveChatType": {
-        "message": "লাইভ চ্যাট টাইপ"
-    },
-    "location": {
-        "message": "অবস্থান"
-    },
-    "loudnessNormalization": {
-        "message": "আওয়াজের স্বাভাবিককরণ"
-    },
-    "markWatchedVideos": {
-        "message": "দেখা ভিডিওগুলি চিহ্নিত করুন"
-    },
-    "mixer": {
-        "message": "মিক্সার"
-    },
-    "myColors": {
-        "message": "আমার রং"
-    },
-    "name": {
-        "message": "নাম"
-    },
-    "nativeMiniPlayer": {
-        "message": "নেটিভ মিনি প্লেয়ার"
-    },
-    "new": {
-        "message": "নতুন"
-    },
-    "nextVideo": {
-        "message": "পরবর্তী ভিডিও"
-    },
-    "night": {
-        "message": "রাত"
-    },
-    "noActiveFeatures": {
-        "message": "কোনও সক্রিয় বৈশিষ্ট্য নেই"
-    },
-    "none": {
-        "message": "কিছুই না"
-    },
-    "noOpenVideoTabs": {
-        "message": "কোনও খোলা ভিডিও ট্যাব নেই"
-    },
-    "normal": {
-        "message": "সাধারণ"
-    },
-    "old": {
-        "message": "পুরাতন"
-    },
-    "onAllVideos": {
-        "message": "সমস্ত ভিডিওতে"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "শুধুমাত্র ইউটিউবে সক্রিয়"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "কেবলমাত্র একজন খেলোয়াড় খেলছে"
-    },
-    "onSubscribedChannels": {
-        "message": "সাবস্ক্রাইব করা চ্যানেলগুলিতে"
-    },
-    "orange": {
-        "message": "কমলা"
-    },
-    "os": {
-        "message": "ওএস"
-    },
-    "other": {
-        "message": "অন্যান্য"
-    },
-    "outline": {
-        "message": "রূপরেখা"
-    },
-    "permissions": {
-        "message": "অনুমতি"
-    },
-    "pictureInPicture": {
-        "message": "পিকচার ইন পিকচার"
-    },
-    "pink": {
-        "message": "গোলাপী"
-    },
-    "plain": {
-        "message": "সরল"
-    },
-    "platform": {
-        "message": "প্ল্যাটফর্ম"
-    },
-    "playbackSpeed": {
-        "message": "প্লেব্যাক গতি"
-    },
-    "player": {
-        "message": "প্লেয়ার"
-    },
-    "playerColor": {
-        "message": "প্লেয়ারের রঙ"
-    },
-    "playerSize": {
-        "message": "খেলোয়াড়ের আকার"
-    },
-    "playlist": {
-        "message": "প্লেলিস্ট"
-    },
-    "playlists": {
-        "message": "প্লেলিস্ট"
-    },
-    "playPause": {
-        "message": "খেলার / বিরতি"
-    },
-    "popupPlayer": {
-        "message": "পপআপ প্লেয়ার"
-    },
-    "position": {
-        "message": "অবস্থান"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "যে কোনও কী টিপুন বা মাউস হুইল ব্যবহার করুন।"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "যে কোনও কী টিপুন বা মাউস হুইল ব্যবহার করুন।"
-    },
-    "previousVideo": {
-        "message": "পূর্ববর্তী ভিডিও"
-    },
-    "primaryColor": {
-        "message": "মৌলিক রঙ"
-    },
-    "purple": {
-        "message": "বেগুনি"
-    },
-    "quality": {
-        "message": "গুণ"
-    },
-    "raised": {
-        "message": "উত্থাপিত"
-    },
-    "ram": {
-        "message": "র্যাম"
-    },
-    "rateUs": {
-        "message": "মতামত দিন"
-    },
-    "red": {
-        "message": "লাল"
-    },
-    "redDislikeButton": {
-        "message": "অপছন্দ বাটন লাল রঙ দেখান"
-    },
-    "relatedVideos": {
-        "message": "সংশ্লিষ্ট ভিডিও"
-    },
-    "removeRelatedSearchResults": {
-        "message": "সম্পর্কিত অনুসন্ধান ফলাফল সরান"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "অনুসন্ধানের ফলাফল থেকে শর্টস রিল সরান"
-    },
-    "repeat": {
-        "message": "পুনরাবৃত্তি"
-    },
-    "reset": {
-        "message": "রিসেট"
-    },
-    "resetAllSettings": {
-        "message": "সমস্ত সেটিংস পুনরায় সেট করুন"
-    },
-    "resetAllShortcuts": {
-        "message": "সমস্ত শর্টকাট পুনরায় সেট করুন"
-    },
-    "reverse": {
-        "message": "বিপরীত"
-    },
-    "rotate": {
-        "message": "ঘুরান"
-    },
-    "save": {
-        "message": "সংরক্ষণ"
-    },
-    "saveAs": {
-        "message": "সংরক্ষণ করুন"
-    },
-    "schedule": {
-        "message": "সময়সূচী"
-    },
-    "screen": {
-        "message": "পর্দা"
-    },
-    "screenshot": {
-        "message": "স্ক্রিনশট"
-    },
-    "search": {
-        "message": "অনুসন্ধান করুন"
-    },
-    "searchBarOnly": {
-        "message": "অনুসন্ধান বার কেবল"
-    },
-    "seekBackward10Seconds": {
-        "message": "পিছনে 10 সেকেন্ড সন্ধান করুন"
-    },
-    "seekForward10Seconds": {
-        "message": "10 সেকেন্ড এগিয়ে যান"
-    },
-    "seekNextChapter": {
-        "message": "পরবর্তী অধ্যায় সন্ধান করুন"
-    },
-    "seekPreviousChapter": {
-        "message": "পূর্ববর্তী অধ্যায় সন্ধান করুন"
-    },
-    "settings": {
-        "message": "সেটিংস"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "সেটিংস সফলভাবে আমদানি করা হয়েছে"
-    },
-    "shortcuts": {
-        "message": "শর্টকাটস"
-    },
-    "showCardsOnMouseHover": {
-        "message": "মাউস হোভারে কার্ডগুলি দেখান"
-    },
-    "showChannelVideosCount": {
-        "message": "চ্যানেল ভিডিও গণনা দেখান"
-    },
-    "showRemainingDuration": {
-        "message": "ভিডিও অবশিষ্ট সময় দেখান"
-    },
-    "shuffle": {
-        "message": "অদলবদল"
-    },
-    "sidebar": {
-        "message": "সাইডবার"
-    },
-    "spacebar": {
-        "message": "স্পেসবার"
-    },
-    "squaredUserImages": {
-        "message": "স্কোয়ার ব্যবহারকারীর চিত্রসমূহ"
-    },
-    "static": {
-        "message": "স্থির"
-    },
-    "statsForNerds": {
-        "message": "ডেভলপারের জন্য পরিসংখ্যান দেখান"
-    },
-    "step": {
-        "message": "পদক্ষেপ"
-    },
-    "stop": {
-        "message": "থামো"
-    },
-    "style": {
-        "message": "স্টাইল"
-    },
-    "styles": {
-        "message": "শৈলী"
-    },
-    "subscriptions": {
-        "message": "সাবস্ক্রিপশন"
-    },
-    "subtitles": {
-        "message": "সাবটাইটেল"
-    },
-    "sunset": {
-        "message": "সূর্যাস্ত"
-    },
-    "sunsetToSunrise": {
-        "message": "সূর্যোদয় সূর্যোদয়"
-    },
-    "systemPeferenceDark": {
-        "message": "সিস্টেমের পছন্দসমূহ : dark"
-    },
-    "systemPeferenceLight": {
-        "message": "সিস্টেমের পছন্দসমূহ : light"
-    },
-    "teal": {
-        "message": "টিল"
-    },
-    "textColor": {
-        "message": "লেখার রঙ"
-    },
-    "themes": {
-        "message": "থিমস"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "এটি সমস্ত কুকি মুছে ফেলবে।"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "এটি সমস্ত ইউটিউব কুকিজ অপসারণ করবে"
-    },
-    "thisWillResetAllSettings": {
-        "message": "এটি সমস্ত সেটিংস পুনরায় সেট করবে।"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "এটি সমস্ত শর্টকাট পুনরায় সেট করবে"
-    },
-    "thumbnails": {
-        "message": "থাম্বনেইলস"
-    },
-    "timeFrom": {
-        "message": "সময় থেকে"
-    },
-    "timeTo": {
-        "message": "সময়"
-    },
-    "todayAt": {
-        "message": "আজ এ"
-    },
-    "toggleCards": {
-        "message": "কার্ড প্রতিস্থাপন করুন"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "শীর্ষ চ্যাট"
-    },
-    "trailerAutoplay": {
-        "message": "ট্রেলার অটোপ্লে"
-    },
-    "translations": {
-        "message": "অনুবাদ"
-    },
-    "transparentBackground": {
-        "message": "স্বচ্ছ পটভূমি"
-    },
-    "trending": {
-        "message": "চলমান"
-    },
-    "tryToReloadThePage": {
-        "message": "পৃষ্ঠাটি পুনরায় লোড করার চেষ্টা করুন"
-    },
-    "type": {
-        "message": "প্রকার"
-    },
-    "upNextAutoplay": {
-        "message": "পরবর্তী অটোপ্লে"
-    },
-    "use24HourFormat": {
-        "message": "24 ঘন্টা বিন্যাস ব্যবহার করুন"
-    },
-    "version": {
-        "message": "সংস্করণ"
-    },
-    "video": {
-        "message": "ভিডিও"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "বিভাগটির নাম পেতে ভিডিওর বর্ণনাটি প্রসারিত হবে"
-    },
-    "videoFormats": {
-        "message": "ভিডিও ফর্ম্যাট"
-    },
-    "videos": {
-        "message": "ভিডিও"
-    },
-    "volume": {
-        "message": "শব্দ"
-    },
-    "watchLater": {
-        "message": "পরে দেখুন"
-    },
-    "watchTime": {
-        "message": "দেখার সময়"
-    },
-    "whenTabIsChanged": {
-        "message": "ট্যাব পরিবর্তন করা হয়"
-    },
-    "white": {
-        "message": "সাদা"
-    },
-    "windowColor": {
-        "message": "উইন্ডো রঙ"
-    },
-    "windowOpacity": {
-        "message": "উইন্ডোর অস্বচ্ছতা"
-    },
-    "yellow": {
-        "message": "হলুদ"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube শিরোনাম (বাম)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube শিরোনাম (ডানদিকে)"
-    },
-    "youtubeHomePage": {
-        "message": "ইউটিউব হোম পৃষ্ঠা"
-    },
-    "youtubeLanguage": {
-        "message": "ইউটিউব ভাষা"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "ইউটিউব h.264 কোডেকের জন্য ভিডিও গুণমানকে 1080p এর মধ্যে সীমাবদ্ধ করে"
-    }
+	"about": {
+		"message": "সম্পর্কিত"
+	},
+	"accept": {
+		"message": "গ্রহণ করুন"
+	},
+	"activate": {
+		"message": "সক্রিয় করুন"
+	},
+	"activateCaptions": {
+		"message": "ক্যাপশন সক্রিয় করুন"
+	},
+	"activated": {
+		"message": "সক্রিয়"
+	},
+	"activatedFeatures": {
+		"message": "বৈশিষ্ট্য সক্রিয় করুন"
+	},
+	"activateFullscreen": {
+		"message": "পূর্ণ পর্দা সক্রিয় করুন"
+	},
+	"activeFeatures": {
+		"message": "সক্রিয় বৈশিষ্"
+	},
+	"addScrollToTop": {
+		"message": "«উপরে যাবার বাটন» যোগ করুন"
+	},
+	"ads": {
+		"message": "বিজ্ঞাপন"
+	},
+	"all": {
+		"message": "সব"
+	},
+	"allow": {
+		"message": "অনুমতি দিন"
+	},
+	"alwaysActive": {
+		"message": "সর্বদা সক্রিয়"
+	},
+	"alwaysShowProgressBar": {
+		"message": "সর্বদা অগ্রগতি বার প্রদর্শন করুন"
+	},
+	"amber": {
+		"message": "অ্যাম্বার"
+	},
+	"analyzer": {
+		"message": "বিশ্লেষক"
+	},
+	"appearance": {
+		"message": "উপস্থিতি"
+	},
+	"audio": {
+		"message": "শ্রুতি"
+	},
+	"audioFormats": {
+		"message": "শ্রুতি ফর্ম্যাট"
+	},
+	"auto": {
+		"message": "অটো"
+	},
+	"autoFullscreen": {
+		"message": "স্বতঃ পূর্ণস্ক্রীন"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "ট্যাবগুলি স্যুইচ করার সময় অটো বিরাম দিন"
+	},
+	"autoplay": {
+		"message": "স্বয়ংক্রিয় চালু"
+	},
+	"backgroundColor": {
+		"message": "পটভূমির রং"
+	},
+	"backgroundOpacity": {
+		"message": "পটভূমি অস্বচ্ছতা"
+	},
+	"backupAndReset": {
+		"message": "ব্যাকআপ এবং পুনরায় সেট করুন"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "সিস্টেম রঙের স্কিমের ভিত্তিতে"
+	},
+	"belowPlayer": {
+		"message": "প্লেয়ারের নিচে"
+	},
+	"black": {
+		"message": "কালো"
+	},
+	"blockAll": {
+		"message": "সবাইকে ব্লক"
+	},
+	"blocklist": {
+		"message": "কালো তালিকা"
+	},
+	"blue": {
+		"message": "নীল"
+	},
+	"blueGray": {
+		"message": "নীল ধূসর"
+	},
+	"bluelight": {
+		"message": "নীল আলো"
+	},
+	"brown": {
+		"message": "বাদামী"
+	},
+	"browser": {
+		"message": "ব্রাউজার"
+	},
+	"browserVersion": {
+		"message": "ব্রাউজার মারজান"
+	},
+	"bubbles": {
+		"message": "বুলবুলা"
+	},
+	"bug": {
+		"message": "বাগ"
+	},
+	"buttons": {
+		"message": "বোতাম"
+	},
+	"cancel": {
+		"message": "বাতিল"
+	},
+	"categories": {
+		"message": "বিভাগসমূহ"
+	},
+	"channel": {
+		"message": "চ্যানেল"
+	},
+	"channels": {
+		"message": "চ্যানেলগুলি"
+	},
+	"characterEdgeStyle": {
+		"message": "ক্যারেক্টার এজ স্টাইল"
+	},
+	"clipboard": {
+		"message": "ক্লিপবোর্ড"
+	},
+	"codecH264": {
+		"message": "কোডেক h.264"
+	},
+	"collapsed": {
+		"message": "ভেঙে দেবো"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "সাবস্ক্রিপশন বিভাগ ভেঙে দেবো"
+	},
+	"comments": {
+		"message": "মন্তব্য"
+	},
+	"confirmationBeforeClosing": {
+		"message": "বন্ধ হওয়ার আগে নিশ্চিতকরণ"
+	},
+	"cookies": {
+		"message": "কুকিজ"
+	},
+	"cores": {
+		"message": "কোর"
+	},
+	"cropChapterTitles": {
+		"message": "অধ্যায়ের শিরোনাম হ্রাস করুন"
+	},
+	"customCss": {
+		"message": "কাস্টম CSS"
+	},
+	"customJs": {
+		"message": "কাস্টম JS"
+	},
+	"customMiniPlayer": {
+		"message": "কাস্টম মিনি প্লেয়ার"
+	},
+	"cyan": {
+		"message": "হালকা নীল"
+	},
+	"dark": {
+		"message": "গা .়"
+	},
+	"darkTheme": {
+		"message": "গা .় থিম"
+	},
+	"dateAndTime": {
+		"message": "তারিখ আর সময়"
+	},
+	"dawn": {
+		"message": "ভোর"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "প্লেব্যাকের গতি হ্রাস করুন"
+	},
+	"decreaseVolume": {
+		"message": "শব্দ হ্রাস করুন"
+	},
+	"deepOrange": {
+		"message": "গভীর কমলা"
+	},
+	"deepPurple": {
+		"message": "গভীর বেগুনি"
+	},
+	"defaultChannelTab": {
+		"message": "ডিফল্ট চ্যানেল ট্যাব"
+	},
+	"defaultContentCountry": {
+		"message": "ডিফল্ট বিষয়বস্তুর দেশ"
+	},
+	"deleteYoutubeCookies": {
+		"message": "ইউটিউব এর কুকি ডিলিট করুন"
+	},
+	"depressed": {
+		"message": "বিষণ্ণ"
+	},
+	"description_ext": {
+		"message": "ইউটিউব পরিপাটি+স্মার্ট করুন! ইউটিউব ভিডিও কালার অ্যাড স্কিপ ভলিউম স্পিড চ্যানেল টুল স্টাইল এইচডি বিজ্ঞাপন অ্যাডব্লক অ্যাডব্লকার ট্যাগ কীওয়ার্ড প্লেলিস্ট"
+	},
+	"desert": {
+		"message": "মরুভূমি"
+	},
+	"details": {
+		"message": "বিশদ"
+	},
+	"developerOptions": {
+		"message": "বিকাশকারী বিকল্পসমূহ"
+	},
+	"device": {
+		"message": "যন্ত্র"
+	},
+	"dim": {
+		"message": "ম্লান"
+	},
+	"disabled": {
+		"message": "অক্ষম"
+	},
+	"dislike": {
+		"message": "অপছন্দ"
+	},
+	"donate": {
+		"message": "দান করুন"
+	},
+	"doNotChange": {
+		"message": "পরিবর্তন করবেন না"
+	},
+	"draggable": {
+		"message": "টেনে আনে"
+	},
+	"dropShadow": {
+		"message": "ছায়া ফেলে দিন"
+	},
+	"email": {
+		"message": "ইমেল"
+	},
+	"empty": {
+		"message": "খালি"
+	},
+	"enabled": {
+		"message": "সক্ষম"
+	},
+	"enabledForced": {
+		"message": "সক্ষম (জোরপূর্বক)"
+	},
+	"expanded": {
+		"message": "প্রসারিত"
+	},
+	"exportSettings": {
+		"message": "সেটিংস রফতানি করুন"
+	},
+	"extension": {
+		"message": "এক্সটেনশন"
+	},
+	"file": {
+		"message": "ফাইল"
+	},
+	"filters": {
+		"message": "ফিল্টার"
+	},
+	"fitToWindow": {
+		"message": "উইন্ডোতে ফিট করুন"
+	},
+	"flash": {
+		"message": "ফ্ল্যাশ"
+	},
+	"font": {
+		"message": "হরফ"
+	},
+	"fontColor": {
+		"message": "অক্ষরের রং"
+	},
+	"fontFamily": {
+		"message": "হরফ সংগ্রহ"
+	},
+	"fontOpacity": {
+		"message": "হরফের অস্বচ্ছতা"
+	},
+	"fontSize": {
+		"message": "অক্ষরের আকার"
+	},
+	"footer": {
+		"message": "পাদচরণ"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "জোর করে প্লেব্যাক গতি"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "জোর করে শুরু থেকে ভিডিও চালান"
+	},
+	"forcedTheaterMode": {
+		"message": "জোর করে থিয়েটার মোড"
+	},
+	"forcedVolume": {
+		"message": "জোর করে শব্দ"
+	},
+	"foundABug": {
+		"message": "একটি বাগ খুঁজে পেয়েছি?"
+	},
+	"fullWindow": {
+		"message": "পুরো উইন্ডো"
+	},
+	"general": {
+		"message": "সাধারণ"
+	},
+	"github": {
+		"message": "গিটহাব"
+	},
+	"goToSearchBox": {
+		"message": "অনুসন্ধান বাক্সে যান"
+	},
+	"gpu": {
+		"message": "জিপিইউ"
+	},
+	"green": {
+		"message": "সবুজ"
+	},
+	"hdThumbnail": {
+		"message": "এইচডি থাম্বনেল"
+	},
+	"header": {
+		"message": "শিরোনাম"
+	},
+	"hidden": {
+		"message": "গোপন"
+	},
+	"hiddenOnVideoPage": {
+		"message": "ভিডিও পৃষ্ঠায় লুকানো"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "অ্যানিমেটেড থাম্বনেলগুলি লুকান"
+	},
+	"hideAnnotations": {
+		"message": "টীকাগুলি লুকান"
+	},
+	"hideCards": {
+		"message": "কার্ড লুকান"
+	},
+	"hideCountryCode": {
+		"message": "কান্ট্রি কোড লুকান"
+	},
+	"hideDate": {
+		"message": "তারিখ লুকান"
+	},
+	"hideDetails": {
+		"message": "আড়াল বিস্তারিত"
+	},
+	"hideEndscreen": {
+		"message": "এন্ডস্ক্রিন লুকান"
+	},
+	"hideFeaturedContent": {
+		"message": "বৈশিষ্ট্যযুক্ত সামগ্রী লুকান"
+	},
+	"hideFooter": {
+		"message": "পাদলেখ লুকান"
+	},
+	"hideGradientBottom": {
+		"message": "গ্রেডিয়েন্ট নীচে লুকান"
+	},
+	"hideHomePageShorts": {
+		"message": "মুখপৃষ্ঠের শর্ট মুছে দিন"
+	},
+	"hidePlaylist": {
+		"message": "প্লেলিস্ট লুকান"
+	},
+	"hideRightButtons": {
+		"message": "ডান বোতামগুলি লুকান"
+	},
+	"hideScrollForDetails": {
+		"message": "«বিশদ জন্য স্ক্রোলs» লুকান"
+	},
+	"hideSkipOverlay": {
+		"message": "স্কিপ ওভারলে লুকান"
+	},
+	"hideViewsCount": {
+		"message": "দর্শন গণনা লুকান"
+	},
+	"hideVoiceSearchButton": {
+		"message": "বক্তৃতা সার্চ বাটন লুকান"
+	},
+	"history": {
+		"message": "ইতিহাস"
+	},
+	"home": {
+		"message": "প্রধান"
+	},
+	"hover": {
+		"message": "ঘোরা"
+	},
+	"hoverOnVideoPage": {
+		"message": "ভিডিও পৃষ্ঠায় ঘোরা"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "ভিডিওটি কত আগে আপলোড হয়েছিল"
+	},
+	"icons": {
+		"message": "আইকন"
+	},
+	"iconsOnly": {
+		"message": "আইকন"
+	},
+	"importSettings": {
+		"message": "সেটিংস আমদানি করুন"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ইউটিউবে উন্নত আইকন"
+	},
+	"improvedtubeLanguage": {
+		"message": "উন্নত ইউটিউব ভাষা"
+	},
+	"improvedtubeVersion": {
+		"message": "উন্নত YouTube সংস্করণ"
+	},
+	"improveLogo": {
+		"message": "লোগো উন্নত করুন"
+	},
+	"increasePlaybackSpeed": {
+		"message": "প্লেব্যাকের গতি বাড়ান"
+	},
+	"increaseVolume": {
+		"message": "শব্দ বৃদ্ধি"
+	},
+	"indigo": {
+		"message": "নীল"
+	},
+	"items": {
+		"message": "আইটেম"
+	},
+	"language": {
+		"message": "ভাষা"
+	},
+	"languages": {
+		"message": "ভাষা"
+	},
+	"legacyYoutube": {
+		"message": "উত্তরাধিকার ইউটিউব"
+	},
+	"light": {
+		"message": "হালকাো"
+	},
+	"lightBlue": {
+		"message": "হালকা নীল"
+	},
+	"lightGreen": {
+		"message": "হালকা সবুজ"
+	},
+	"like": {
+		"message": "লাইক"
+	},
+	"lime": {
+		"message": "চুন"
+	},
+	"limitPageWidth": {
+		"message": "পৃষ্ঠার প্রস্থ সীমিত করুন"
+	},
+	"list": {
+		"message": "তালিকা"
+	},
+	"liveChat": {
+		"message": "সরাসরি কথোপকথন"
+	},
+	"liveChatType": {
+		"message": "লাইভ চ্যাট টাইপ"
+	},
+	"location": {
+		"message": "অবস্থান"
+	},
+	"loudnessNormalization": {
+		"message": "আওয়াজের স্বাভাবিককরণ"
+	},
+	"markWatchedVideos": {
+		"message": "দেখা ভিডিওগুলি চিহ্নিত করুন"
+	},
+	"mixer": {
+		"message": "মিক্সার"
+	},
+	"myColors": {
+		"message": "আমার রং"
+	},
+	"name": {
+		"message": "নাম"
+	},
+	"nativeMiniPlayer": {
+		"message": "নেটিভ মিনি প্লেয়ার"
+	},
+	"new": {
+		"message": "নতুন"
+	},
+	"nextVideo": {
+		"message": "পরবর্তী ভিডিও"
+	},
+	"night": {
+		"message": "রাত"
+	},
+	"noActiveFeatures": {
+		"message": "কোনও সক্রিয় বৈশিষ্ট্য নেই"
+	},
+	"none": {
+		"message": "কিছুই না"
+	},
+	"noOpenVideoTabs": {
+		"message": "কোনও খোলা ভিডিও ট্যাব নেই"
+	},
+	"normal": {
+		"message": "সাধারণ"
+	},
+	"old": {
+		"message": "পুরাতন"
+	},
+	"onAllVideos": {
+		"message": "সমস্ত ভিডিওতে"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "শুধুমাত্র ইউটিউবে সক্রিয়"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "কেবলমাত্র একজন খেলোয়াড় খেলছে"
+	},
+	"onSubscribedChannels": {
+		"message": "সাবস্ক্রাইব করা চ্যানেলগুলিতে"
+	},
+	"orange": {
+		"message": "কমলা"
+	},
+	"os": {
+		"message": "ওএস"
+	},
+	"other": {
+		"message": "অন্যান্য"
+	},
+	"outline": {
+		"message": "রূপরেখা"
+	},
+	"permissions": {
+		"message": "অনুমতি"
+	},
+	"pictureInPicture": {
+		"message": "পিকচার ইন পিকচার"
+	},
+	"pink": {
+		"message": "গোলাপী"
+	},
+	"plain": {
+		"message": "সরল"
+	},
+	"platform": {
+		"message": "প্ল্যাটফর্ম"
+	},
+	"playbackSpeed": {
+		"message": "প্লেব্যাক গতি"
+	},
+	"player": {
+		"message": "প্লেয়ার"
+	},
+	"playerColor": {
+		"message": "প্লেয়ারের রঙ"
+	},
+	"playerSize": {
+		"message": "খেলোয়াড়ের আকার"
+	},
+	"playlist": {
+		"message": "প্লেলিস্ট"
+	},
+	"playlists": {
+		"message": "প্লেলিস্ট"
+	},
+	"playPause": {
+		"message": "খেলার / বিরতি"
+	},
+	"popupPlayer": {
+		"message": "পপআপ প্লেয়ার"
+	},
+	"position": {
+		"message": "অবস্থান"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "যে কোনও কী টিপুন বা মাউস হুইল ব্যবহার করুন।"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "যে কোনও কী টিপুন বা মাউস হুইল ব্যবহার করুন।"
+	},
+	"previousVideo": {
+		"message": "পূর্ববর্তী ভিডিও"
+	},
+	"primaryColor": {
+		"message": "মৌলিক রঙ"
+	},
+	"purple": {
+		"message": "বেগুনি"
+	},
+	"quality": {
+		"message": "গুণ"
+	},
+	"raised": {
+		"message": "উত্থাপিত"
+	},
+	"ram": {
+		"message": "র্যাম"
+	},
+	"rateUs": {
+		"message": "মতামত দিন"
+	},
+	"red": {
+		"message": "লাল"
+	},
+	"redDislikeButton": {
+		"message": "অপছন্দ বাটন লাল রঙ দেখান"
+	},
+	"relatedVideos": {
+		"message": "সংশ্লিষ্ট ভিডিও"
+	},
+	"removeRelatedSearchResults": {
+		"message": "সম্পর্কিত অনুসন্ধান ফলাফল সরান"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "অনুসন্ধানের ফলাফল থেকে শর্টস রিল সরান"
+	},
+	"repeat": {
+		"message": "পুনরাবৃত্তি"
+	},
+	"reset": {
+		"message": "রিসেট"
+	},
+	"resetAllSettings": {
+		"message": "সমস্ত সেটিংস পুনরায় সেট করুন"
+	},
+	"resetAllShortcuts": {
+		"message": "সমস্ত শর্টকাট পুনরায় সেট করুন"
+	},
+	"reverse": {
+		"message": "বিপরীত"
+	},
+	"rotate": {
+		"message": "ঘুরান"
+	},
+	"save": {
+		"message": "সংরক্ষণ"
+	},
+	"saveAs": {
+		"message": "সংরক্ষণ করুন"
+	},
+	"schedule": {
+		"message": "সময়সূচী"
+	},
+	"screen": {
+		"message": "পর্দা"
+	},
+	"screenshot": {
+		"message": "স্ক্রিনশট"
+	},
+	"search": {
+		"message": "অনুসন্ধান করুন"
+	},
+	"searchBarOnly": {
+		"message": "অনুসন্ধান বার কেবল"
+	},
+	"seekBackward10Seconds": {
+		"message": "পিছনে 10 সেকেন্ড সন্ধান করুন"
+	},
+	"seekForward10Seconds": {
+		"message": "10 সেকেন্ড এগিয়ে যান"
+	},
+	"seekNextChapter": {
+		"message": "পরবর্তী অধ্যায় সন্ধান করুন"
+	},
+	"seekPreviousChapter": {
+		"message": "পূর্ববর্তী অধ্যায় সন্ধান করুন"
+	},
+	"settings": {
+		"message": "সেটিংস"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "সেটিংস সফলভাবে আমদানি করা হয়েছে"
+	},
+	"shortcuts": {
+		"message": "শর্টকাটস"
+	},
+	"showCardsOnMouseHover": {
+		"message": "মাউস হোভারে কার্ডগুলি দেখান"
+	},
+	"showChannelVideosCount": {
+		"message": "চ্যানেল ভিডিও গণনা দেখান"
+	},
+	"showRemainingDuration": {
+		"message": "ভিডিও অবশিষ্ট সময় দেখান"
+	},
+	"shuffle": {
+		"message": "অদলবদল"
+	},
+	"sidebar": {
+		"message": "সাইডবার"
+	},
+	"spacebar": {
+		"message": "স্পেসবার"
+	},
+	"squaredUserImages": {
+		"message": "স্কোয়ার ব্যবহারকারীর চিত্রসমূহ"
+	},
+	"static": {
+		"message": "স্থির"
+	},
+	"statsForNerds": {
+		"message": "ডেভলপারের জন্য পরিসংখ্যান দেখান"
+	},
+	"step": {
+		"message": "পদক্ষেপ"
+	},
+	"stop": {
+		"message": "থামো"
+	},
+	"style": {
+		"message": "স্টাইল"
+	},
+	"styles": {
+		"message": "শৈলী"
+	},
+	"subscriptions": {
+		"message": "সাবস্ক্রিপশন"
+	},
+	"subtitles": {
+		"message": "সাবটাইটেল"
+	},
+	"sunset": {
+		"message": "সূর্যাস্ত"
+	},
+	"sunsetToSunrise": {
+		"message": "সূর্যোদয় সূর্যোদয়"
+	},
+	"systemPeferenceDark": {
+		"message": "সিস্টেমের পছন্দসমূহ : dark"
+	},
+	"systemPeferenceLight": {
+		"message": "সিস্টেমের পছন্দসমূহ : light"
+	},
+	"teal": {
+		"message": "টিল"
+	},
+	"textColor": {
+		"message": "লেখার রঙ"
+	},
+	"themes": {
+		"message": "থিমস"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "এটি সমস্ত কুকি মুছে ফেলবে।"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "এটি সমস্ত ইউটিউব কুকিজ অপসারণ করবে"
+	},
+	"thisWillResetAllSettings": {
+		"message": "এটি সমস্ত সেটিংস পুনরায় সেট করবে।"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "এটি সমস্ত শর্টকাট পুনরায় সেট করবে"
+	},
+	"thumbnails": {
+		"message": "থাম্বনেইলস"
+	},
+	"timeFrom": {
+		"message": "সময় থেকে"
+	},
+	"timeTo": {
+		"message": "সময়"
+	},
+	"todayAt": {
+		"message": "আজ এ"
+	},
+	"toggleCards": {
+		"message": "কার্ড প্রতিস্থাপন করুন"
+	},
+	"topChat": {
+		"message": "শীর্ষ চ্যাট"
+	},
+	"trailerAutoplay": {
+		"message": "ট্রেলার অটোপ্লে"
+	},
+	"translations": {
+		"message": "অনুবাদ"
+	},
+	"transparentBackground": {
+		"message": "স্বচ্ছ পটভূমি"
+	},
+	"trending": {
+		"message": "চলমান"
+	},
+	"tryToReloadThePage": {
+		"message": "পৃষ্ঠাটি পুনরায় লোড করার চেষ্টা করুন"
+	},
+	"type": {
+		"message": "প্রকার"
+	},
+	"upNextAutoplay": {
+		"message": "পরবর্তী অটোপ্লে"
+	},
+	"use24HourFormat": {
+		"message": "24 ঘন্টা বিন্যাস ব্যবহার করুন"
+	},
+	"version": {
+		"message": "সংস্করণ"
+	},
+	"video": {
+		"message": "ভিডিও"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "বিভাগটির নাম পেতে ভিডিওর বর্ণনাটি প্রসারিত হবে"
+	},
+	"videoFormats": {
+		"message": "ভিডিও ফর্ম্যাট"
+	},
+	"videos": {
+		"message": "ভিডিও"
+	},
+	"volume": {
+		"message": "শব্দ"
+	},
+	"watchLater": {
+		"message": "পরে দেখুন"
+	},
+	"watchTime": {
+		"message": "দেখার সময়"
+	},
+	"whenTabIsChanged": {
+		"message": "ট্যাব পরিবর্তন করা হয়"
+	},
+	"white": {
+		"message": "সাদা"
+	},
+	"windowColor": {
+		"message": "উইন্ডো রঙ"
+	},
+	"windowOpacity": {
+		"message": "উইন্ডোর অস্বচ্ছতা"
+	},
+	"yellow": {
+		"message": "হলুদ"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube শিরোনাম (বাম)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube শিরোনাম (ডানদিকে)"
+	},
+	"youtubeHomePage": {
+		"message": "ইউটিউব হোম পৃষ্ঠা"
+	},
+	"youtubeLanguage": {
+		"message": "ইউটিউব ভাষা"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "ইউটিউব h.264 কোডেকের জন্য ভিডিও গুণমানকে 1080p এর মধ্যে সীমাবদ্ধ করে"
+	}
 }

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -1,11 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Elimina els Shorts de la pàgina d'inici"
-    },
-    "qualityWithoutFocus": {
-        "message": "Quality without focus"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Elimineu el carrossel de Shorts dels resultats de cerca"
-    }
+	"hideHomePageShorts": {
+		"message": "Elimina els Shorts de la pàgina d'inici"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Elimineu el carrossel de Shorts dels resultats de cerca"
+	}
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -1,11 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Odebrat Shorts z úvodní stránky"
-    },
-    "qualityWithoutFocus": {
-        "message": "Quality without focus"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Odstraňte karuselu Shorts z výsledků vyhledávání"
-    }
+	"hideHomePageShorts": {
+		"message": "Odebrat Shorts z úvodní stránky"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Odstraňte karuselu Shorts z výsledků vyhledávání"
+	}
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -1,11 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Fjern Shorts fra hjemmesiden"
-    },
-    "qualityWithoutFocus": {
-        "message": "Quality without focus"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Fjern Shorts-rulle fra søgeresultaterne"
-    }
+	"hideHomePageShorts": {
+		"message": "Fjern Shorts fra hjemmesiden"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Fjern Shorts-rulle fra søgeresultaterne"
+	}
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,842 +1,839 @@
 {
-    "about": {
-        "message": "Info"
-    },
-    "accept": {
-        "message": "Akzeptieren"
-    },
-    "activate": {
-        "message": "Aktivieren"
-    },
-    "activateCaptions": {
-        "message": "Untertitel aktivieren"
-    },
-    "activated": {
-        "message": "Aktiviert"
-    },
-    "activatedFeatures": {
-        "message": "Aktivierte Features"
-    },
-    "activateFullscreen": {
-        "message": "Vollbild aktivieren"
-    },
-    "activeFeatures": {
-        "message": "Aktive Funktionen"
-    },
-    "addScrollToTop": {
-        "message": "„Nach Oben“-Button"
-    },
-    "ads": {
-        "message": "Werbung"
-    },
-    "all": {
-        "message": "Alles"
-    },
-    "allow": {
-        "message": "zulassen"
-    },
-    "alwaysActive": {
-        "message": "Immer aktiv"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Zeitleiste immer anzeigen"
-    },
-    "amber": {
-        "message": "Bernstein"
-    },
-    "analyzer": {
-        "message": "Analyse"
-    },
-    "appearance": {
-        "message": "Aussehen"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Daten wirklich exportieren?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Daten wirklich importieren?"
-    },
-    "audioFormats": {
-        "message": "Audio-Formate"
-    },
-    "autoFullscreen": {
-        "message": "Auto-Vollbild"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Video pausieren beim Tab-Wechsel"
-    },
-    "backgroundColor": {
-        "message": "Hintergrundfarbe"
-    },
-    "backgroundOpacity": {
-        "message": "Hintergrunddeckkraft"
-    },
-    "backupAndReset": {
-        "message": "Sichern oder zurücksetzen"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Basierend auf Systemfarben"
-    },
-    "belowPlayer": {
-        "message": "Unter dem Player"
-    },
-    "black": {
-        "message": "Schwarz"
-    },
-    "blockAll": {
-        "message": "immer blockieren"
-    },
-    "blockMusic": {
-        "message": "Musik blockieren"
-    },
-    "blue": {
-        "message": "Blau"
-    },
-    "blueGray": {
-        "message": "Blau grau"
-    },
-    "bluelight": {
-        "message": "Blaues Licht"
-    },
-    "brown": {
-        "message": "Braun"
-    },
-    "browserVersion": {
-        "message": "Browser-Version"
-    },
-    "bubbles": {
-        "message": "Blasen"
-    },
-    "cancel": {
-        "message": "Abbrechen"
-    },
-    "categories": {
-        "message": "Kategorien"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanäle"
-    },
-    "characterEdgeStyle": {
-        "message": "Zeichenumrandung"
-    },
-    "clipboard": {
-        "message": "Zwischenablage"
-    },
-    "collapsed": {
-        "message": "Eingeklappt"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Abos einklappen"
-    },
-    "comments": {
-        "message": "Kommentare"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Bestätigung beim Schließen"
-    },
-    "cores": {
-        "message": "Kerne"
-    },
-    "cropChapterTitles": {
-        "message": "Kapitel abschneiden"
-    },
-    "customCss": {
-        "message": "CSS hinzufügen"
-    },
-    "customJs": {
-        "message": "JS hinzufügen"
-    },
-    "customMiniPlayer": {
-        "message": "Benutzerdefinierter Mini-Player"
-    },
-    "dark": {
-        "message": "Dunkel"
-    },
-    "darkTheme": {
-        "message": "Dark-Theme"
-    },
-    "dateAndTime": {
-        "message": "Datum & Uhrzeit"
-    },
-    "dawn": {
-        "message": "Morgendämmerung"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Abspielgeschwindigkeit verringern"
-    },
-    "decreaseVolume": {
-        "message": "Lautstärke reduzieren"
-    },
-    "deepOrange": {
-        "message": "Dunkel-Orange"
-    },
-    "deepPurple": {
-        "message": "Dunkel-Lila"
-    },
-    "defaultChannelTab": {
-        "message": "Standard-Kanal-Tab"
-    },
-    "defaultContentCountry": {
-        "message": "Standard-Land für Inhalte"
-    },
-    "deleteWatchedVideos": {
-        "message": "Gesehene Videos entfernen"
-    },
-    "deleteYoutubeCookies": {
-        "message": "YouTube-Cookies löschen"
-    },
-    "desert": {
-        "message": "Wüste"
-    },
-    "developerOptions": {
-        "message": "Entwickleroptionen"
-    },
-    "device": {
-        "message": "Gerät"
-    },
-    "dim": {
-        "message": "dimmen"
-    },
-    "disabled": {
-        "message": "ausgeschaltet"
-    },
-    "dislike": {
-        "message": "'Mag ich nicht'"
-    },
-    "donate": {
-        "message": "Spenden"
-    },
-    "doNotChange": {
-        "message": "Nicht ändern"
-    },
-    "draggable": {
-        "message": "Verschiebbar"
-    },
-    "dropShadow": {
-        "message": "Schlagschatten"
-    },
-    "email": {
-        "message": "E-Mail"
-    },
-    "empty": {
-        "message": "leer"
-    },
-    "enabled": {
-        "message": "aktiviert"
-    },
-    "enabledForced": {
-        "message": "aktiviert (erzwungen)"
-    },
-    "expanded": {
-        "message": "ausgeklappt"
-    },
-    "exportSettings": {
-        "message": "Einstellungen als Datei exportieren"
-    },
-    "extension": {
-        "message": "Erweiterung"
-    },
-    "file": {
-        "message": "Datei"
-    },
-    "filters": {
-        "message": "Filter"
-    },
-    "fitToWindow": {
-        "message": "Ans Fenster anpassen"
-    },
-    "font": {
-        "message": "Schriftart"
-    },
-    "fontColor": {
-        "message": "Schriftfarbe"
-    },
-    "fontFamily": {
-        "message": "Schriftart Familie"
-    },
-    "fontOpacity": {
-        "message": "Schriftdeckkraft"
-    },
-    "fontSize": {
-        "message": "Schriftgröße"
-    },
-    "footer": {
-        "message": "Fußzeile"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "erzwungene Abspielgeschwindigkeit"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Spiele Video erzwungen von Beginn ab"
-    },
-    "forcedTheaterMode": {
-        "message": "Kinomodus erzwingen"
-    },
-    "forcedVolume": {
-        "message": "Fixe Lautstärke"
-    },
-    "forceSDR": {
-        "message": "SDR erzwingen"
-    },
-    "foundABug": {
-        "message": "Fehler gefunden?"
-    },
-    "fullWindow": {
-        "message": "Ganzes Fenster"
-    },
-    "general": {
-        "message": "Allgemein"
-    },
-    "goToSearchBox": {
-        "message": "YouTube Suche"
-    },
-    "green": {
-        "message": "Grün"
-    },
-    "hdThumbnail": {
-        "message": "HD-Vorschaubild"
-    },
-    "header": {
-        "message": "Header / 'Kopfzeile'"
-    },
-    "hidden": {
-        "message": "Ausblenden"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Auf Videoseiten ausblenden"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Keine animierten Vorschaubilder"
-    },
-    "hideAnnotations": {
-        "message": "Anmerkungen ausblenden"
-    },
-    "hideCards": {
-        "message": "Karten ausblenden"
-    },
-    "hideCountryCode": {
-        "message": "Ländercode ausblenden"
-    },
-    "hideDate": {
-        "message": "Datum ausblenden"
-    },
-    "hideDetails": {
-        "message": "Details ausblenden"
-    },
-    "hideEndscreen": {
-        "message": "Endkarten ausblenden (Schlussbildschirme)"
-    },
-    "hideFeaturedContent": {
-        "message": "'Empfohlene Inhalte' ausblenden"
-    },
-    "hideFooter": {
-        "message": "Fußzeile ausblenden"
-    },
-    "hideGradientBottom": {
-        "message": "Farbverlauf ausblenden"
-    },
-    "hideHomePageShorts": {
-        "message": "Startseite Shorts entfernen"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Kontrolleiste ausblenden"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Player-Kontrollen ausblenden"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Kontrollleistenoptionen ausblenden"
-    },
-    "hidePlaylist": {
-        "message": "Playlists ausblenden"
-    },
-    "hideRightButtons": {
-        "message": "Rechte Buttons ausblenden"
-    },
-    "hideScrollForDetails": {
-        "message": "„Für Details scrollen“ ausblenden"
-    },
-    "hideSkipOverlay": {
-        "message": "Überspringen Overlay ausblenden"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Thumbnail Overlay ausblenden"
-    },
-    "hideThumbnails": {
-        "message": "Thumbnails ausblenden"
-    },
-    "hideViewsCount": {
-        "message": "Videoaufrufe ausblenden"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Sprachsuche ausblenden"
-    },
-    "high": {
-        "message": "Hoch"
-    },
-    "history": {
-        "message": "Verlauf"
-    },
-    "home": {
-        "message": "Standard"
-    },
-    "hover": {
-        "message": "Nur anzeigen bei Mausover"
-    },
-    "hoverOnVideoPage": {
-        "message": "auf Video-Seiten bei Mausover"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Alter des Videos (seit Hochlade-Datum)"
-    },
-    "iconsOnly": {
-        "message": "nur Icons"
-    },
-    "importSettings": {
-        "message": "Einstellungen importieren"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube Icon auf YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube Sprache"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube Version"
-    },
-    "improveLogo": {
-        "message": "Logo verbessern"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Abspielgeschwingkeit erhöhen"
-    },
-    "increaseVolume": {
-        "message": "Lautstärke erhöhen"
-    },
-    "language": {
-        "message": "Sprache"
-    },
-    "languages": {
-        "message": "Sprachen"
-    },
-    "legacyYoutube": {
-        "message": "Klassiches YouTube"
-    },
-    "library": {
-        "message": "Bibliothek"
-    },
-    "light": {
-        "message": "Hell"
-    },
-    "lightBlue": {
-        "message": "Hellblau"
-    },
-    "lightGreen": {
-        "message": "Hellgrün"
-    },
-    "lime": {
-        "message": "Limette"
-    },
-    "limitPageWidth": {
-        "message": "Seitenbreite limitieren"
-    },
-    "list": {
-        "message": "Liste"
-    },
-    "liveChat": {
-        "message": "Live-Chat"
-    },
-    "liveChatType": {
-        "message": "Live-Chat Typ"
-    },
-    "location": {
-        "message": "Standort"
-    },
-    "loudnessNormalization": {
-        "message": "Lautstärke normalisieren"
-    },
-    "low": {
-        "message": "Niedrig"
-    },
-    "markWatchedVideos": {
-        "message": "gesehene Videos markieren"
-    },
-    "mixer": {
-        "message": "Mischpult"
-    },
-    "moveSidebarLeft": {
-        "message": "Seitenleiste nach links verschieben"
-    },
-    "moveThumbnailsRight": {
-        "message": "Thumbnails nach rechts verschieben"
-    },
-    "myColors": {
-        "message": "Meine Farben"
-    },
-    "nativeMiniPlayer": {
-        "message": "Standard Mini-Player"
-    },
-    "new": {
-        "message": "Neu"
-    },
-    "nextVideo": {
-        "message": "Nächstes Video"
-    },
-    "night": {
-        "message": "Nacht"
-    },
-    "noActiveFeatures": {
-        "message": "Keine aktiven Features"
-    },
-    "none": {
-        "message": "Keine"
-    },
-    "noOpenVideoTabs": {
-        "message": "Keine YouTube Videos geöffnet"
-    },
-    "old": {
-        "message": "Alt"
-    },
-    "onAllVideos": {
-        "message": "in allen Videos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "nur auf YouTube rot färben"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Nur ein Video gleichzeitig"
-    },
-    "onSubscribedChannels": {
-        "message": "nur in abonnierten Kanälen"
-    },
-    "os": {
-        "message": "Betriebsystem"
-    },
-    "other": {
-        "message": "Andere"
-    },
-    "outline": {
-        "message": "Umrandung"
-    },
-    "permissions": {
-        "message": "Berechtigungen"
-    },
-    "pictureInPicture": {
-        "message": "Bild-in-Bild"
-    },
-    "plain": {
-        "message": "Schlicht"
-    },
-    "platform": {
-        "message": "Plattform"
-    },
-    "playbackSpeed": {
-        "message": "Abspielgeschwindigkeit"
-    },
-    "playerColor": {
-        "message": "Playerfarbe"
-    },
-    "playerSize": {
-        "message": "Playergröße"
-    },
-    "popupPlayer": {
-        "message": "Player in eigenem Fenster"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Eine Taste drücken oder scrollen!"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Eine Taste drücken oder scrollen!"
-    },
-    "previousVideo": {
-        "message": "Letztes Video"
-    },
-    "primaryColor": {
-        "message": "Primäre Farbe"
-    },
-    "purple": {
-        "message": "Lila"
-    },
-    "quality": {
-        "message": "Qualität"
-    },
-    "qualityWithoutFocus": {
-        "message": "Qualität ohne Fokus"
-    },
-    "raised": {
-        "message": "Erhöht"
-    },
-    "rateMe": {
-        "message": "Bewerte mich"
-    },
-    "rateUs": {
-        "message": "Bewerte uns!"
-    },
-    "red": {
-        "message": "Rot"
-    },
-    "redDislikeButton": {
-        "message": "Zeige 'Mag ich nicht' Button rot"
-    },
-    "relatedVideos": {
-        "message": "Ähnliche Videos"
-    },
-    "remote": {
-        "message": "Auf TV abspielen"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Ähnliche Suchergebnisse entfernen"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Shorts-Reel aus den Suchergebnissen entfernen"
-    },
-    "repeat": {
-        "message": "Repeat (Wiederholen)"
-    },
-    "reset": {
-        "message": "Zurücksetzen"
-    },
-    "resetAllSettings": {
-        "message": "Alle Einstellungen zurücksetzen"
-    },
-    "resetAllShortcuts": {
-        "message": "Alle Shortcuts zurücksetzen"
-    },
-    "reverse": {
-        "message": "Rückwärts"
-    },
-    "rotate": {
-        "message": "Drehen"
-    },
-    "save": {
-        "message": "Speichern"
-    },
-    "saveAs": {
-        "message": "Speichern als"
-    },
-    "schedule": {
-        "message": "Zeitplan"
-    },
-    "screen": {
-        "message": "Bildschirm"
-    },
-    "search": {
-        "message": "Suche"
-    },
-    "searchBarOnly": {
-        "message": "Nur die Suchleiste"
-    },
-    "seekBackward10Seconds": {
-        "message": "10 Sekunden zurück"
-    },
-    "seekForward10Seconds": {
-        "message": "10 Sekunden überspringen"
-    },
-    "seekNextChapter": {
-        "message": "Nächstes Kapitel"
-    },
-    "seekPreviousChapter": {
-        "message": "Vorheriges Kapitel"
-    },
-    "settings": {
-        "message": "Einstellungen"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Einstellungen erfolgreich importiert!"
-    },
-    "shortcuts": {
-        "message": "Hotkeys"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Infokarten bei Mausover anzeigen"
-    },
-    "showChannelVideosCount": {
-        "message": "Anzahl Videos je Channel anzeigen"
-    },
-    "showLess": {
-        "message": "Weniger zeigen"
-    },
-    "showMore": {
-        "message": "Mehr zeigen"
-    },
-    "showRemainingDuration": {
-        "message": "Verbleibende Laufzeit anzeigen"
-    },
-    "shuffle": {
-        "message": "Zufallswiedergabe"
-    },
-    "sidebar": {
-        "message": "Seitenleiste"
-    },
-    "spacebar": {
-        "message": "Leertaste"
-    },
-    "squaredUserImages": {
-        "message": "Quadratische Profilbilder"
-    },
-    "static": {
-        "message": "Statisch"
-    },
-    "statsForNerds": {
-        "message": "Statistiken für Nerds"
-    },
-    "step": {
-        "message": "Schritt"
-    },
-    "stop": {
-        "message": "Stopp"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stile"
-    },
-    "subscribe": {
-        "message": "Abonnieren"
-    },
-    "subscriptions": {
-        "message": "Abos"
-    },
-    "subtitles": {
-        "message": "Untertitel"
-    },
-    "sunset": {
-        "message": "Sonnenuntergang"
-    },
-    "sunsetToSunrise": {
-        "message": "Abends bis Morgens"
-    },
-    "systemPeferenceDark": {
-        "message": "System Einstellungen: dunkel"
-    },
-    "systemPeferenceLight": {
-        "message": "System Einstellungen: hell"
-    },
-    "teal": {
-        "message": "Blaugrün"
-    },
-    "textColor": {
-        "message": "Textfarbe"
-    },
-    "themes": {
-        "message": "Farbschemen"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Alle Cookies werden gelöscht"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Alle YouTube Cookies werden gelöscht"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Alle Einstellungen werden entfernt"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Alle Shortcuts werden zurückgesetzt"
-    },
-    "thumbnails": {
-        "message": "Vorschaubilder"
-    },
-    "thumbnailsQuality": {
-        "message": "Thumbnailqualität"
-    },
-    "timeFrom": {
-        "message": "Start"
-    },
-    "timeTo": {
-        "message": "Ende"
-    },
-    "todayAt": {
-        "message": "Heute um"
-    },
-    "toggleAutoplay": {
-        "message": "Autoplay umschalten"
-    },
-    "toggleCards": {
-        "message": "Karten ausblenden"
-    },
-    "toggleControls": {
-        "message": "Kontrollen umschalten"
-    },
-    "topChat": {
-        "message": "Top Chat"
-    },
-    "trackWatchedVideos": {
-        "message": "Gesehene Videos protokollieren"
-    },
-    "trailerAutoplay": {
-        "message": "Kanal-Intro automatisch abspielen"
-    },
-    "translations": {
-        "message": "Übersetzungen"
-    },
-    "transparentBackground": {
-        "message": "Transparenter Hintergrund"
-    },
-    "trending": {
-        "message": "Trends"
-    },
-    "tryToReloadThePage": {
-        "message": "Versuche, die Seite neu zu laden"
-    },
-    "type": {
-        "message": "Typ"
-    },
-    "upNextAutoplay": {
-        "message": "Nächstes Video automatisch abspielen"
-    },
-    "use24HourFormat": {
-        "message": "24-Stunden Format"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Die Video-Beschreibung wird um den Kategorienamen erweitert"
-    },
-    "videoFormats": {
-        "message": "Videoformate"
-    },
-    "viewMode": {
-        "message": "Darstellungsmodus"
-    },
-    "volume": {
-        "message": "Lautstärke"
-    },
-    "watchLater": {
-        "message": "Später ansehen"
-    },
-    "watchTime": {
-        "message": "Verbrauchte Zeit"
-    },
-    "whenTabIsChanged": {
-        "message": "Beim Tab-Wechsel"
-    },
-    "white": {
-        "message": "Weiß"
-    },
-    "windowColor": {
-        "message": "Fensterfarbe"
-    },
-    "windowOpacity": {
-        "message": "Fensterdeckkraft"
-    },
-    "yellow": {
-        "message": "Gelb"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube Kopfzeile (Links)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube Kopfzeile (Rechts)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube Startseite"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube Sprache"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube begrenzt die Qualität auf 1080p für den h.264 Codec"
-    }
+	"about": {
+		"message": "Info"
+	},
+	"accept": {
+		"message": "Akzeptieren"
+	},
+	"activate": {
+		"message": "Aktivieren"
+	},
+	"activateCaptions": {
+		"message": "Untertitel aktivieren"
+	},
+	"activated": {
+		"message": "Aktiviert"
+	},
+	"activatedFeatures": {
+		"message": "Aktivierte Features"
+	},
+	"activateFullscreen": {
+		"message": "Vollbild aktivieren"
+	},
+	"activeFeatures": {
+		"message": "Aktive Funktionen"
+	},
+	"addScrollToTop": {
+		"message": "„Nach Oben“-Button"
+	},
+	"ads": {
+		"message": "Werbung"
+	},
+	"all": {
+		"message": "Alles"
+	},
+	"allow": {
+		"message": "zulassen"
+	},
+	"alwaysActive": {
+		"message": "Immer aktiv"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Zeitleiste immer anzeigen"
+	},
+	"amber": {
+		"message": "Bernstein"
+	},
+	"analyzer": {
+		"message": "Analyse"
+	},
+	"appearance": {
+		"message": "Aussehen"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Daten wirklich exportieren?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Daten wirklich importieren?"
+	},
+	"audioFormats": {
+		"message": "Audio-Formate"
+	},
+	"autoFullscreen": {
+		"message": "Auto-Vollbild"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Video pausieren beim Tab-Wechsel"
+	},
+	"backgroundColor": {
+		"message": "Hintergrundfarbe"
+	},
+	"backgroundOpacity": {
+		"message": "Hintergrunddeckkraft"
+	},
+	"backupAndReset": {
+		"message": "Sichern oder zurücksetzen"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Basierend auf Systemfarben"
+	},
+	"belowPlayer": {
+		"message": "Unter dem Player"
+	},
+	"black": {
+		"message": "Schwarz"
+	},
+	"blockAll": {
+		"message": "immer blockieren"
+	},
+	"blockMusic": {
+		"message": "Musik blockieren"
+	},
+	"blue": {
+		"message": "Blau"
+	},
+	"blueGray": {
+		"message": "Blau grau"
+	},
+	"bluelight": {
+		"message": "Blaues Licht"
+	},
+	"brown": {
+		"message": "Braun"
+	},
+	"browserVersion": {
+		"message": "Browser-Version"
+	},
+	"bubbles": {
+		"message": "Blasen"
+	},
+	"cancel": {
+		"message": "Abbrechen"
+	},
+	"categories": {
+		"message": "Kategorien"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanäle"
+	},
+	"characterEdgeStyle": {
+		"message": "Zeichenumrandung"
+	},
+	"clipboard": {
+		"message": "Zwischenablage"
+	},
+	"collapsed": {
+		"message": "Eingeklappt"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Abos einklappen"
+	},
+	"comments": {
+		"message": "Kommentare"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Bestätigung beim Schließen"
+	},
+	"cores": {
+		"message": "Kerne"
+	},
+	"cropChapterTitles": {
+		"message": "Kapitel abschneiden"
+	},
+	"customCss": {
+		"message": "CSS hinzufügen"
+	},
+	"customJs": {
+		"message": "JS hinzufügen"
+	},
+	"customMiniPlayer": {
+		"message": "Benutzerdefinierter Mini-Player"
+	},
+	"dark": {
+		"message": "Dunkel"
+	},
+	"darkTheme": {
+		"message": "Dark-Theme"
+	},
+	"dateAndTime": {
+		"message": "Datum & Uhrzeit"
+	},
+	"dawn": {
+		"message": "Morgendämmerung"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Abspielgeschwindigkeit verringern"
+	},
+	"decreaseVolume": {
+		"message": "Lautstärke reduzieren"
+	},
+	"deepOrange": {
+		"message": "Dunkel-Orange"
+	},
+	"deepPurple": {
+		"message": "Dunkel-Lila"
+	},
+	"defaultChannelTab": {
+		"message": "Standard-Kanal-Tab"
+	},
+	"defaultContentCountry": {
+		"message": "Standard-Land für Inhalte"
+	},
+	"deleteWatchedVideos": {
+		"message": "Gesehene Videos entfernen"
+	},
+	"deleteYoutubeCookies": {
+		"message": "YouTube-Cookies löschen"
+	},
+	"desert": {
+		"message": "Wüste"
+	},
+	"developerOptions": {
+		"message": "Entwickleroptionen"
+	},
+	"device": {
+		"message": "Gerät"
+	},
+	"dim": {
+		"message": "dimmen"
+	},
+	"disabled": {
+		"message": "ausgeschaltet"
+	},
+	"dislike": {
+		"message": "'Mag ich nicht'"
+	},
+	"donate": {
+		"message": "Spenden"
+	},
+	"doNotChange": {
+		"message": "Nicht ändern"
+	},
+	"draggable": {
+		"message": "Verschiebbar"
+	},
+	"dropShadow": {
+		"message": "Schlagschatten"
+	},
+	"email": {
+		"message": "E-Mail"
+	},
+	"empty": {
+		"message": "leer"
+	},
+	"enabled": {
+		"message": "aktiviert"
+	},
+	"enabledForced": {
+		"message": "aktiviert (erzwungen)"
+	},
+	"expanded": {
+		"message": "ausgeklappt"
+	},
+	"exportSettings": {
+		"message": "Einstellungen als Datei exportieren"
+	},
+	"extension": {
+		"message": "Erweiterung"
+	},
+	"file": {
+		"message": "Datei"
+	},
+	"filters": {
+		"message": "Filter"
+	},
+	"fitToWindow": {
+		"message": "Ans Fenster anpassen"
+	},
+	"font": {
+		"message": "Schriftart"
+	},
+	"fontColor": {
+		"message": "Schriftfarbe"
+	},
+	"fontFamily": {
+		"message": "Schriftart Familie"
+	},
+	"fontOpacity": {
+		"message": "Schriftdeckkraft"
+	},
+	"fontSize": {
+		"message": "Schriftgröße"
+	},
+	"footer": {
+		"message": "Fußzeile"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "erzwungene Abspielgeschwindigkeit"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Spiele Video erzwungen von Beginn ab"
+	},
+	"forcedTheaterMode": {
+		"message": "Kinomodus erzwingen"
+	},
+	"forcedVolume": {
+		"message": "Fixe Lautstärke"
+	},
+	"forceSDR": {
+		"message": "SDR erzwingen"
+	},
+	"foundABug": {
+		"message": "Fehler gefunden?"
+	},
+	"fullWindow": {
+		"message": "Ganzes Fenster"
+	},
+	"general": {
+		"message": "Allgemein"
+	},
+	"goToSearchBox": {
+		"message": "YouTube Suche"
+	},
+	"green": {
+		"message": "Grün"
+	},
+	"hdThumbnail": {
+		"message": "HD-Vorschaubild"
+	},
+	"header": {
+		"message": "Header / 'Kopfzeile'"
+	},
+	"hidden": {
+		"message": "Ausblenden"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Auf Videoseiten ausblenden"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Keine animierten Vorschaubilder"
+	},
+	"hideAnnotations": {
+		"message": "Anmerkungen ausblenden"
+	},
+	"hideCards": {
+		"message": "Karten ausblenden"
+	},
+	"hideCountryCode": {
+		"message": "Ländercode ausblenden"
+	},
+	"hideDate": {
+		"message": "Datum ausblenden"
+	},
+	"hideDetails": {
+		"message": "Details ausblenden"
+	},
+	"hideEndscreen": {
+		"message": "Endkarten ausblenden (Schlussbildschirme)"
+	},
+	"hideFeaturedContent": {
+		"message": "'Empfohlene Inhalte' ausblenden"
+	},
+	"hideFooter": {
+		"message": "Fußzeile ausblenden"
+	},
+	"hideGradientBottom": {
+		"message": "Farbverlauf ausblenden"
+	},
+	"hideHomePageShorts": {
+		"message": "Startseite Shorts entfernen"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Kontrolleiste ausblenden"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Player-Kontrollen ausblenden"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Kontrollleistenoptionen ausblenden"
+	},
+	"hidePlaylist": {
+		"message": "Playlists ausblenden"
+	},
+	"hideRightButtons": {
+		"message": "Rechte Buttons ausblenden"
+	},
+	"hideScrollForDetails": {
+		"message": "„Für Details scrollen“ ausblenden"
+	},
+	"hideSkipOverlay": {
+		"message": "Überspringen Overlay ausblenden"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Thumbnail Overlay ausblenden"
+	},
+	"hideThumbnails": {
+		"message": "Thumbnails ausblenden"
+	},
+	"hideViewsCount": {
+		"message": "Videoaufrufe ausblenden"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Sprachsuche ausblenden"
+	},
+	"high": {
+		"message": "Hoch"
+	},
+	"history": {
+		"message": "Verlauf"
+	},
+	"home": {
+		"message": "Standard"
+	},
+	"hover": {
+		"message": "Nur anzeigen bei Mausover"
+	},
+	"hoverOnVideoPage": {
+		"message": "auf Video-Seiten bei Mausover"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Alter des Videos (seit Hochlade-Datum)"
+	},
+	"iconsOnly": {
+		"message": "nur Icons"
+	},
+	"importSettings": {
+		"message": "Einstellungen importieren"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube Icon auf YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube Sprache"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube Version"
+	},
+	"improveLogo": {
+		"message": "Logo verbessern"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Abspielgeschwingkeit erhöhen"
+	},
+	"increaseVolume": {
+		"message": "Lautstärke erhöhen"
+	},
+	"language": {
+		"message": "Sprache"
+	},
+	"languages": {
+		"message": "Sprachen"
+	},
+	"legacyYoutube": {
+		"message": "Klassiches YouTube"
+	},
+	"library": {
+		"message": "Bibliothek"
+	},
+	"light": {
+		"message": "Hell"
+	},
+	"lightBlue": {
+		"message": "Hellblau"
+	},
+	"lightGreen": {
+		"message": "Hellgrün"
+	},
+	"lime": {
+		"message": "Limette"
+	},
+	"limitPageWidth": {
+		"message": "Seitenbreite limitieren"
+	},
+	"list": {
+		"message": "Liste"
+	},
+	"liveChat": {
+		"message": "Live-Chat"
+	},
+	"liveChatType": {
+		"message": "Live-Chat Typ"
+	},
+	"location": {
+		"message": "Standort"
+	},
+	"loudnessNormalization": {
+		"message": "Lautstärke normalisieren"
+	},
+	"low": {
+		"message": "Niedrig"
+	},
+	"markWatchedVideos": {
+		"message": "gesehene Videos markieren"
+	},
+	"mixer": {
+		"message": "Mischpult"
+	},
+	"moveSidebarLeft": {
+		"message": "Seitenleiste nach links verschieben"
+	},
+	"moveThumbnailsRight": {
+		"message": "Thumbnails nach rechts verschieben"
+	},
+	"myColors": {
+		"message": "Meine Farben"
+	},
+	"nativeMiniPlayer": {
+		"message": "Standard Mini-Player"
+	},
+	"new": {
+		"message": "Neu"
+	},
+	"nextVideo": {
+		"message": "Nächstes Video"
+	},
+	"night": {
+		"message": "Nacht"
+	},
+	"noActiveFeatures": {
+		"message": "Keine aktiven Features"
+	},
+	"none": {
+		"message": "Keine"
+	},
+	"noOpenVideoTabs": {
+		"message": "Keine YouTube Videos geöffnet"
+	},
+	"old": {
+		"message": "Alt"
+	},
+	"onAllVideos": {
+		"message": "in allen Videos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "nur auf YouTube rot färben"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Nur ein Video gleichzeitig"
+	},
+	"onSubscribedChannels": {
+		"message": "nur in abonnierten Kanälen"
+	},
+	"os": {
+		"message": "Betriebsystem"
+	},
+	"other": {
+		"message": "Andere"
+	},
+	"outline": {
+		"message": "Umrandung"
+	},
+	"permissions": {
+		"message": "Berechtigungen"
+	},
+	"pictureInPicture": {
+		"message": "Bild-in-Bild"
+	},
+	"plain": {
+		"message": "Schlicht"
+	},
+	"platform": {
+		"message": "Plattform"
+	},
+	"playbackSpeed": {
+		"message": "Abspielgeschwindigkeit"
+	},
+	"playerColor": {
+		"message": "Playerfarbe"
+	},
+	"playerSize": {
+		"message": "Playergröße"
+	},
+	"popupPlayer": {
+		"message": "Player in eigenem Fenster"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Eine Taste drücken oder scrollen!"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Eine Taste drücken oder scrollen!"
+	},
+	"previousVideo": {
+		"message": "Letztes Video"
+	},
+	"primaryColor": {
+		"message": "Primäre Farbe"
+	},
+	"purple": {
+		"message": "Lila"
+	},
+	"quality": {
+		"message": "Qualität"
+	},
+	"qualityWithoutFocus": {
+		"message": "Qualität ohne Fokus"
+	},
+	"raised": {
+		"message": "Erhöht"
+	},
+	"rateMe": {
+		"message": "Bewerte mich"
+	},
+	"rateUs": {
+		"message": "Bewerte uns!"
+	},
+	"red": {
+		"message": "Rot"
+	},
+	"redDislikeButton": {
+		"message": "Zeige 'Mag ich nicht' Button rot"
+	},
+	"relatedVideos": {
+		"message": "Ähnliche Videos"
+	},
+	"remote": {
+		"message": "Auf TV abspielen"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Ähnliche Suchergebnisse entfernen"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Shorts-Reel aus den Suchergebnissen entfernen"
+	},
+	"repeat": {
+		"message": "Repeat (Wiederholen)"
+	},
+	"reset": {
+		"message": "Zurücksetzen"
+	},
+	"resetAllSettings": {
+		"message": "Alle Einstellungen zurücksetzen"
+	},
+	"resetAllShortcuts": {
+		"message": "Alle Shortcuts zurücksetzen"
+	},
+	"reverse": {
+		"message": "Rückwärts"
+	},
+	"rotate": {
+		"message": "Drehen"
+	},
+	"save": {
+		"message": "Speichern"
+	},
+	"saveAs": {
+		"message": "Speichern als"
+	},
+	"schedule": {
+		"message": "Zeitplan"
+	},
+	"screen": {
+		"message": "Bildschirm"
+	},
+	"search": {
+		"message": "Suche"
+	},
+	"searchBarOnly": {
+		"message": "Nur die Suchleiste"
+	},
+	"seekBackward10Seconds": {
+		"message": "10 Sekunden zurück"
+	},
+	"seekForward10Seconds": {
+		"message": "10 Sekunden überspringen"
+	},
+	"seekNextChapter": {
+		"message": "Nächstes Kapitel"
+	},
+	"seekPreviousChapter": {
+		"message": "Vorheriges Kapitel"
+	},
+	"settings": {
+		"message": "Einstellungen"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Einstellungen erfolgreich importiert!"
+	},
+	"shortcuts": {
+		"message": "Hotkeys"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Infokarten bei Mausover anzeigen"
+	},
+	"showChannelVideosCount": {
+		"message": "Anzahl Videos je Channel anzeigen"
+	},
+	"showLess": {
+		"message": "Weniger zeigen"
+	},
+	"showMore": {
+		"message": "Mehr zeigen"
+	},
+	"showRemainingDuration": {
+		"message": "Verbleibende Laufzeit anzeigen"
+	},
+	"shuffle": {
+		"message": "Zufallswiedergabe"
+	},
+	"sidebar": {
+		"message": "Seitenleiste"
+	},
+	"spacebar": {
+		"message": "Leertaste"
+	},
+	"squaredUserImages": {
+		"message": "Quadratische Profilbilder"
+	},
+	"static": {
+		"message": "Statisch"
+	},
+	"statsForNerds": {
+		"message": "Statistiken für Nerds"
+	},
+	"step": {
+		"message": "Schritt"
+	},
+	"stop": {
+		"message": "Stopp"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stile"
+	},
+	"subscribe": {
+		"message": "Abonnieren"
+	},
+	"subscriptions": {
+		"message": "Abos"
+	},
+	"subtitles": {
+		"message": "Untertitel"
+	},
+	"sunset": {
+		"message": "Sonnenuntergang"
+	},
+	"sunsetToSunrise": {
+		"message": "Abends bis Morgens"
+	},
+	"systemPeferenceDark": {
+		"message": "System Einstellungen: dunkel"
+	},
+	"systemPeferenceLight": {
+		"message": "System Einstellungen: hell"
+	},
+	"teal": {
+		"message": "Blaugrün"
+	},
+	"textColor": {
+		"message": "Textfarbe"
+	},
+	"themes": {
+		"message": "Farbschemen"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Alle Cookies werden gelöscht"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Alle YouTube Cookies werden gelöscht"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Alle Einstellungen werden entfernt"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Alle Shortcuts werden zurückgesetzt"
+	},
+	"thumbnails": {
+		"message": "Vorschaubilder"
+	},
+	"thumbnailsQuality": {
+		"message": "Thumbnailqualität"
+	},
+	"timeFrom": {
+		"message": "Start"
+	},
+	"timeTo": {
+		"message": "Ende"
+	},
+	"todayAt": {
+		"message": "Heute um"
+	},
+	"toggleAutoplay": {
+		"message": "Autoplay umschalten"
+	},
+	"toggleCards": {
+		"message": "Karten ausblenden"
+	},
+	"toggleControls": {
+		"message": "Kontrollen umschalten"
+	},
+	"trackWatchedVideos": {
+		"message": "Gesehene Videos protokollieren"
+	},
+	"trailerAutoplay": {
+		"message": "Kanal-Intro automatisch abspielen"
+	},
+	"translations": {
+		"message": "Übersetzungen"
+	},
+	"transparentBackground": {
+		"message": "Transparenter Hintergrund"
+	},
+	"trending": {
+		"message": "Trends"
+	},
+	"tryToReloadThePage": {
+		"message": "Versuche, die Seite neu zu laden"
+	},
+	"type": {
+		"message": "Typ"
+	},
+	"upNextAutoplay": {
+		"message": "Nächstes Video automatisch abspielen"
+	},
+	"use24HourFormat": {
+		"message": "24-Stunden Format"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Die Video-Beschreibung wird um den Kategorienamen erweitert"
+	},
+	"videoFormats": {
+		"message": "Videoformate"
+	},
+	"viewMode": {
+		"message": "Darstellungsmodus"
+	},
+	"volume": {
+		"message": "Lautstärke"
+	},
+	"watchLater": {
+		"message": "Später ansehen"
+	},
+	"watchTime": {
+		"message": "Verbrauchte Zeit"
+	},
+	"whenTabIsChanged": {
+		"message": "Beim Tab-Wechsel"
+	},
+	"white": {
+		"message": "Weiß"
+	},
+	"windowColor": {
+		"message": "Fensterfarbe"
+	},
+	"windowOpacity": {
+		"message": "Fensterdeckkraft"
+	},
+	"yellow": {
+		"message": "Gelb"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube Kopfzeile (Links)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube Kopfzeile (Rechts)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube Startseite"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube Sprache"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube begrenzt die Qualität auf 1080p für den h.264 Codec"
+	}
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -1,1261 +1,1235 @@
 {
-  "about": {
-    "message": "Σχετικά"
-  },
-  "accept": {
-    "message": "Αποδοχή"
-  },
-  "activate": {
-    "message": "Ενεργοποίηση"
-  },
-  "activateCaptions": {
-    "message": "Ενεργοποίηση Υπότιτλων"
-  },
-  "activated": {
-    "message": "Επιτυχής Ενεργοποιήση"
-  },
-  "activatedFeatures": {
-    "message": "Ενεργοποιημένες Λειτουργίες"
-  },
-  "activateFullscreen": {
-    "message": "Ενεργοποίηση Πλήρους Οθόνη"
-  },
-  "activeFeatures": {
-    "message": "Ενεργές λειτουργίες"
-  },
-  "addScrollToTop": {
-    "message": "Πρόσθεση συντόμευσης για την κορυφή της σελίδας"
-  },
-  "ads": {
-    "message": "Διαφημίσεις"
-  },
-  "all": {
-    "message": "Όλα"
-  },
-  "allow": {
-    "message": "Αποδοχή"
-  },
-  "Allow_auto_generate": {
-    "message": "Ενεργοποίηση αυτόματης δημιουργίας"
-  },
-  "allow60fps": {
-    "message": "Ενεργοποίηση 60fps"
-  },
-  "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-    "message": "Όλες οι ρυθμίσεις σας θα διαγραφούν και δεν μπορούν να ανακτηθούν"
-  },
-  "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-    "message": "Όλες οι συντομεύσεις σας θα διαγραφούν και δεν μπορούν να ανακτηθούν"
-  },
-  "always": {
-    "message": "Πάντα"
-  },
-  "alwaysActive": {
-    "message": "Πάντοτε ενεργό"
-  },
-  "alwaysShowProgressBar": {
-    "message": "Πάντα ορατός ο ενδείκτης προόδου"
-  },
-  "amber": {
-    "message": "Κεχρί"
-  },
-  "analyzer": {
-    "message": "Αναλυτής"
-  },
-  "animations": {
-    "message": "Animations-Κινούμενα σχέδια"
-  },
-  "appearance": {
-    "message": "Εμφάνιση"
-  },
-  "areYouSureYouWantToExportTheData": {
-    "message": "Είστε σίγουρος/η ότι θέλετε να εξάγετε τα δεδομένα;\n"
-  },
-  "areYouSureYouWantToImportTheData": {
-    "message": "Είστε σίγουρος/η ότι θέλετε να εισαγάγετε τα δεδομένα;"
-  },
-  "areYouSureYouWantToSyncTheData": {
-    "message": "Είστε σίγουρος/η ότι θέλετε να συγχρονίσετε τα δεδομένα;"
-  },
-  "ARROWDOWN": {
-    "message": "⇩"
-  },
-  "ARROWLEFT": {
-    "message": "⇦"
-  },
-  "ARROWRIGHT": {
-    "message": "⇨"
-  },
-  "ARROWUP": {
-    "message": "⇧"
-  },
-  "atHistory": {
-    "message": "στο 'Ιστορικό'"
-  },
-  "atSubscriptions": {
-    "message": "στις 'Συνδρομές'"
-  },
-  "atTrending": {
-    "message": "στις 'Τάσεις'"
-  },
-  "audio": {
-    "message": "Ήχος"
-  },
-  "audioFormats": {
-    "message": "Μορφές ήχου"
-  },
-  "auto": {
-    "message": "Αυτόματο"
-  },
-  "autoFullscreen": {
-    "message": "Αυτόματη Πλήρης Οθόνη"
-  },
-  "autopauseWhenSwitchingTabs": {
-    "message": "Αυτόματη παύση όταν αλλάζετε καρτέλα"
-  },
-  "autoPictureInPicture": {
-    "message": "Αυτόματη Picture In Picture (PiP)"
-  },
-  "autoplay": {
-    "message": "Αυτόματη αναπαραγωγή"
-  },
-  "autoplayDisable": {
-    "message": "Απενεργοποίηση αυτόματης αναπαραγωγής"
-  },
-  "avoidAv1": {
-    "message": "Αποφύγετε το AV1"
-  },
-  "avoidAv1Vp8Vp9": {
-    "message": "Αποφύγετε το AV1, VP8, VP9"
-  },
-  "avoidAv1Vp9": {
-    "message": "Αποφύγετε το AV1, VP9"
-  },
-  "avoidCpuRenderingWhenPossible": {
-    "message": "Αποφύγετε τη CPU αποτύπωση όταν είναι δυνατόν"
-    },
-    "backgroundColor": {
-      "message": "Χρώμα φόντου"
-    },
-    "backgroundOpacity": {
-      "message": "Διαφάνεια φόντου"
-    },
-    "backupAndReset": {
-      "message": "Αντίγραφα ασφαλείας & reset"
-    },
-    "baseOnSystemColorScheme": {
-      "message": "Με βάση τις ρυθμίσεις χρώματος του συστήματος"
-    },
-    "belowPlayer": {
-      "message": "Κάτω από το Player"
-    },
-    "black": {
-      "message": "Μαύρο"
-    },
-    "block_Codec_Alert_h264": {
-      "message": "Χρειάζεστε είτε το H.264 είτε το VP9 ενεργοποιημένο για να αναπαραχθούν βίντεο στο Youtube."
-    },
-    "blockAll": {
-      "message": "Απενεργοποίηση (Αποκλεισμός ή Παράβλεψη)"
-    },
-    "blocklist": {
-      "message": "Λίστα αποκλεισμού"
-    },
-    "blockMusic": {
-      "message": "Παράκαμψη κατά την αναπαραγωγή μουσική"
-    },
-    "blue": {
-      "message": "Μπλε"
-    },
-    "blueGray": {
-      "message": "Μπλε γκρίζο"
-    },
-    "bluelight": {
-      "message": "Μπλε φως"
-    },
-    "brown": {
-      "message": "Καφέ"
-    },
-    "browserAccountSync": {
-      "message": "Συγχρονισμός λογαριασμού με browser"
-    },
-    "browserVersion": {
-      "message": "Έκδοση browser"
-    },
-    "bubbles": {
-      "message": "Φούσκες"
-    },
-    "bug": {
-      "message": "Σφάλμα κώδικα"
-    },
-    "buttons": {
-      "message": "Κουμπιά"
-    },
-    "cancel": {
-      "message": "Ακύρωση"
-    },
-    "categories": {
-      "message": "Κατηγορίες"
-    },
-    "channel": {
-      "message": "Κανάλι"
-    },
-    "channels": {
-      "message": "Κανάλια"
-    },
-    "chapters": {
-      "message": "Κεφάλαια"
-    },
-    "characterEdgeStyle": {
-      "message": "Στυλ άκρων χαρακτήρων"
-    },
-    "clip": {
-      "message": "Κλιπ"
-    },
-    "collapsed": {
-      "message": "Κλειστό"
-    },
-    "collapseOfSubscriptionSections": {
-      "message": "Σύμπτυξη μενού συνδρομών"
-    },
-    "columns": {
-      "message": "Επιπλέον στήλη πλαϊνής μπάρας"
-    },
-    "comment": {
-      "message": "Σχόλιο"
-    },
-    "comments": {
-      "message": "Σχόλια"
-    },
-    "community": {
-      "message": "Κοινότητα"
-    },
-    "compact_spacing": {
-      "message": "Συμπαγής Διάταξη"
-    },
-    "compactTheme": {
-      "message": "Συμπαγές θεματικό"
-    },
-    "confirmationBeforeClosing": {
-      "message": "Επιβεβαίωση πριν την αποχώρηση"
-    },
-    "cores": {
-      "message": "Πυρήνες"
-    },
-    "cropChapterTitles": {
-      "message": "Περίκοπη τίτλων των κεφαλαίων του player"
-    },
-    "Currently_requiring_a_YouTube_API_key": {
-      "message": "Προς το παρόν απαιτείται κλειδί API του YouTube"
-    },
-    "custom": {
-      "message": "Προσαρμοσμένο"
-    },
-    "customCss": {
-      "message": "Εξατομίκευση CSS"
-    },
-    "customJs": {
-      "message": "Εξατομίκευση JS"
-    },
-    "customMiniPlayer": {
-      "message": "Εξατομικευμένο Mini-Player"
-    },
-    "cyan": {
-      "message": "Κυανό"
-    },
-    "dark": {
-      "message": "Σκούρο"
-    },
-    "darkTheme": {
-      "message": "Σκούρο θέμα"
-    },
-    "dateAndTime": {
-      "message": "Ημερομηνία & ώρα"
-    },
-    "dawn": {
-      "message": "Αυγή"
-    },
-    "decreasePlaybackSpeed": {
-      "message": "Μείωση ταχύτητας αναπαραγωγής"
-    },
-    "decreaseVolume": {
-      "message": "Μειώση έντασης"
-    },
-    "deepOrange": {
-      "message": "Βαθύ πορτοκαλί"
-    },
-    "deepPurple": {
-      "message": "Βαθύ μοβ"
-    },
-    "default": {
-      "message": "Προεπιλογή"
-    },
-    "default_CC": {
-      "message": "Προεπιλογή"
-    },
-    "defaultChannelTab": {
-      "message": "Προεπιλεγμένη καρτέλα καναλιού"
-    },
-    "defaultContentCountry": {
-      "message": "Χώρα (ψηφιακή πλοήγηση)"
-    },
-    "defaultPlaybackSpeed": {
-      "message": "Προεπιλεγμένη Ταχύτητα Αναπαραγωγής"
-    },
-    "default_theme": {
-      "message": "Προεπιλογή"
-    },
-    "deleteWatchedVideos": {
-      "message": "Διαγραφή Ιστορικού παρακολούθησης"
-    },
-    "deleteYoutubeCookies": {
-      "message": "Κατάργηση Youtube cookies"
-    },
-    "description": {
-      "message": "Περιγραφή"
-    },
-    "description_ext": {
-      "message": "YouTube, καθαρό + έξυπνο; Μέγεθος βίντεο Youtube player χρώμα Youtube ad παράβλεψης ταχύτητα έντασης ετικέτες παράβλεψης  απόκρυψη λίστας"
-    },
-    "desert": {
-      "message": "Έρημος"
-    },
-    "details": {
-      "message": "Λεπτομέρειες"
-    },
-    "developerOptions": {
-      "message": "Επιλογές για προγραμματιστές"
-    },
-    "device": {
-      "message": "Συσκευή"
-    },
-    "dim": {
-      "message": "Σκοτεινό"
-    },
-    "disabled": {
-      "message": "Απενεργοποιημένο"
-    },
-    "disableThumbnailPlayback": {
-      "message": "Απενεργοποίηση αναπαραγωγής εικονιδίων"
-    },
-    "dislike": {
-      "message": "Δε μου αρέσει"
-    },
-    "displayDayOfTheWeak": {
-      "message": "Εμφάνιση ημέρας της εβδομάδας"
-    },
-    "donate": {
-      "message": "Δωρεά"
-    },
-    "doNotChange": {
-      "message": "Να μην αλλάξει"
-    },
-    "Download": {
-      "message": "Λήψη"
-    },
-    "draggable": {
-      "message": "Μετακινήσιμο με σύρση"
-    },
-    "dropShadow": {
-      "message": "Drop Επισκίαση"
-    },
-    "durationWithSpeed": {
-      "message": "Εμφάνιση υπολειπόμενης διάρκειας με σχέση προς την ταχύτητα αναπαραγωγής"
-    },
-    "Embedded_YouTube": {
-      "message": "Ενσωματωμένο YouTube"
-    },
-    "embedded_Hide_Share": {
-      "message": "Απόκρυψη κοινοποίησης σε ενσωματωμένο βίντεο"
-    },
-    "empty": {
-      "message": "Κενό"
-    },
-    "enabled": {
-      "message": "Ενεργοποιημένο"
-    },
-    "enabledForced": {
-      "message": "Ενεργοποιημένο (Υποχρεωτικά)"
-    },
-    "expanded": {
-      "message": "Ανοικτό"
-    },
-    "exportSettings": {
-      "message": "Εξαγωγή ρυθμίσεων"
-    },
-    "extension": {
-      "message": "Επέκταση"
-    },
-    "ExtraButtons": {
-      "message": "Επιπρόσθετα κουμπιά"
-    },
-    "extraButtonsBelowThePlayer": {
-      "message": "Πρόσθετα κουμπιά κάτω από τον παίκτη"
-    },
-    "Feature_not_yet_available": {
-      "message": "Η λειτουργία δεν είναι διαθέσιμη ακόμα"
-    },
-    "file": {
-      "message": "Αρχείο"
-    },
-    "filters": {
-      "message": "Φίλτρα"
-    },
-    "fitToWindow": {
-      "message": "Προσαρμογή στο παράθυρο"
-    },
-    "Focus": {
-      "message": "Εστίαση"
-    },
-    "flash": {
-      "message": "Flash"
-    },
-    "font": {
-      "message": "Γραμματοσειρά"
-    },
-    "fontColor": {
-      "message": "Χρώμα γραμματοσειράς"
-    },
-    "fontFamily": {
-      "message": "Οικογένεια γραμματοσειράς"
-    },
-    "fontOpacity": {
-      "message": "Διαφάνεια γραμματοσειράς"
-    },
-    "fontSize": {
-      "message": "Μέγεθος γραμματοσειράς"
-    },
-    "footer": {
-      "message": "Υποσέλιδο"
-    },
-    "forcedPlaybackSpeed": {
-      "message": "Υποχρεωτική ταχύτητα αναπαραγωγής"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-      "message": "Επιβολή αναπαραγωγής βίντεο από την αρχή"
-    },
-    "forcedPlaybackSpeedMusic": {
-      "message": "Επιβολή ταχύτητας αναπαραγωγής για μουσική"
-    },
-    "forcedTheaterMode": {
-      "message": "Υποχρεωτική λειτουργία κινηματογράφου"
-    },
-    "forcedVolume": {
-      "message": "Υποχρεωτική ένταση"
-    },
-    "forceSDR": {
-      "message": "Επιβολή SDR"
-    },
-    "foundABug": {
-      "message": "Εντοπίσατε κάποιο σφάλμα;"
-    },
-    "fullWindow": {
-      "message": "Πλήρες παράθυρο"
-    },
-    "general": {
-      "message": "Γενικά"
-    },
-    "geoPreference": {
-      "message": "Προτίμηση Γεωγραφικού Χώρου"
-    },
-    "goToSearchBox": {
-      "message": "Πήγαινε στο πεδίο αναζήτησης"
-    },
-    "GPUnotindatabase": {
-      "message": "GPU εκτός βάσης δεδομένων"
-    },
-    "green": {
-      "message": "Πράσινο"
-    },
-    "grey": {
-      "message": "Γκρι"
-    },
-    "halfTransparent": {
-      "message": "Ημι-αχνό"
-    },
-    "Hamburger_Menu": {
-      "message": "Μενού hamburger"
-    },
-    "hardwareInformation": {
-      "message": "Πληροφορίες hardware"
-    },
-    "hd": {
-      "message": "HD-Υψηλή ευκρίνεια"
-    },
-    "hdThumbnail": {
-      "message": "HD Εικονίδιο βίντεο"
-    },
-    "header": {
-      "message": "Κεφαλίδα"
-    },
-    "hidden": {
-      "message": "Κρυμμένο"
-    },
-    "hiddenOnVideoPage": {
-      "message": "Κρυμμένο στη σελίδα βίντεο"
-    },
-    "hide_author_avatars": {
-      "message": "Απόκρυψη εικονιδίου συγγραφέα"
-    },
-    "hideAnimatedThumbnails": {
-      "message": "Απόκρυψη κινούμενων εικονιδίων"
-    },
-    "hideAnnotations": {
-      "message": "Απόκρυψη των annotations"
-    },
-    "hideCards": {
-      "message": "Απόκρυψη καρτών"
-    },
-    "hideCategories": {
-      "message": "Απόκρυψη κατηγοριών"
-    },
-    "hideCommentsCount": {
-      "message": "Απόκρυψη μετρητή σχολίων"
-    },
-    "hideCountryCode": {
-      "message": "Απόκρυψη κωδικού χώρας"
-    },
-    "hideDate": {
-      "message": "Απόκρυψη ημερομηνίας"
-    },
-    "hideDetailButton": {
-      "message": "Απόκρυψη κουμπιού λεπτομερειών"
-    },
-    "hideDetails": {
-      "message": "Απόκρυψη λεπτομερειών"
-    },
-    "hideEndscreen": {
-      "message": "Απόκρυψη τελικής οθόνης"
-    },
-    "hideFeaturedContent": {
-      "message": "Απόκρυψη προτεινόμενου περιεχομένου"
-    },
-    "hideFooter": {
-      "message": "Απόκρυψη υποσέλιδου"
-    },
-    "hideGradientBottom": {
-      "message": "Απόκρυψη κάτω μέρους της χρωματικής διαβάθμισης"
-    },
-    "hideHomePageShorts": {
-      "message": "Απόκρυψη Shorts από την αρχική σελίδα"
-    },
-    "hide_Labels": {
-      "message": "Απόκρυψη ετικετών"
-    },
-    "hideMore": {
-      "message": "Απόκρυψη περισσότερων"
-    },
-    "Hide_Pause_Overlay": {
-      "message": "Απόκρυψη επικάλυψης παύσης"
-    },
-    "hidePlayerControlsBar": {
-      "message": "Απόκρυψη γραμμής ελέγχου player"
-    },
-    "hidePlayerControlsBarButtons": {
-      "message": "Απόκρυψη κουμπιών γραμμής ελέγχου player"
-    },
-    "hidePlayerControlsBarOptions": {
-      "message": "Απόκρυψη ελέγχου επιλογών player"
-    },
-    "hidePlaylist": {
-      "message": "Απόκρυψη playlist"
-    },
-    "hideReport": {
-      "message": "Απόκρυψη αναφοράς"
-    },
-    "hideRightButtons": {
-      "message": "Απόκρυψη δεξιών κουμπιών"
-    },
-    "hideScrollForDetails": {
-      "message": "Απόκρυψη του «Scroll for details»"
-    },
-    "Hide_Shorts_remixing_this_video": {
-      "message": "Απόκρυψη remixing Shorts του βίντεο"
-    },
-    "Hide_sidebar": {
-      "message": "Απόκρυψη πλαϊνής στήλης"
-    },
-    "hideSkipOverlay": {
-      "message": "Απόκρυψη επικάλυψης παράβλεψης"
-    },
-    "Hide_the_tabs_only": {
-      "message": "Απόκρυψη μόνο των tabs"
-    },
-    "hideThumbnailOverlay": {
-      "message": "Απόκρυψη επικάλυψης εικονιδίων"
-    },
-    "hideThumbnails": {
-      "message": "Απόκρυψη εικονιδίων(Thumbnails)"
-    },
-    "hideViewsCount": {
-      "message": "Απόκρυψη αριθμού προβολών"
-    },
-    "hideVoiceSearchButton": {
-      "message": "Απόκρυψη κουμπιού αναζήτησης φωνής"
-    },
-    "Hide_YouTube_Logo": {
-      "message": "Απόκρυψη λογότυπου του YouTube"
-    },
-    "high": {
-      "message": "Υψηλή"
-    },
-    "history": {
-      "message": "Ιστορικό"
-    },
-    "home": {
-      "message": "Αρχική σελίδα"
-    },
-    "homeScreen": {
-      "message": "Αρχική οθόνη"
-    },
-    "hover": {
-      "message": "Κέρσορας από πάνω"
-    },
-    "hoverOnVideoPage": {
-      "message": "Κέρσορας πάνω στη σελίδα βίντεο"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-      "message": "Διάρκεια ανάρτησης του βιντεο"
-    },
-    "icons": {
-      "message": "Εικονίδια"
-    },
-    "iconsOnly": {
-      "message": "Εικονίδια μόνο"
-    },
-    "importSettings": {
-      "message": "Εισαγωγή ρυθμίσεων"
-    },
-    "improvedtubeButtons": {
-      "message": "ImprovedTube Κουμπιά"
-    },
-    "improvedtubeIconOnYoutube": {
-      "message": "Εικονίδιο ImprovedTube στο YouTube"
-    },
-    "improvedtubeLanguage": {
-      "message": "Γλώσσα ImprovedTube"
-    },
-    "improvedtubeVersion": {
-      "message": "Έκδοση ImprovedTube"
-    },
-    "improveLogo": {
-      "message": "Λογότυπο Improve"
-    },
-    "increasePlaybackSpeed": {
-      "message": "Αύξησε την ταχύτητα αναπαραγωγής"
-    },
-    "increaseVolume": {
-      "message": "Αύξησε την ένταση"
-    },
-    "items": {
-      "message": "Αντικείμενα"
-    },
-    "language": {
-      "message": "Γλώσσα"
-    },
-    "language_closed_caption": {
-      "message": "Προεπιλεγμένη γλώσσα - Κλειστά Captions"
-    },
-    "languages": {
-      "message": "Γλώσσες"
-    },
-    "legacyYoutube": {
-      "message": "Παλιά έκδοση YouTube"
-    },
-    "layerAnimationScale": {
-      "message": "Κλίμακα κινούμενου επιπέδου"
-    },
-    "layout": {
-      "message": "Διάταξη"
-    },
-    "library": {
-      "message": "Βιβλιοθήκη"
-    },
-    "light": {
-      "message": "Ανοιχτόχρωμο"
-    },
-    "lightBlue": {
-      "message": "Ανοικτό μπλε"
-    },
-    "lightGreen": {
-      "message": "Ανοικτό πράσινο"
-    },
-    "like": {
-      "message": "Μου αρέσει"
-    },
-    "liked": {
-      "message": "Βίντεο που μου αρέσουν"
-    },
-    "likes": {
-      "message": "Likes (Μου αρέσει)"
-    },
-    "lime": {
-      "message": "Μοσχολέμονο"
-    },
-    "limitPageWidth": {
-      "message": "Περιορισμός πλάτους σελίδας"
-    },
-    "list": {
-      "message": "Λίστα"
-    },
-    "liveChat": {
-      "message": "Live συνομιλία"
-    },
-    "liveChatType": {
-      "message": "Τύπος Live συνομιλίας"
-    },
-    "location": {
-      "message": "Τοποθεσία"
-    },
-    "loop": {
-      "message": "Επανάληψη"
-    },
-    "loudnessNormalization": {
-      "message": "Κανονικοποίηση έντασης"
-    },
-    "low": {
-      "message": "Χαμηλή"
-    },
-    "markWatchedVideos": {
-      "message": "Επισήμανση βίντεο που προβλήθηκαν"
-    },
-    "maxWidthWithinThePage": {
-      "message": "Μέγ. πλάτος εντός της σελίδας"
-    },
-    "medium": {
-      "message": "Μεσαία"
-    },
-    "more": {
-      "message": "Περισσότερα"
-    },
-    "mostViewedChannels": {
-      "message": "Kανάλια με τις περισσότερες προβολές"
-    },
-    "moveSidebarLeft": {
-      "message": "Μετακίνηση πλαϊνής στήλης προς τα αριστερά"
-    },
-    "moveThumbnailsRight": {
-      "message": "Μετακίνηση εικονιδιών (Thumbnails) προς τα δεξιά"
-    },
-    "myColors": {
-      "message": "Τα χρώματά μου"
-    },
-    "My_specs": {
-      "message": "Προδιαγραφές"
-    },
-    "name": {
-      "message": "Όνομα"
-    },
-    "nativeMiniPlayer": {
-      "message": "Mini player συστήματος"
-    },
-    "new": {
-      "message": "Νέο"
-    },
-    "nextVideo": {
-      "message": "Επόμενο βίντεο"
-    },
-    "night": {
-      "message": "Νύχτα"
-    },
-    "noActiveFeatures": {
-      "message": "Καμία λειτουργία ενεργή"
-    },
-    "none": {
-      "message": "Κανένα"
-    },
-    "noOpenVideoTabs": {
-      "message": "Καμία άλλη καρτέλα βίντεο ανοικτή"
-    },
-    "normal": {
-      "message": "Κανονικό"
-    },
-    "Not_optimal": {
-      "message": "Όχι βέλτιστο"
-    },
-    "off": {
-      "message": "Απενεργοποιημένο"
-    },
-    "old": {
-      "message": "Παλιό"
-    },
-    "onAllVideos": {
-      "message": "Σε όλα τα βίντεο"
-    },
-    "onlyActiveOnYoutube": {
-      "message": "Μόνο ενεργό στο YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-      "message": "Μόνο ένα player λειτουργεί"
-    },
-    "onSmallCreators": {
-      "message": "Μόνο για μικρά κανάλια"
-    },
-    "onSubscribedChannels": {
-      "message": "Σε κανάλια που έχει γίνει συνδρομή"
-    },
-    "openNewTab": {
-      "message": "Άνοιξε σε νέα σελίδα"
-    },
-    "openPopupPlayer": {
-      "message": "Άνοιξε το video/playlist σε νέο παράθυρο"
-    },
-    "optimizeCodecForHardwareAcceleration": {
-      "message": "Βελτιστοποίηση κωδικοποιητή για επιτάχυνση υλικού"
-    },
-    "orange": {
-      "message": "Πορτοκαλί"
-    },
-    "other": {
-      "message": "Άλλο"
-    },
-    "outline": {
-      "message": "Περίγραμμα"
-    },
-    "overlay": {
-      "message": "Επικάλυψη"
-    },
-    "permissions": {
-      "message": "Άδεια"
-    },
-    "pink": {
-      "message": "Ροζ"
-    },
-    "plain": {
-      "message": "Σκέτο"
-    },
-    "platform": {
-      "message": "Πλατφόρμα"
-    },
-    "playAllButton": {
-      "message": "Κουμπί αναπαραγωγής όλων"
-    },
-    "playbackSpeed": {
-      "message": "Ταχύτητα αναπαραγωγής"
-    },
-    "player_auto_cinema_mode": {
-      "message": "Αυτόματη λειτουργία κινηματογράφου"
-    },
-    "player_autoplay_disable": {
-      "message": "Απενεργοποίηση αυτόματης αναπαραγωγής"
-    },
-    "player_auplayer_SDR": {
-      "message": "Αυτόματη επαναλαμβανόμενη λειτουργία SDR"
-    },
-    "player_cinema_mode_button": {
-      "message": "Κουμπί λειτουργίας κινηματογράφου"
-    },
-    "player_dont_speed_education": {
-      "message": "Μη επιβολή ταχύτητας εκπαίδευσης"
-    },
-    "player_fit_to_win_button": {
-      "message": "Κουμπί προσαρμογής στο παράθυρο"
-    },
-    "player_rotate_button": {
-      "message": "Περιστροφή βίντεο"
-    },
-    "playerSize": {
-      "message": "Μέγεθος player"
-    },
-    "playerColor": {
-      "message": "Χρώμα γραμμής προόδου player"
-    },
-    "playPause": {
-      "message": "Αναπαραγωγή/Παύση"
-    },
-    "popupWindowButtons": {
-      "message": "Κουμπιά pop up παραθύρου"
-    },
-    "position": {
-      "message": "Θέση"
-    },
-    "pressAnyKeyOrScroll": {
-      "message": "Πίεσε οποιοδήποτε πλήκτρο ή χρησιμοποίησε τη ροδέλα στο ποντίκι."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-      "message": "Πίεσε οποιοδήποτε πλήκτρο ή χρησιμοποίησε τη ροδέλα στο ποντίκι."
-    },
-    "previousVideo": {
-      "message": "Προηγούμενο βίντεο"
-    },
-    "primaryColor": {
-      "message": "Χρώμα γραμμής προόδου"
-    },
-    "pullSyncSettings": {
-      "message": "Επανάκτηση ρυθμίσεων συγχρονισμού-Pull"
-    },
-    "purple": {
-      "message": "Μοβ"
-    },
-    "pushSyncSettings": {
-      "message": "Μεταφορά ρυθμίσεων συγχρονισμού-Push"
-    },
-    "quality": {
-      "message": "Ποιότητα"
-    },
-    "raised": {
-      "message": "Υψωμένος"
-    },
-    "rateMe": {
-    "message": "Αξιολόγησε με"
-    },
-    "rateUs": {
-      "message": "Αξιολόγησέ μας"
-    },
-    "red": {
-      "message": "Κόκκινο"
-    },
-    "redDislikeButton": {
-      "message": "Μετατροπή «Δε μου αρέσει» σε κόκκινο"
-    },
-    "relatedVideos": {
-      "message": "Σχετικά videos"
-    },
-    "remote": {
-      "message": "Παίξε στην TV"
-    },
-    "remove": {
-      "message": "Αφαίρεση"
-    },
-    "removeBlackBars": {
-      "message": "Κατάργηση μαύρων μπαρών"
-    },
-    "removeIcons": {
-      "message": "Αφαίρεση εικονιδίων"
-    },
-    "removeName": {
-      "message": "Αφαίρεση ονόματος"
-    },
-    "removeNames": {
-      "message": "Αφαίρεση ονομάτων"
-    },
-    "removeRelatedSearchResults": {
-      "message": "Αφαίρεση σχετικών αποτελεσμάτων αναζήτησης"
-    },
-    "removeShortsReelSearchResults": {
-      "message": "Αφαίρεση της λίστας Shorts από τα αποτελέσματα αναζήτησης"
-    },
-    "RemoveSubtitlesForLyrics": {
-      "message": "Κατάργηση υποτίτλων για στίχους"
-    },
-    "repeat": {
-      "message": "Επανάληψη"
-    },
-    "report": {
-      "message": "Αναφορά"
-    },
-    "reset": {
-      "message": "Επαναφορά"
-    },
-    "resetAllSettings": {
-      "message": "Επαναφορά όλων των ρυθμίσεων"
-    },
-    "resetAllShortcuts": {
-      "message": "Επαναφορά όλων των συντομεύσεων"
-    },
-    "reverse": {
-      "message": "Ανάποδα"
-    },
-    "rotate": {
-      "message": "Περιστροφή"
-    },
-    "save": {
-      "message": "Αποθήκευση"
-    },
-    "saveAs": {
-      "message": "Αποθήκευση ως"
-    },
-    "schedule": {
-      "message": "Πρόγραμμα",
-      "placeholders": {},
-      "description": ""
-    },
-    "screen": {
-      "message": "Οθόνη"
-    },
-    "screenshot": {
-      "message": "Στιγμιότυπο οθόνης"
-    },
-    "sd": {
-      "message": "SD-Κανονική ευκρίνεια"
-    },
-    "search": {
-      "message": "Αναζήτηση"
-    },
-    "searchBarOnly": {
-      "message": "Πεδίο αναζήτησης μόνο"
-    },
-    "seekBackward10Seconds": {
-      "message": "Πίσω 10 δευτερόλεπτα"
-    },
-    "seekForward10Seconds": {
-      "message": "Μπροστά 10 δευτερόλεπτα"
-    },
-    "seekNextChapter": {
-      "message": "Αναζήτηση επόμενου κεφαλαίου στο player"
-    },
-    "seekPreviousChapter": {
-      "message": "Αναζήτηση προηγούμενου κεφαλαίου"
-    },
-    "settings": {
-      "message": "Ρυθμίσεις"
-    },
-    "settingsSuccessfullyImported": {
-      "message": "Επιτυχής εισαγωγή ρυθμίσεων"
-    },
-    "share": {
-      "message": "Κοινοποίηση"
-    },
-    "shortcut_chapters": {
-      "message": "Συντόμευση κεφαλαίων του player"
-    },
-    "shortcuts": {
-      "message": "Συντομεύσεις"
-    },
-    "shortcut_screenshot": {
-      "message": "Στιγμιότυπο οθόνης"
-    },
-    "shorts": {
-      "message": "Shorts"
-    },
-    "showCardsOnMouseHover": {
-      "message": "Εμφάνιση καρτών όταν ο κέρσορας είναι από πάνω"
-    },
-    "showChannelVideosCount": {
-      "message": "Εμφάνιση συνολικών προβολών του καναλιού"
-    },
-    "showLess": {
-      "message": "Δείξε λιγότερα"
-    },
-    "showMore": {
-      "message": "Δείξε περισσότερα"
-    },
-    "showRemainingDuration": {
-      "message": "Εμφάνιση υπολειπόμενης διάρκειας"
-    },
-    "showVersion": {
-      "message": "Εμφάνιση έκδοσης"
-    },
-    "shuffle": {
-      "message": "Τυχαία αναπαραγωγή"
-    },
-    "sidebar": {
-      "message": "Πλαϊνή στήλη"
-    },
-    "Sidebar_simple_alternative": {
-      "message": "Απλή εναλλακτική πλαϊνή στήλη"
-    },
-    "softwareInformation": {
-      "message": "Πληροφορίες λογισμικού"
-    },
-    "squaredUserImages": {
-      "message": "Τετράγωνες εικόνες χρήστη"
-    },
-    "static": {
-      "message": "Στατικό"
-    },
-    "statsForNerds": {
-      "message": "Στατιστικά για Σπασίκλες"
-    },
-    "step": {
-      "message": "Βήμα"
-    },
-    "stop": {
-      "message": "Διακοπή"
-    },
-    "style": {
-      "message": "Στυλ"
-    },
-    "styles": {
-      "message": "Στυλ"
-    },
-    "subscribe": {
-      "message": "Συνδρομή"
-    },
-    "subscriptions": {
-      "message": "Συνδρομές"
-    },
-    "Subtitle_Capture_including_the_current_words": {
-      "message": "Καταγραφή υποτίτλων συμπεριλαμβανομένων των τρεχουσών λέξεων"
-    },
-    "subtitles": {
-      "message": "Υπότιτλοι"
-    },
-    "sunset": {
-      "message": "Ηλιοβασίλεμα"
-    },
-    "sunsetToSunrise": {
-      "message": "Από δύση έως ανατολή"
-    },
-    "systemPeferenceDark": {
-      "message": "Προτίμηση συστήματος: Σκούρο"
-    },
-    "systemPeferenceLight": {
-      "message": "Προτίμηση συστήματος: Ανοιχτόχρωμο"
-    },
-    "teal": {
-      "message": "Γαλαζοπράσινο"
-    },
-    "textColor": {
-      "message": "Χρώμα κειμένου"
-    },
-    "themes": {
-      "message": "Θέματα"
-    },
-    "thisWillRemoveAllCookies": {
-      "message": "Αφαίρεση όλων των cookies."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-      "message": "Διαγραφή ολόκληρου του Ιστορικού παρακολούθησης"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-      "message": "Aφαίρεση των Youtube cookies."
-    },
-    "thisWillResetAllSettings": {
-      "message": "Επαναφορά Ρυθμίσεων"
-    },
-    "thisWillResetAllShortcuts": {
-      "message": "Eπαναφορά όλων των συντομεύσεων."
-    },
-    "thumbnails": {
-      "message": "Εικονίδια των Βιντεο-Μικρογραφίες"
-    },
-    "thumbnailsQuality": {
-      "message": "Ποιότητα εικονιδίων"
-    },
-    "timeFrom": {
-      "message": "Χρόνος από"
-    },
-    "timeTo": {
-      "message": "Χρόνος έως"
-    },
-    "Titles": {
-      "message": "Τίτλοι"
-    },
-    "todayAt": {
-      "message": "Σήμερα στις"
-    },
-    "toggleAutoplay": {
-      "message": "Εναλλαγή αυτόματης αναπαραγωγής"
-    },
-    "toggleCards": {
-      "message": "Εναλλαγή καρτών"
-    },
-    "toggleControls": {
-      "message": "Eναλλαγή των controls"
-    },
-    "topChat": {
-      "message": "Top chat"
-    },
-    "To_the_side_No_page_margin": {
-      "message": "Προς τα πλάγια χωρίς περιθώρια σελίδας"
-    },
-    "trackWatchedVideos": {
-      "message": "Καταγραφή πληροφοριών Ιστορικού παρακολούθησης"
-    },
-    "trailerAutoplay": {
-      "message": "Αυτόματη αναπαραγωγή τρέιλερ"
-    },
-    "Transcript": {
-      "message": "Αποσπάσματα"
-    },
-    "translations": {
-      "message": "Μεταφράσεις"
-    },
-    "transparentBackground": {
-      "message": "Διαφανές φόντο"
-    },
-    "transparentColor": {
-      "message": "Διαφανές χρώμα"
-    },
-    "trending": {
-      "message": "Τάσεις"
-    },
-    "tryToReloadThePage": {
-      "message": "Προσπάθεια επαναφόρτωσης σελίδας"
-    },
-    "type": {
-      "message": "Τύπος"
-    },
-    "upNextAutoplay": {
-      "message": "Επόμενο στο autoplay"
-    },
-    "use24HourFormat": {
-      "message": "Χρήση κανονικής 24ώρης μορφής ώρας"
-    },
-    "version": {
-      "message": "Έκδοση"
-    },
-    "video": {
-      "message": "Βίντεο"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-      "message": "Η περιγραφή του βίντεο θα επεκταθεί ωστε να συμπεριληφθεί το όνομα της κατηγορίας."
-    },
-    "videoFormats": {
-      "message": "Μορφές βίντεο"
-    },
-    "videos": {
-      "message": "Βίντεο"
-    },
-    "viewMode": {
-      "message": "Λειτουργία προβολής"
-    },
-    "volume": {
-      "message": "Ένταση"
-    },
-    "watchedVideos": {
-      "message": "Ιστορικό παρακολούθησης"
-    },
-    "watchLater": {
-      "message": "Προβολή αργότερα"
-    },
-    "watchTime": {
-      "message": "Χρόνος προβολής"
-    },
-    "whenPaused": {
-      "message": "Κατά την παύση"
-    },
-    "whenTabIsChanged": {
-      "message": "Κατά την αλλαγή καρτέλας"
-    },
-    "white": {
-      "message": "Λευκό"
-    },
-    "windowColor": {
-      "message": "Χρώμα παραθύρου"
-    },
-    "windowOpacity": {
-      "message": "Διαφάνεια παραθύρου"
-    },
-    "with_scrollbars": {
-      "message": "Με scrollbar"
-    },
-    "yellow": {
-      "message": "Κίτρινο"
-    },
-    "youTubeButtons": {
-      "message": "YouTube-Κουμπιά"
-    },
-    "youtubeHeaderLeft": {
-      "message": "Κεφαλίδα YouTube (αριστερά)"
-    },
-    "youtubeHeaderRight": {
-      "message": "Κεφαλίδα YouTube (δεξιά)"
-    },
-    "youtubeHomePage": {
-      "message": "Αρχική σελίδα YouTube"
-    },
-    "youtubeLanguage": {
-      "message": "Γλώσσα YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-      "message": "Το YouTube περιορίζει την ποιότητα σε 1080p για το h.264 codec"
-    },
-    "youtubesDark": {
-      "message": "YouTube-σκοτεινό"
-    },
-    "Youtube_Search": {
-      "message": "Youtube-Αναζήτηση"
-    }
+	"about": {
+		"message": "Σχετικά"
+	},
+	"accept": {
+		"message": "Αποδοχή"
+	},
+	"activate": {
+		"message": "Ενεργοποίηση"
+	},
+	"activateCaptions": {
+		"message": "Ενεργοποίηση Υπότιτλων"
+	},
+	"activated": {
+		"message": "Επιτυχής Ενεργοποιήση"
+	},
+	"activatedFeatures": {
+		"message": "Ενεργοποιημένες Λειτουργίες"
+	},
+	"activateFullscreen": {
+		"message": "Ενεργοποίηση Πλήρους Οθόνη"
+	},
+	"activeFeatures": {
+		"message": "Ενεργές λειτουργίες"
+	},
+	"addScrollToTop": {
+		"message": "Πρόσθεση συντόμευσης για την κορυφή της σελίδας"
+	},
+	"ads": {
+		"message": "Διαφημίσεις"
+	},
+	"all": {
+		"message": "Όλα"
+	},
+	"allow": {
+		"message": "Αποδοχή"
+	},
+	"Allow_auto_generate": {
+		"message": "Ενεργοποίηση αυτόματης δημιουργίας"
+	},
+	"allow60fps": {
+		"message": "Ενεργοποίηση 60fps"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "Όλες οι ρυθμίσεις σας θα διαγραφούν και δεν μπορούν να ανακτηθούν"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Όλες οι συντομεύσεις σας θα διαγραφούν και δεν μπορούν να ανακτηθούν"
+	},
+	"always": {
+		"message": "Πάντα"
+	},
+	"alwaysActive": {
+		"message": "Πάντοτε ενεργό"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Πάντα ορατός ο ενδείκτης προόδου"
+	},
+	"amber": {
+		"message": "Κεχρί"
+	},
+	"analyzer": {
+		"message": "Αναλυτής"
+	},
+	"animations": {
+		"message": "Animations-Κινούμενα σχέδια"
+	},
+	"appearance": {
+		"message": "Εμφάνιση"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Είστε σίγουρος/η ότι θέλετε να εξάγετε τα δεδομένα;\n"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Είστε σίγουρος/η ότι θέλετε να εισαγάγετε τα δεδομένα;"
+	},
+	"areYouSureYouWantToSyncTheData": {
+		"message": "Είστε σίγουρος/η ότι θέλετε να συγχρονίσετε τα δεδομένα;"
+	},
+	"atHistory": {
+		"message": "στο 'Ιστορικό'"
+	},
+	"atSubscriptions": {
+		"message": "στις 'Συνδρομές'"
+	},
+	"atTrending": {
+		"message": "στις 'Τάσεις'"
+	},
+	"audio": {
+		"message": "Ήχος"
+	},
+	"audioFormats": {
+		"message": "Μορφές ήχου"
+	},
+	"auto": {
+		"message": "Αυτόματο"
+	},
+	"autoFullscreen": {
+		"message": "Αυτόματη Πλήρης Οθόνη"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Αυτόματη παύση όταν αλλάζετε καρτέλα"
+	},
+	"autoPictureInPicture": {
+		"message": "Αυτόματη Picture In Picture (PiP)"
+	},
+	"autoplay": {
+		"message": "Αυτόματη αναπαραγωγή"
+	},
+	"autoplayDisable": {
+		"message": "Απενεργοποίηση αυτόματης αναπαραγωγής"
+	},
+	"avoidAv1": {
+		"message": "Αποφύγετε το AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Αποφύγετε το AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Αποφύγετε το AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+	"message": "Αποφύγετε τη CPU αποτύπωση όταν είναι δυνατόν"
+	},
+	"backgroundColor": {
+		"message": "Χρώμα φόντου"
+	},
+	"backgroundOpacity": {
+		"message": "Διαφάνεια φόντου"
+	},
+	"backupAndReset": {
+		"message": "Αντίγραφα ασφαλείας & reset"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Με βάση τις ρυθμίσεις χρώματος του συστήματος"
+	},
+	"belowPlayer": {
+		"message": "Κάτω από το Player"
+	},
+	"black": {
+		"message": "Μαύρο"
+	},
+	"block_Codec_Alert_h264": {
+		"message": "Χρειάζεστε είτε το H.264 είτε το VP9 ενεργοποιημένο για να αναπαραχθούν βίντεο στο Youtube."
+	},
+	"blockAll": {
+		"message": "Απενεργοποίηση (Αποκλεισμός ή Παράβλεψη)"
+	},
+	"blocklist": {
+		"message": "Λίστα αποκλεισμού"
+	},
+	"blockMusic": {
+		"message": "Παράκαμψη κατά την αναπαραγωγή μουσική"
+	},
+	"blue": {
+		"message": "Μπλε"
+	},
+	"blueGray": {
+		"message": "Μπλε γκρίζο"
+	},
+	"bluelight": {
+		"message": "Μπλε φως"
+	},
+	"brown": {
+		"message": "Καφέ"
+	},
+	"browserAccountSync": {
+		"message": "Συγχρονισμός λογαριασμού με browser"
+	},
+	"browserVersion": {
+		"message": "Έκδοση browser"
+	},
+	"bubbles": {
+		"message": "Φούσκες"
+	},
+	"bug": {
+		"message": "Σφάλμα κώδικα"
+	},
+	"buttons": {
+		"message": "Κουμπιά"
+	},
+	"cancel": {
+		"message": "Ακύρωση"
+	},
+	"categories": {
+		"message": "Κατηγορίες"
+	},
+	"channel": {
+		"message": "Κανάλι"
+	},
+	"channels": {
+		"message": "Κανάλια"
+	},
+	"chapters": {
+		"message": "Κεφάλαια"
+	},
+	"characterEdgeStyle": {
+		"message": "Στυλ άκρων χαρακτήρων"
+	},
+	"clip": {
+		"message": "Κλιπ"
+	},
+	"collapsed": {
+		"message": "Κλειστό"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Σύμπτυξη μενού συνδρομών"
+	},
+	"columns": {
+		"message": "Επιπλέον στήλη πλαϊνής μπάρας"
+	},
+	"comments": {
+		"message": "Σχόλια"
+	},
+	"community": {
+		"message": "Κοινότητα"
+	},
+	"compact_spacing": {
+		"message": "Συμπαγής Διάταξη"
+	},
+	"compactTheme": {
+		"message": "Συμπαγές θεματικό"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Επιβεβαίωση πριν την αποχώρηση"
+	},
+	"cores": {
+		"message": "Πυρήνες"
+	},
+	"cropChapterTitles": {
+		"message": "Περίκοπη τίτλων των κεφαλαίων του player"
+	},
+	"Currently_requiring_a_YouTube_API_key": {
+		"message": "Προς το παρόν απαιτείται κλειδί API του YouTube"
+	},
+	"custom": {
+		"message": "Προσαρμοσμένο"
+	},
+	"customCss": {
+		"message": "Εξατομίκευση CSS"
+	},
+	"customJs": {
+		"message": "Εξατομίκευση JS"
+	},
+	"customMiniPlayer": {
+		"message": "Εξατομικευμένο Mini-Player"
+	},
+	"cyan": {
+		"message": "Κυανό"
+	},
+	"dark": {
+		"message": "Σκούρο"
+	},
+	"darkTheme": {
+		"message": "Σκούρο θέμα"
+	},
+	"dateAndTime": {
+		"message": "Ημερομηνία & ώρα"
+	},
+	"dawn": {
+		"message": "Αυγή"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Μείωση ταχύτητας αναπαραγωγής"
+	},
+	"decreaseVolume": {
+		"message": "Μειώση έντασης"
+	},
+	"deepOrange": {
+		"message": "Βαθύ πορτοκαλί"
+	},
+	"deepPurple": {
+		"message": "Βαθύ μοβ"
+	},
+	"default": {
+		"message": "Προεπιλογή"
+	},
+	"default_CC": {
+		"message": "Προεπιλογή"
+	},
+	"defaultChannelTab": {
+		"message": "Προεπιλεγμένη καρτέλα καναλιού"
+	},
+	"defaultContentCountry": {
+		"message": "Χώρα (ψηφιακή πλοήγηση)"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Προεπιλεγμένη Ταχύτητα Αναπαραγωγής"
+	},
+	"default_theme": {
+		"message": "Προεπιλογή"
+	},
+	"deleteWatchedVideos": {
+		"message": "Διαγραφή Ιστορικού παρακολούθησης"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Κατάργηση Youtube cookies"
+	},
+	"description": {
+		"message": "Περιγραφή"
+	},
+	"description_ext": {
+		"message": "YouTube, καθαρό + έξυπνο; Μέγεθος βίντεο Youtube player χρώμα Youtube ad παράβλεψης ταχύτητα έντασης ετικέτες παράβλεψης  απόκρυψη λίστας"
+	},
+	"desert": {
+		"message": "Έρημος"
+	},
+	"details": {
+		"message": "Λεπτομέρειες"
+	},
+	"developerOptions": {
+		"message": "Επιλογές για προγραμματιστές"
+	},
+	"device": {
+		"message": "Συσκευή"
+	},
+	"dim": {
+		"message": "Σκοτεινό"
+	},
+	"disabled": {
+		"message": "Απενεργοποιημένο"
+	},
+	"disableThumbnailPlayback": {
+		"message": "Απενεργοποίηση αναπαραγωγής εικονιδίων"
+	},
+	"dislike": {
+		"message": "Δε μου αρέσει"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Εμφάνιση ημέρας της εβδομάδας"
+	},
+	"donate": {
+		"message": "Δωρεά"
+	},
+	"doNotChange": {
+		"message": "Να μην αλλάξει"
+	},
+	"Download": {
+		"message": "Λήψη"
+	},
+	"draggable": {
+		"message": "Μετακινήσιμο με σύρση"
+	},
+	"dropShadow": {
+		"message": "Drop Επισκίαση"
+	},
+	"durationWithSpeed": {
+		"message": "Εμφάνιση υπολειπόμενης διάρκειας με σχέση προς την ταχύτητα αναπαραγωγής"
+	},
+	"Embedded_YouTube": {
+		"message": "Ενσωματωμένο YouTube"
+	},
+	"embedded_Hide_Share": {
+		"message": "Απόκρυψη κοινοποίησης σε ενσωματωμένο βίντεο"
+	},
+	"empty": {
+		"message": "Κενό"
+	},
+	"enabled": {
+		"message": "Ενεργοποιημένο"
+	},
+	"enabledForced": {
+		"message": "Ενεργοποιημένο (Υποχρεωτικά)"
+	},
+	"expanded": {
+		"message": "Ανοικτό"
+	},
+	"exportSettings": {
+		"message": "Εξαγωγή ρυθμίσεων"
+	},
+	"extension": {
+		"message": "Επέκταση"
+	},
+	"ExtraButtons": {
+		"message": "Επιπρόσθετα κουμπιά"
+	},
+	"extraButtonsBelowThePlayer": {
+		"message": "Πρόσθετα κουμπιά κάτω από τον παίκτη"
+	},
+	"Feature_not_yet_available": {
+		"message": "Η λειτουργία δεν είναι διαθέσιμη ακόμα"
+	},
+	"file": {
+		"message": "Αρχείο"
+	},
+	"filters": {
+		"message": "Φίλτρα"
+	},
+	"fitToWindow": {
+		"message": "Προσαρμογή στο παράθυρο"
+	},
+	"focus": {
+		"message": "Εστίαση"
+	},
+	"font": {
+		"message": "Γραμματοσειρά"
+	},
+	"fontColor": {
+		"message": "Χρώμα γραμματοσειράς"
+	},
+	"fontFamily": {
+		"message": "Οικογένεια γραμματοσειράς"
+	},
+	"fontOpacity": {
+		"message": "Διαφάνεια γραμματοσειράς"
+	},
+	"fontSize": {
+		"message": "Μέγεθος γραμματοσειράς"
+	},
+	"footer": {
+		"message": "Υποσέλιδο"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Υποχρεωτική ταχύτητα αναπαραγωγής"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Επιβολή αναπαραγωγής βίντεο από την αρχή"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "Επιβολή ταχύτητας αναπαραγωγής για μουσική"
+	},
+	"forcedTheaterMode": {
+		"message": "Υποχρεωτική λειτουργία κινηματογράφου"
+	},
+	"forcedVolume": {
+		"message": "Υποχρεωτική ένταση"
+	},
+	"forceSDR": {
+		"message": "Επιβολή SDR"
+	},
+	"foundABug": {
+		"message": "Εντοπίσατε κάποιο σφάλμα;"
+	},
+	"fullWindow": {
+		"message": "Πλήρες παράθυρο"
+	},
+	"general": {
+		"message": "Γενικά"
+	},
+	"geoPreference": {
+		"message": "Προτίμηση Γεωγραφικού Χώρου"
+	},
+	"goToSearchBox": {
+		"message": "Πήγαινε στο πεδίο αναζήτησης"
+	},
+	"GPUnotindatabase": {
+		"message": "GPU εκτός βάσης δεδομένων"
+	},
+	"green": {
+		"message": "Πράσινο"
+	},
+	"grey": {
+		"message": "Γκρι"
+	},
+	"halfTransparent": {
+		"message": "Ημι-αχνό"
+	},
+	"Hamburger_Menu": {
+		"message": "Μενού hamburger"
+	},
+	"hardwareInformation": {
+		"message": "Πληροφορίες hardware"
+	},
+	"hd": {
+		"message": "HD-Υψηλή ευκρίνεια"
+	},
+	"hdThumbnail": {
+		"message": "HD Εικονίδιο βίντεο"
+	},
+	"header": {
+		"message": "Κεφαλίδα"
+	},
+	"hidden": {
+		"message": "Κρυμμένο"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Κρυμμένο στη σελίδα βίντεο"
+	},
+	"hide_author_avatars": {
+		"message": "Απόκρυψη εικονιδίου συγγραφέα"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Απόκρυψη κινούμενων εικονιδίων"
+	},
+	"hideAnnotations": {
+		"message": "Απόκρυψη των annotations"
+	},
+	"hideCards": {
+		"message": "Απόκρυψη καρτών"
+	},
+	"hideCategories": {
+		"message": "Απόκρυψη κατηγοριών"
+	},
+	"hideCommentsCount": {
+		"message": "Απόκρυψη μετρητή σχολίων"
+	},
+	"hideCountryCode": {
+		"message": "Απόκρυψη κωδικού χώρας"
+	},
+	"hideDate": {
+		"message": "Απόκρυψη ημερομηνίας"
+	},
+	"hideDetailButton": {
+		"message": "Απόκρυψη κουμπιού λεπτομερειών"
+	},
+	"hideDetails": {
+		"message": "Απόκρυψη λεπτομερειών"
+	},
+	"hideEndscreen": {
+		"message": "Απόκρυψη τελικής οθόνης"
+	},
+	"hideFeaturedContent": {
+		"message": "Απόκρυψη προτεινόμενου περιεχομένου"
+	},
+	"hideFooter": {
+		"message": "Απόκρυψη υποσέλιδου"
+	},
+	"hideGradientBottom": {
+		"message": "Απόκρυψη κάτω μέρους της χρωματικής διαβάθμισης"
+	},
+	"hideHomePageShorts": {
+		"message": "Απόκρυψη Shorts από την αρχική σελίδα"
+	},
+	"hide_Labels": {
+		"message": "Απόκρυψη ετικετών"
+	},
+	"hideMore": {
+		"message": "Απόκρυψη περισσότερων"
+	},
+	"Hide_Pause_Overlay": {
+		"message": "Απόκρυψη επικάλυψης παύσης"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Απόκρυψη γραμμής ελέγχου player"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Απόκρυψη κουμπιών γραμμής ελέγχου player"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Απόκρυψη ελέγχου επιλογών player"
+	},
+	"hidePlaylist": {
+		"message": "Απόκρυψη playlist"
+	},
+	"hideReport": {
+		"message": "Απόκρυψη αναφοράς"
+	},
+	"hideRightButtons": {
+		"message": "Απόκρυψη δεξιών κουμπιών"
+	},
+	"hideScrollForDetails": {
+		"message": "Απόκρυψη του «Scroll for details»"
+	},
+	"Hide_Shorts_remixing_this_video": {
+		"message": "Απόκρυψη remixing Shorts του βίντεο"
+	},
+	"Hide_sidebar": {
+		"message": "Απόκρυψη πλαϊνής στήλης"
+	},
+	"hideSkipOverlay": {
+		"message": "Απόκρυψη επικάλυψης παράβλεψης"
+	},
+	"Hide_the_tabs_only": {
+		"message": "Απόκρυψη μόνο των tabs"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Απόκρυψη επικάλυψης εικονιδίων"
+	},
+	"hideThumbnails": {
+		"message": "Απόκρυψη εικονιδίων(Thumbnails)"
+	},
+	"hideViewsCount": {
+		"message": "Απόκρυψη αριθμού προβολών"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Απόκρυψη κουμπιού αναζήτησης φωνής"
+	},
+	"Hide_YouTube_Logo": {
+		"message": "Απόκρυψη λογότυπου του YouTube"
+	},
+	"high": {
+		"message": "Υψηλή"
+	},
+	"history": {
+		"message": "Ιστορικό"
+	},
+	"home": {
+		"message": "Αρχική σελίδα"
+	},
+	"homeScreen": {
+		"message": "Αρχική οθόνη"
+	},
+	"hover": {
+		"message": "Κέρσορας από πάνω"
+	},
+	"hoverOnVideoPage": {
+		"message": "Κέρσορας πάνω στη σελίδα βίντεο"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Διάρκεια ανάρτησης του βιντεο"
+	},
+	"icons": {
+		"message": "Εικονίδια"
+	},
+	"iconsOnly": {
+		"message": "Εικονίδια μόνο"
+	},
+	"importSettings": {
+		"message": "Εισαγωγή ρυθμίσεων"
+	},
+	"improvedtubeButtons": {
+		"message": "ImprovedTube Κουμπιά"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Εικονίδιο ImprovedTube στο YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Γλώσσα ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Έκδοση ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Λογότυπο Improve"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Αύξησε την ταχύτητα αναπαραγωγής"
+	},
+	"increaseVolume": {
+		"message": "Αύξησε την ένταση"
+	},
+	"items": {
+		"message": "Αντικείμενα"
+	},
+	"language": {
+		"message": "Γλώσσα"
+	},
+	"language_closed_caption": {
+		"message": "Προεπιλεγμένη γλώσσα - Κλειστά Captions"
+	},
+	"languages": {
+		"message": "Γλώσσες"
+	},
+	"legacyYoutube": {
+		"message": "Παλιά έκδοση YouTube"
+	},
+	"layerAnimationScale": {
+		"message": "Κλίμακα κινούμενου επιπέδου"
+	},
+	"layout": {
+		"message": "Διάταξη"
+	},
+	"library": {
+		"message": "Βιβλιοθήκη"
+	},
+	"light": {
+		"message": "Ανοιχτόχρωμο"
+	},
+	"lightBlue": {
+		"message": "Ανοικτό μπλε"
+	},
+	"lightGreen": {
+		"message": "Ανοικτό πράσινο"
+	},
+	"like": {
+		"message": "Μου αρέσει"
+	},
+	"liked": {
+		"message": "Βίντεο που μου αρέσουν"
+	},
+	"likes": {
+		"message": "Likes (Μου αρέσει)"
+	},
+	"lime": {
+		"message": "Μοσχολέμονο"
+	},
+	"limitPageWidth": {
+		"message": "Περιορισμός πλάτους σελίδας"
+	},
+	"list": {
+		"message": "Λίστα"
+	},
+	"liveChat": {
+		"message": "Live συνομιλία"
+	},
+	"liveChatType": {
+		"message": "Τύπος Live συνομιλίας"
+	},
+	"location": {
+		"message": "Τοποθεσία"
+	},
+	"loop": {
+		"message": "Επανάληψη"
+	},
+	"loudnessNormalization": {
+		"message": "Κανονικοποίηση έντασης"
+	},
+	"low": {
+		"message": "Χαμηλή"
+	},
+	"markWatchedVideos": {
+		"message": "Επισήμανση βίντεο που προβλήθηκαν"
+	},
+	"maxWidthWithinThePage": {
+		"message": "Μέγ. πλάτος εντός της σελίδας"
+	},
+	"medium": {
+		"message": "Μεσαία"
+	},
+	"more": {
+		"message": "Περισσότερα"
+	},
+	"mostViewedChannels": {
+		"message": "Kανάλια με τις περισσότερες προβολές"
+	},
+	"moveSidebarLeft": {
+		"message": "Μετακίνηση πλαϊνής στήλης προς τα αριστερά"
+	},
+	"moveThumbnailsRight": {
+		"message": "Μετακίνηση εικονιδιών (Thumbnails) προς τα δεξιά"
+	},
+	"myColors": {
+		"message": "Τα χρώματά μου"
+	},
+	"My_specs": {
+		"message": "Προδιαγραφές"
+	},
+	"name": {
+		"message": "Όνομα"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini player συστήματος"
+	},
+	"new": {
+		"message": "Νέο"
+	},
+	"nextVideo": {
+		"message": "Επόμενο βίντεο"
+	},
+	"night": {
+		"message": "Νύχτα"
+	},
+	"noActiveFeatures": {
+		"message": "Καμία λειτουργία ενεργή"
+	},
+	"none": {
+		"message": "Κανένα"
+	},
+	"noOpenVideoTabs": {
+		"message": "Καμία άλλη καρτέλα βίντεο ανοικτή"
+	},
+	"normal": {
+		"message": "Κανονικό"
+	},
+	"Not_optimal": {
+		"message": "Όχι βέλτιστο"
+	},
+	"off": {
+		"message": "Απενεργοποιημένο"
+	},
+	"old": {
+		"message": "Παλιό"
+	},
+	"onAllVideos": {
+		"message": "Σε όλα τα βίντεο"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Μόνο ενεργό στο YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Μόνο ένα player λειτουργεί"
+	},
+	"onSmallCreators": {
+		"message": "Μόνο για μικρά κανάλια"
+	},
+	"onSubscribedChannels": {
+		"message": "Σε κανάλια που έχει γίνει συνδρομή"
+	},
+	"openNewTab": {
+		"message": "Άνοιξε σε νέα σελίδα"
+	},
+	"openPopupPlayer": {
+		"message": "Άνοιξε το video/playlist σε νέο παράθυρο"
+	},
+	"optimizeCodecForHardwareAcceleration": {
+		"message": "Βελτιστοποίηση κωδικοποιητή για επιτάχυνση υλικού"
+	},
+	"orange": {
+		"message": "Πορτοκαλί"
+	},
+	"other": {
+		"message": "Άλλο"
+	},
+	"outline": {
+		"message": "Περίγραμμα"
+	},
+	"overlay": {
+		"message": "Επικάλυψη"
+	},
+	"permissions": {
+		"message": "Άδεια"
+	},
+	"pink": {
+		"message": "Ροζ"
+	},
+	"plain": {
+		"message": "Σκέτο"
+	},
+	"platform": {
+		"message": "Πλατφόρμα"
+	},
+	"playAllButton": {
+		"message": "Κουμπί αναπαραγωγής όλων"
+	},
+	"playbackSpeed": {
+		"message": "Ταχύτητα αναπαραγωγής"
+	},
+	"player_auto_cinema_mode": {
+		"message": "Αυτόματη λειτουργία κινηματογράφου"
+	},
+	"player_autoplay_disable": {
+		"message": "Απενεργοποίηση αυτόματης αναπαραγωγής"
+	},
+	"player_auplayer_SDR": {
+		"message": "Αυτόματη επαναλαμβανόμενη λειτουργία SDR"
+	},
+	"player_cinema_mode_button": {
+		"message": "Κουμπί λειτουργίας κινηματογράφου"
+	},
+	"player_dont_speed_education": {
+		"message": "Μη επιβολή ταχύτητας εκπαίδευσης"
+	},
+	"player_fit_to_win_button": {
+		"message": "Κουμπί προσαρμογής στο παράθυρο"
+	},
+	"player_rotate_button": {
+		"message": "Περιστροφή βίντεο"
+	},
+	"playerSize": {
+		"message": "Μέγεθος player"
+	},
+	"playerColor": {
+		"message": "Χρώμα γραμμής προόδου player"
+	},
+	"playPause": {
+		"message": "Αναπαραγωγή/Παύση"
+	},
+	"popupWindowButtons": {
+		"message": "Κουμπιά pop up παραθύρου"
+	},
+	"position": {
+		"message": "Θέση"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Πίεσε οποιοδήποτε πλήκτρο ή χρησιμοποίησε τη ροδέλα στο ποντίκι."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Πίεσε οποιοδήποτε πλήκτρο ή χρησιμοποίησε τη ροδέλα στο ποντίκι."
+	},
+	"previousVideo": {
+		"message": "Προηγούμενο βίντεο"
+	},
+	"primaryColor": {
+		"message": "Χρώμα γραμμής προόδου"
+	},
+	"pullSyncSettings": {
+		"message": "Επανάκτηση ρυθμίσεων συγχρονισμού-Pull"
+	},
+	"purple": {
+		"message": "Μοβ"
+	},
+	"pushSyncSettings": {
+		"message": "Μεταφορά ρυθμίσεων συγχρονισμού-Push"
+	},
+	"quality": {
+		"message": "Ποιότητα"
+	},
+	"raised": {
+		"message": "Υψωμένος"
+	},
+	"rateMe": {
+	"message": "Αξιολόγησε με"
+	},
+	"rateUs": {
+		"message": "Αξιολόγησέ μας"
+	},
+	"red": {
+		"message": "Κόκκινο"
+	},
+	"redDislikeButton": {
+		"message": "Μετατροπή «Δε μου αρέσει» σε κόκκινο"
+	},
+	"relatedVideos": {
+		"message": "Σχετικά videos"
+	},
+	"remote": {
+		"message": "Παίξε στην TV"
+	},
+	"remove": {
+		"message": "Αφαίρεση"
+	},
+	"removeBlackBars": {
+		"message": "Κατάργηση μαύρων μπαρών"
+	},
+	"removeIcons": {
+		"message": "Αφαίρεση εικονιδίων"
+	},
+	"removeName": {
+		"message": "Αφαίρεση ονόματος"
+	},
+	"removeNames": {
+		"message": "Αφαίρεση ονομάτων"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Αφαίρεση σχετικών αποτελεσμάτων αναζήτησης"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Αφαίρεση της λίστας Shorts από τα αποτελέσματα αναζήτησης"
+	},
+	"RemoveSubtitlesForLyrics": {
+		"message": "Κατάργηση υποτίτλων για στίχους"
+	},
+	"repeat": {
+		"message": "Επανάληψη"
+	},
+	"report": {
+		"message": "Αναφορά"
+	},
+	"reset": {
+		"message": "Επαναφορά"
+	},
+	"resetAllSettings": {
+		"message": "Επαναφορά όλων των ρυθμίσεων"
+	},
+	"resetAllShortcuts": {
+		"message": "Επαναφορά όλων των συντομεύσεων"
+	},
+	"reverse": {
+		"message": "Ανάποδα"
+	},
+	"rotate": {
+		"message": "Περιστροφή"
+	},
+	"save": {
+		"message": "Αποθήκευση"
+	},
+	"saveAs": {
+		"message": "Αποθήκευση ως"
+	},
+	"schedule": {
+		"message": "Πρόγραμμα"
+	},
+	"screen": {
+		"message": "Οθόνη"
+	},
+	"screenshot": {
+		"message": "Στιγμιότυπο οθόνης"
+	},
+	"sd": {
+		"message": "SD-Κανονική ευκρίνεια"
+	},
+	"search": {
+		"message": "Αναζήτηση"
+	},
+	"searchBarOnly": {
+		"message": "Πεδίο αναζήτησης μόνο"
+	},
+	"seekBackward10Seconds": {
+		"message": "Πίσω 10 δευτερόλεπτα"
+	},
+	"seekForward10Seconds": {
+		"message": "Μπροστά 10 δευτερόλεπτα"
+	},
+	"seekNextChapter": {
+		"message": "Αναζήτηση επόμενου κεφαλαίου στο player"
+	},
+	"seekPreviousChapter": {
+		"message": "Αναζήτηση προηγούμενου κεφαλαίου"
+	},
+	"settings": {
+		"message": "Ρυθμίσεις"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Επιτυχής εισαγωγή ρυθμίσεων"
+	},
+	"share": {
+		"message": "Κοινοποίηση"
+	},
+	"shortcut_chapters": {
+		"message": "Συντόμευση κεφαλαίων του player"
+	},
+	"shortcuts": {
+		"message": "Συντομεύσεις"
+	},
+	"shortcut_screenshot": {
+		"message": "Στιγμιότυπο οθόνης"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Εμφάνιση καρτών όταν ο κέρσορας είναι από πάνω"
+	},
+	"showChannelVideosCount": {
+		"message": "Εμφάνιση συνολικών προβολών του καναλιού"
+	},
+	"showLess": {
+		"message": "Δείξε λιγότερα"
+	},
+	"showMore": {
+		"message": "Δείξε περισσότερα"
+	},
+	"showRemainingDuration": {
+		"message": "Εμφάνιση υπολειπόμενης διάρκειας"
+	},
+	"showVersion": {
+		"message": "Εμφάνιση έκδοσης"
+	},
+	"shuffle": {
+		"message": "Τυχαία αναπαραγωγή"
+	},
+	"sidebar": {
+		"message": "Πλαϊνή στήλη"
+	},
+	"Sidebar_simple_alternative": {
+		"message": "Απλή εναλλακτική πλαϊνή στήλη"
+	},
+	"softwareInformation": {
+		"message": "Πληροφορίες λογισμικού"
+	},
+	"squaredUserImages": {
+		"message": "Τετράγωνες εικόνες χρήστη"
+	},
+	"static": {
+		"message": "Στατικό"
+	},
+	"statsForNerds": {
+		"message": "Στατιστικά για Σπασίκλες"
+	},
+	"step": {
+		"message": "Βήμα"
+	},
+	"stop": {
+		"message": "Διακοπή"
+	},
+	"style": {
+		"message": "Στυλ"
+	},
+	"styles": {
+		"message": "Στυλ"
+	},
+	"subscribe": {
+		"message": "Συνδρομή"
+	},
+	"subscriptions": {
+		"message": "Συνδρομές"
+	},
+	"Subtitle_Capture_including_the_current_words": {
+		"message": "Καταγραφή υποτίτλων συμπεριλαμβανομένων των τρεχουσών λέξεων"
+	},
+	"subtitles": {
+		"message": "Υπότιτλοι"
+	},
+	"sunset": {
+		"message": "Ηλιοβασίλεμα"
+	},
+	"sunsetToSunrise": {
+		"message": "Από δύση έως ανατολή"
+	},
+	"systemPeferenceDark": {
+		"message": "Προτίμηση συστήματος: Σκούρο"
+	},
+	"systemPeferenceLight": {
+		"message": "Προτίμηση συστήματος: Ανοιχτόχρωμο"
+	},
+	"teal": {
+		"message": "Γαλαζοπράσινο"
+	},
+	"textColor": {
+		"message": "Χρώμα κειμένου"
+	},
+	"themes": {
+		"message": "Θέματα"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Αφαίρεση όλων των cookies."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Διαγραφή ολόκληρου του Ιστορικού παρακολούθησης"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Aφαίρεση των Youtube cookies."
+	},
+	"thisWillResetAllSettings": {
+		"message": "Επαναφορά Ρυθμίσεων"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Eπαναφορά όλων των συντομεύσεων."
+	},
+	"thumbnails": {
+		"message": "Εικονίδια των Βιντεο-Μικρογραφίες"
+	},
+	"thumbnailsQuality": {
+		"message": "Ποιότητα εικονιδίων"
+	},
+	"timeFrom": {
+		"message": "Χρόνος από"
+	},
+	"timeTo": {
+		"message": "Χρόνος έως"
+	},
+	"titles": {
+		"message": "Τίτλοι"
+	},
+	"todayAt": {
+		"message": "Σήμερα στις"
+	},
+	"toggleAutoplay": {
+		"message": "Εναλλαγή αυτόματης αναπαραγωγής"
+	},
+	"toggleCards": {
+		"message": "Εναλλαγή καρτών"
+	},
+	"toggleControls": {
+		"message": "Eναλλαγή των controls"
+	},
+	"To_the_side_No_page_margin": {
+		"message": "Προς τα πλάγια χωρίς περιθώρια σελίδας"
+	},
+	"trackWatchedVideos": {
+		"message": "Καταγραφή πληροφοριών Ιστορικού παρακολούθησης"
+	},
+	"trailerAutoplay": {
+		"message": "Αυτόματη αναπαραγωγή τρέιλερ"
+	},
+	"Transcript": {
+		"message": "Αποσπάσματα"
+	},
+	"translations": {
+		"message": "Μεταφράσεις"
+	},
+	"transparentBackground": {
+		"message": "Διαφανές φόντο"
+	},
+	"transparentColor": {
+		"message": "Διαφανές χρώμα"
+	},
+	"trending": {
+		"message": "Τάσεις"
+	},
+	"tryToReloadThePage": {
+		"message": "Προσπάθεια επαναφόρτωσης σελίδας"
+	},
+	"type": {
+		"message": "Τύπος"
+	},
+	"upNextAutoplay": {
+		"message": "Επόμενο στο autoplay"
+	},
+	"use24HourFormat": {
+		"message": "Χρήση κανονικής 24ώρης μορφής ώρας"
+	},
+	"version": {
+		"message": "Έκδοση"
+	},
+	"video": {
+		"message": "Βίντεο"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Η περιγραφή του βίντεο θα επεκταθεί ωστε να συμπεριληφθεί το όνομα της κατηγορίας."
+	},
+	"videoFormats": {
+		"message": "Μορφές βίντεο"
+	},
+	"videos": {
+		"message": "Βίντεο"
+	},
+	"viewMode": {
+		"message": "Λειτουργία προβολής"
+	},
+	"volume": {
+		"message": "Ένταση"
+	},
+	"watchedVideos": {
+		"message": "Ιστορικό παρακολούθησης"
+	},
+	"watchLater": {
+		"message": "Προβολή αργότερα"
+	},
+	"watchTime": {
+		"message": "Χρόνος προβολής"
+	},
+	"whenPaused": {
+		"message": "Κατά την παύση"
+	},
+	"whenTabIsChanged": {
+		"message": "Κατά την αλλαγή καρτέλας"
+	},
+	"white": {
+		"message": "Λευκό"
+	},
+	"windowColor": {
+		"message": "Χρώμα παραθύρου"
+	},
+	"windowOpacity": {
+		"message": "Διαφάνεια παραθύρου"
+	},
+	"with_scrollbars": {
+		"message": "Με scrollbar"
+	},
+	"yellow": {
+		"message": "Κίτρινο"
+	},
+	"youTubeButtons": {
+		"message": "YouTube-Κουμπιά"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Κεφαλίδα YouTube (αριστερά)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Κεφαλίδα YouTube (δεξιά)"
+	},
+	"youtubeHomePage": {
+		"message": "Αρχική σελίδα YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Γλώσσα YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "Το YouTube περιορίζει την ποιότητα σε 1080p για το h.264 codec"
+	},
+	"youtubesDark": {
+		"message": "YouTube-σκοτεινό"
+	},
+	"Youtube_Search": {
+		"message": "Youtube-Αναζήτηση"
+	}
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -221,6 +221,9 @@
 	"blocklist": {
 		"message": "Blocklist"
 	},
+	"blocklist_add_channel": {
+		"message": "Add channel to Blocklist"
+	},
 	"blockMusic": {
 		"message": "Skip ads while I play music"
 	},
@@ -305,6 +308,9 @@
 	"comments": {
 		"message": "Comments"
 	},
+	"community": {
+		"message": "Community"
+	},
 	"compact_spacing": {
 		"message": "Compact Spacing"
 	},
@@ -331,6 +337,9 @@
 	},
 	"customCss": {
 		"message": "Custom CSS"
+	},
+	"custom_colors": {
+		"message": "Custom colors"
 	},
 	"customJs": {
 		"message": "Custom JS"
@@ -491,6 +500,9 @@
 	"flash": {
 		"message": "Flash"
 	},
+	"focus": {
+		"message": "Focus"
+	},
 	"font": {
 		"message": "Font"
 	},
@@ -578,6 +590,9 @@
 	"header": {
 		"message": "Header"
 	},
+	"header_transparent_alternative": {
+		"message": "Transparent background alternative"
+	},
 	"hidden": {
 		"message": "Hidden"
 	},
@@ -597,7 +612,7 @@
 		"message": "Hide Shorts remixing this video"
 	},
 	"Hide_sidebar": {
-		"message": "Hide sidebar "
+		"message": "Hide sidebar"
 	},
 	"Hide_the_tabs_only": {
 		"message": "Hide the tabs only"
@@ -818,6 +833,12 @@
 	"markWatchedVideos": {
 		"message": "Mark watched videos"
 	},
+	"max_width_within_page": {
+		"message": "Max. width within the page"
+	},	
+	"magenta": {
+		"message": "Magenta"
+	},
 	"medium": {
 		"message": "Medium"
 	},
@@ -884,6 +905,9 @@
 	"old": {
 		"message": "Old"
 	},
+	"on": {
+		"message": "On"
+	},
 	"onAllVideos": {
 		"message": "On"
 	},
@@ -939,7 +963,7 @@
 		"message": "Platform"
 	},
 	"playAllButton": {
-		"message": "\"Play all\"button"
+		"message": "\"Play all\" button"
 	},
 	"playbackSpeed": {
 		"message": "Playback speed"
@@ -1058,6 +1082,9 @@
 	"removeShortsReelSearchResults": {
 		"message": "Remove Shorts reel from search results"
 	},
+	"remove_subscriptions_shorts": {
+		"message": "Remove Shorts from Subscriptions"
+	},
 	"repeat": {
 		"message": "Repeat"
 	},
@@ -1139,6 +1166,9 @@
 	"shortcuts": {
 		"message": "Shortcuts"
 	},
+	"shorts": {
+		"message": "Shorts"
+	},
 	"showCardsOnMouseHover": {
 		"message": "Show cards on mouse hover"
 	},
@@ -1165,6 +1195,9 @@
 	},
 	"Sidebar_simple_alternative": {
 		"message": "Sidebar (simple alternative)"
+	},
+	"sidebar_thumb_title_max": {
+		"message": "Show whole video title"
 	},
 	"softwareInformation": {
 		"message": "Software information"
@@ -1247,6 +1280,12 @@
 	"thisWillResetAllShortcuts": {
 		"message": "This will reset all shortcuts"
 	},
+	"thumb_per_row": {
+		"message": "Thumbnails per row"
+	},
+	"thumb_title_max": {
+		"message": "Show whole video title under thumbnail"
+	},
 	"thumbnails": {
 		"message": "Thumbnails"
 	},
@@ -1261,6 +1300,9 @@
 	},
 	"To_the_side_No_page_margin": {
 		"message": "To the side! (No page margin)"
+	},
+	"titles": {
+		"message": "Titles"
 	},
 	"todayAt": {
 		"message": "Today at"

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -1,53 +1,41 @@
 {
-    "analyzer": {
-        "message": "Analyser"
-    },
-    "backgroundColor": {
-        "message": "Background colour"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Base on system colour scheme"
-    },
-    "bitness": {
-        "message": "bitness"
-    },
-    "blueGray": {
-        "message": "Blue grey"
-    },
-    "compact_spacing": {
-        "message": "compact spacing"
-    },
-    "description_ext": {
-        "message": "Make YouTube tidy+smart! YouTube video colour ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
-    },
-    "fontColor": {
-        "message": "Font colour"
-    },
-    "forcedTheaterMode": {
-        "message": "Forced theatre mode"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide 5 seconds skip animation"
-    },
-    "myColors": {
-        "message": "My colours"
-    },
-    "player_rotate_button": {
-        "message": "player rotate button"
-    },
-    "playerColor": {
-        "message": "Player colour"
-    },
-    "primaryColor": {
-        "message": "Primary colour"
-    },
-    "qualityWithoutFocus": {
-        "message": "Quality without focus"
-    },
-    "textColor": {
-        "message": "Text colour"
-    },
-    "windowColor": {
-        "message": "Window colour"
-    }
+	"analyzer": {
+		"message": "Analyser"
+	},
+	"backgroundColor": {
+		"message": "Background colour"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Base on system colour scheme"
+	},
+	"blueGray": {
+		"message": "Blue grey"
+	},
+	"description_ext": {
+		"message": "Make YouTube tidy+smart! YouTube video colour ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+	},
+	"fontColor": {
+		"message": "Font colour"
+	},
+	"forcedTheaterMode": {
+		"message": "Forced theatre mode"
+	},
+	"hideSkipOverlay": {
+		"message": "Hide 5 seconds skip animation"
+	},
+	"myColors": {
+		"message": "My colours"
+	},
+	"playerColor": {
+		"message": "Player colour"
+	},
+	"primaryColor": {
+		"message": "Primary colour"
+	},
+	"textColor": {
+		"message": "Text colour"
+	},
+	"windowColor": {
+		"message": "Window colour"
+	}
 }

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -1,11 +1,1 @@
-{
-    "compact_spacing": {
-        "message": "compact spacing"
-    },
-    "player_rotate_button": {
-        "message": "player rotate button"
-    },
-    "qualityWithoutFocus": {
-        "message": "Quality without focus"
-    }
-}
+{}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,1109 +1,1085 @@
 {
-    "about": {
-        "message": "Acerca de"
-    },
-    "accept": {
-        "message": "Aceptar"
-    },
-    "activate": {
-        "message": "Activar"
-    },
-    "activateCaptions": {
-        "message": "Activar subtítulos"
-    },
-    "activated": {
-        "message": "Activado"
-    },
-    "activatedFeatures": {
-        "message": "Características activadas"
-    },
-    "activateFullscreen": {
-        "message": "Activar pantalla completa"
-    },
-    "activeFeatures": {
-        "message": "Activar características"
-    },
-    "addScrollToTop": {
-        "message": "Añadir «Volver arriba»"
-    },
-    "ads": {
-        "message": "Anuncios"
-    },
-    "all": {
-        "message": "Todo"
-    },
-    "allow": {
-        "message": "Permitir"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todos tus atajos serán borrados y no podrán ser recuperados"
-    },
-    "always": {
-        "message": "Siempre"
-    },
-    "alwaysActive": {
-        "message": "Siempre activo"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Siempre mostrar barra de progreso"
-    },
-    "amber": {
-        "message": "Ámbar"
-    },
-    "analyzer": {
-        "message": "Analizador"
-    },
-    "appearance": {
-        "message": "Apariencia"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "¿Estas seguro que deseas exportar la informacion?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "¿Estas seguro que deseas importar la informacion?"
-    },
-    "areYouSureYouWantToSyncTheData": {
-        "message": "¿Está seguro que desea sincronizar la configuración actual?"
-    },
-    "audio": {
-        "message": "Sonido"
-    },
-    "audioFormats": {
-        "message": "Formatos de audio"
-    },
-    "auto": {
-        "message": "Automático"
-    },
-    "autoFullscreen": {
-        "message": "Pantalla completa automática"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausar al cambiar de pestaña"
-    },
-    "autoPictureInPicture": {
-        "message": "Auto Picture-In-Picture"
-    },
-    "autoplay": {
-        "message": "Reproducción automática"
-    },
-    "avoidAv1": {
-        "message": "Evitar AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Evitar AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Evitar AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Evitar renderizar con CPU cuando sea posible"
-    },
-    "backgroundColor": {
-        "message": "Color de fondo"
-    },
-    "backgroundOpacity": {
-        "message": "Opacidad de fondo"
-    },
-    "backupAndReset": {
-        "message": "Copia de seguridad y reinicio"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Según tema del sistema"
-    },
-    "belowPlayer": {
-        "message": "Debajo del reproductor"
-    },
-    "black": {
-        "message": "Negro"
-    },
-    "block_Codec_Alert_h264": {
-        "message": "Necesita activar VP9 o H.264 para que Youtube reproduzca videos."
-    },
-    "blockAll": {
-        "message": "Bloquear todo"
-    },
-    "blockAv1": {
-        "message": "Bloquear AV1"
-    },
-    "blockH264": {
-        "message": "Bloquear H.264"
-    },
-    "blocklist": {
-        "message": "Lista negra"
-    },
-    "blockMusic": {
-        "message": "Bloquear musica"
-    },
-    "blockVp8": {
-        "message": "Bloquear VP8"
-    },
-    "blockVp9": {
-        "message": "Bloquear VP9"
-    },
-    "blue": {
-        "message": "Azul"
-    },
-    "blueGray": {
-        "message": "Gris azulado"
-    },
-    "bluelight": {
-        "message": "Luz azul"
-    },
-    "brightness": {
-        "message": "Luminosidad"
-    },
-    "brown": {
-        "message": "Marrón"
-    },
-    "browser": {
-        "message": "Navegador"
-    },
-    "browserAccountSync": {
-        "message": "Sincronizar (Cuenta del Navegador)"
-    },
-    "browserVersion": {
-        "message": "Version del navegador"
-    },
-    "bubbles": {
-        "message": "Burbujas"
-    },
-    "bug": {
-        "message": "Error (Bug)"
-    },
-    "buttons": {
-        "message": "Botones"
-    },
-    "cancel": {
-        "message": "Cancelar"
-    },
-    "categories": {
-        "message": "Categorías"
-    },
-    "channel": {
-        "message": "Canal"
-    },
-    "channels": {
-        "message": "Canales"
-    },
-    "clipboard": {
-        "message": "Portapapeles"
-    },
-    "codecH264": {
-        "message": "Códec h.264"
-    },
-    "codecs": {
-        "message": "Codecs"
-    },
-    "collapsed": {
-        "message": "Compacto"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Compactar sección de suscripciones"
-    },
-    "columns": {
-        "message": "Columna lateral extra (sin mover los vídeos relacionados, si la ventana es suficientemente ancha)"
-    },
-    "comments": {
-        "message": "Comentarios"
-    },
-    "compact_spacing": {
-        "message": "espaciamiento compacto"
-    },
-    "compactTheme": {
-        "message": "tema compacto"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Confirmar antes de cerrar"
-    },
-    "cookies": {
-        "message": "Cookies"
-    },
-    "cores": {
-        "message": "Núcleos"
-    },
-    "cropChapterTitles": {
-        "message": "Recortar título de capítulos"
-    },
-    "custom": {
-        "message": "Personalizado"
-    },
-    "customCss": {
-        "message": "CSS personalizado"
-    },
-    "customJs": {
-        "message": "JS personalizado"
-    },
-    "customMiniPlayer": {
-        "message": "Mini-Reproductor personalizado"
-    },
-    "cyan": {
-        "message": "Cian"
-    },
-    "dark": {
-        "message": "Oscuro"
-    },
-    "darkTheme": {
-        "message": "Tema oscuro"
-    },
-    "dateAndTime": {
-        "message": "Fecha y hora"
-    },
-    "dawn": {
-        "message": "Amanecer"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Disminuir velocidad de reproducción"
-    },
-    "decreaseVolume": {
-        "message": "Bajar volumen"
-    },
-    "deepOrange": {
-        "message": "Naranja profundo"
-    },
-    "deepPurple": {
-        "message": "Violeta profundo"
-    },
-    "default": {
-        "message": "Por defecto"
-    },
-    "default_CC": {
-        "message": "predeterminado"
-    },
-    "default_theme": {
-        "message": "predeterminado"
-    },
-    "defaultChannelTab": {
-        "message": "Pestaña del canal por defecto"
-    },
-    "defaultContentCountry": {
-        "message": "Contenido del pais por defecto"
-    },
-    "defaultPlaybackSpeed": {
-        "message": "Velocidad de reproducción predeterminada"
-    },
-    "deleteWatchedVideos": {
-        "message": "Eliminar videos vistos"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Borrar cookies de YouTube"
-    },
-    "description": {
-        "message": "Descripcion"
-    },
-    "description_ext": {
-        "message": "YouTube, marea + inteligente? Video Youtube que el reproductor de youtube tamaño color color youtube saltar la velocidad de reproducción de las etiquetas skipper del canal de volumen ocultar"
-    },
-    "desert": {
-        "message": "Desierto"
-    },
-    "details": {
-        "message": "Detalles"
-    },
-    "developerOptions": {
-        "message": "Opciones de desarrollador"
-    },
-    "device": {
-        "message": "Dispositivo"
-    },
-    "dim": {
-        "message": "Oscuro"
-    },
-    "disabled": {
-        "message": "Desactivado"
-    },
-    "disableThumbnailPlayback": {
-        "message": "Desactivar la reproducción de vídeo al pasar el cursor"
-    },
-    "dislike": {
-        "message": "No me gusta"
-    },
-    "donate": {
-        "message": "Donar"
-    },
-    "doNotChange": {
-        "message": "No cambiar"
-    },
-    "download": {
-        "message": "Descargar"
-    },
-    "draggable": {
-        "message": "Arrastrable"
-    },
-    "email": {
-        "message": "Correo electrónico"
-    },
-    "embedded_Hide_Share": {
-        "message": "Ocultar compartimiento incrustado"
-    },
-    "empty": {
-        "message": "Vacío"
-    },
-    "enabled": {
-        "message": "Activado"
-    },
-    "enabledForced": {
-        "message": "Activado (forzado)"
-    },
-    "expanded": {
-        "message": "Expandido"
-    },
-    "exportSettings": {
-        "message": "Exportar configuración"
-    },
-    "extension": {
-        "message": "Extensión"
-    },
-    "ExtraButtons": {
-        "message": "Botones extra"
-    },
-    "extraButtonsBelowThePlayer": {
-        "message": "Botones adicionales bajo el reproductor"
-    },
-    "file": {
-        "message": "Archivo"
-    },
-    "filters": {
-        "message": "Filtros"
-    },
-    "fitToWindow": {
-        "message": "Ajustar a la ventana"
-    },
-    "flash": {
-        "message": "Flash"
-    },
-    "font": {
-        "message": "Fuente"
-    },
-    "fontColor": {
-        "message": "Color de fuente"
-    },
-    "fontFamily": {
-        "message": "Tipografia de fuente"
-    },
-    "fontOpacity": {
-        "message": "Opacidad de fuente"
-    },
-    "fontSize": {
-        "message": "Tamaño de fuente"
-    },
-    "footer": {
-        "message": "Pie de pagina"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Forzar velocidad de reproducción"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(¿Forzar velocidad de reproducción incluso para la música?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forzar la reproduccion del video desde el inicio"
-    },
-    "forcedTheaterMode": {
-        "message": "Forzar modo teatro"
-    },
-    "forcedVolume": {
-        "message": "Forzar volumen"
-    },
-    "forceSDR": {
-        "message": "Forzar SDR"
-    },
-    "foundABug": {
-        "message": "¿Encontraste un error (bug)?"
-    },
-    "fullWindow": {
-        "message": "Pantalla completa"
-    },
-    "general": {
-        "message": "General"
-    },
-    "geoPreference": {
-        "message": "Preferencia de Geo"
-    },
-    "github": {
-        "message": "GitHub"
-    },
-    "goToSearchBox": {
-        "message": "Ir a la barra de búsqueda"
-    },
-    "GPUnotindatabase": {
-        "message": "GPU no está en la base de datos"
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "hardwareInformation": {
-        "message": "Información de hardware"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura HD"
-    },
-    "header": {
-        "message": "Encabezado"
-    },
-    "hidden": {
-        "message": "Oculto"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Oculto en la página de video"
-    },
-    "hide_author_avatars": {
-        "message": "Ocultar avatares del autor"
-    },
-    "hide_labels": {
-        "message": "Ocultar nombres"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Ocultar miniaturas animadas"
-    },
-    "hideAnnotations": {
-        "message": "Ocultar anotaciones"
-    },
-    "hideCards": {
-        "message": "Ocultar tarjetas"
-    },
-    "hideCommentsCount": {
-        "message": "Ocultar contador de comentarios"
-    },
-    "hideCountryCode": {
-        "message": "Ocultar código de país"
-    },
-    "hideDate": {
-        "message": "Ocultar fecha"
-    },
-    "hideDetailButton": {
-        "message": "Botones (debajo del reproductor)"
-    },
-    "hideDetails": {
-        "message": "Ocultar detalles"
-    },
-    "hideEndscreen": {
-        "message": "Ocultar pantalla final"
-    },
-    "hideFeaturedContent": {
-        "message": "Ocultar contenido destacado"
-    },
-    "hideFooter": {
-        "message": "Ocultar pie de página"
-    },
-    "hideGradientBottom": {
-        "message": "Ocultar parte inferior degradada"
-    },
-    "hideHomePageShorts": {
-        "message": "Eliminar Shorts de la página de inicio"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ocultar la barra del reproductor"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ocultar los controles de la barra del reproductor"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ocultar opciones de control del reproductor"
-    },
-    "hidePlaylist": {
-        "message": "Ocultar playlist"
-    },
-    "hideRightButtons": {
-        "message": "Ocultar botones de la derecha"
-    },
-    "hideScrollForDetails": {
-        "message": "Ocultar «Desliza hacia abajo para ver más detalles»"
-    },
-    "hideSkipOverlay": {
-        "message": "Ocultar superposición de saltar"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ocultar la superposición de miniaturas"
-    },
-    "hideThumbnails": {
-        "message": "Ocultar miniaturas"
-    },
-    "hideVideoTitleFullScreen": {
-        "message": "Ocultar título de vídeo en pantalla completa"
-    },
-    "hideViewsCount": {
-        "message": "Ocultar contador de visitas"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ocultar boton de busqueda por voz"
-    },
-    "high": {
-        "message": "Alto"
-    },
-    "history": {
-        "message": "Historial"
-    },
-    "home": {
-        "message": "Inicio"
-    },
-    "hover": {
-        "message": "Cursor sobre (hover)"
-    },
-    "hoverOnVideoPage": {
-        "message": "Cursor sobre (hover) en página de video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Hace cuánto tiempo se subió el video"
-    },
-    "icons": {
-        "message": "Iconos"
-    },
-    "iconsOnly": {
-        "message": "Solo iconos"
-    },
-    "importSettings": {
-        "message": "Importar configuración"
-    },
-    "improvedtubeButtons": {
-        "message": "Botones ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Icono ImprovedTube en YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Idioma de ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Version de ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Mejorar logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Aumentar velocidad de reproducción"
-    },
-    "increaseVolume": {
-        "message": "Subir volumen"
-    },
-    "indigo": {
-        "message": "Índigo"
-    },
-    "language": {
-        "message": "Idioma"
-    },
-    "language_closed_caption": {
-        "message": "Idioma predeterminado - Closed Captions"
-    },
-    "languages": {
-        "message": "Idiomas"
-    },
-    "layout": {
-        "message": "Estilo"
-    },
-    "legacyYoutube": {
-        "message": "YouTube antiguo"
-    },
-    "library": {
-        "message": "Biblioteca"
-    },
-    "light": {
-        "message": "Claro"
-    },
-    "lightBlue": {
-        "message": "Azul claro"
-    },
-    "lightGreen": {
-        "message": "Verde claro"
-    },
-    "like": {
-        "message": "Me gusta"
-    },
-    "liked": {
-        "message": "Me gusta"
-    },
-    "likes": {
-        "message": "Gustos"
-    },
-    "lime": {
-        "message": "Lima"
-    },
-    "limitPageWidth": {
-        "message": "Limitar ancho de la pagina"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Chat en directo"
-    },
-    "liveChatType": {
-        "message": "Tipo de chat en directo"
-    },
-    "location": {
-        "message": "Ubicación"
-    },
-    "loop": {
-        "message": "Bucle"
-    },
-    "loudnessNormalization": {
-        "message": "Normalización de volumen"
-    },
-    "low": {
-        "message": "Bajo"
-    },
-    "markWatchedVideos": {
-        "message": "Marcar videos vistos"
-    },
-    "medium": {
-        "message": "Medio"
-    },
-    "mixer": {
-        "message": "Mezclador"
-    },
-    "more": {
-        "message": "Más"
-    },
-    "mostViewedChannels": {
-        "message": "Canales más vistos"
-    },
-    "moveSidebarLeft": {
-        "message": "Mover barra lateral a la izquierda"
-    },
-    "moveThumbnailsRight": {
-        "message": "Mover miniaturas a la derecha"
-    },
-    "My_specs": {
-        "message": "Mis especificaciones"
-    },
-    "myColors": {
-        "message": "Mis colores"
-    },
-    "name": {
-        "message": "Nombre"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini-Reproductor nativo"
-    },
-    "new": {
-        "message": "Nuevo"
-    },
-    "nextVideo": {
-        "message": "Siguiente video"
-    },
-    "night": {
-        "message": "Noche"
-    },
-    "nightMode": {
-        "message": "Modo nocturno"
-    },
-    "noActiveFeatures": {
-        "message": "Sin características activas"
-    },
-    "none": {
-        "message": "Ninguno"
-    },
-    "noOpenVideoTabs": {
-        "message": "Sin pestañas de video abiertas"
-    },
-    "normal": {
-        "message": "Normal"
-    },
-    "off": {
-        "message": "Desactivado"
-    },
-    "ok": {
-        "message": "Aceptar"
-    },
-    "old": {
-        "message": "Viejo"
-    },
-    "onAllVideos": {
-        "message": "En todos los videos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Solo activo en YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Solo una pestaña reproduciendo"
-    },
-    "onSmallCreators": {
-        "message": "Desactivado, excepto para canales pequeños"
-    },
-    "onSubscribedChannels": {
-        "message": "En canales suscritos"
-    },
-    "openNewTab": {
-        "message": "Abrir en una pestaña nueva"
-    },
-    "openPopupPlayer": {
-        "message": "Abrir video/lista de reproduccion en una nueva ventana"
-    },
-    "orange": {
-        "message": "Naranja"
-    },
-    "os": {
-        "message": "OS"
-    },
-    "other": {
-        "message": "Otro"
-    },
-    "permissions": {
-        "message": "Permisos"
-    },
-    "pictureInPicture": {
-        "message": "Imagen en imagen"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Plano"
-    },
-    "platform": {
-        "message": "Plataforma"
-    },
-    "playAllButton": {
-        "message": "Boton \"Reproducir todo\""
-    },
-    "playbackSpeed": {
-        "message": "Velocidad de reproducción"
-    },
-    "player": {
-        "message": "Reproductor"
-    },
-    "playerColor": {
-        "message": "Color del reproductor"
-    },
-    "playerSize": {
-        "message": "Tamaño del reproductor"
-    },
-    "playlist": {
-        "message": "Lista de reproducción"
-    },
-    "playlists": {
-        "message": "Listas de reproducción"
-    },
-    "playPause": {
-        "message": "Reproducir / pausar"
-    },
-    "popupPlayer": {
-        "message": "Reproductor emergente"
-    },
-    "popupWindowButtons": {
-        "message": "Añade un botón de reproductor emergente a cada miniatura"
-    },
-    "position": {
-        "message": "Posición"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Aprieta una tecla o haz scroll"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Aprieta una tecla o usa la rueda del ratón"
-    },
-    "previousVideo": {
-        "message": "Reproducir video anterior"
-    },
-    "primaryColor": {
-        "message": "Color Primario"
-    },
-    "purple": {
-        "message": "Morado"
-    },
-    "quality": {
-        "message": "Calidad"
-    },
-    "qualityWithoutFocus": {
-        "message": "Calidad sin enfoque"
-    },
-    "rateMe": {
-        "message": "Califícame"
-    },
-    "rateUs": {
-        "message": "Califíquenos"
-    },
-    "red": {
-        "message": "Rojo"
-    },
-    "redDislikeButton": {
-        "message": "Mostrar el botón de dislike de color rojo"
-    },
-    "relatedVideos": {
-        "message": "Vídeos relacionados"
-    },
-    "remote": {
-        "message": "Reproducir en el televisor"
-    },
-    "Remove": {
-        "message": "Eliminar"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Quitar resultados relacionados"
-    },
-    "repeat": {
-        "message": "Repetir"
-    },
-    "report": {
-        "message": "Reportar"
-    },
-    "reset": {
-        "message": "Reiniciar"
-    },
-    "resetAllSettings": {
-        "message": "Restablecer todos los ajustes"
-    },
-    "resetAllShortcuts": {
-        "message": "Restablecer todos los atajos"
-    },
-    "reverse": {
-        "message": "Revertir"
-    },
-    "rotate": {
-        "message": "Rotar"
-    },
-    "save": {
-        "message": "Guardar"
-    },
-    "saveAs": {
-        "message": "Guardar como"
-    },
-    "schedule": {
-        "message": "Programar"
-    },
-    "screen": {
-        "message": "Pantalla"
-    },
-    "screenshot": {
-        "message": "Captura de pantalla"
-    },
-    "scrollBar": {
-        "message": "Barra de desplazamiento"
-    },
-    "sd": {
-        "message": "SD - baja Qualidade"
-    },
-    "search": {
-        "message": "Búsqueda"
-    },
-    "searchBarOnly": {
-        "message": "Solo barra de búsqueda"
-    },
-    "seekBackward10Seconds": {
-        "message": "Retroceder 10 segundos"
-    },
-    "seekForward10Seconds": {
-        "message": "Adelantar 10 segundos"
-    },
-    "seekNextChapter": {
-        "message": "Saltar al siguiente capítulo"
-    },
-    "seekPreviousChapter": {
-        "message": "Saltar al capítulo anterior"
-    },
-    "settings": {
-        "message": "Ajustes"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Ajustes importados correctamente"
-    },
-    "share": {
-        "message": "Compartir"
-    },
-    "shortcut_screenshot": {
-        "message": "Captura de pantalla"
-    },
-    "shortcuts": {
-        "message": "Atajos"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Mostrar tarjetas al pasar el ratón"
-    },
-    "showChannelVideosCount": {
-        "message": "Mostrar recuento de videos del canal"
-    },
-    "showLess": {
-        "message": "Mostrar menos"
-    },
-    "showMore": {
-        "message": "Mostrar mas"
-    },
-    "showRemainingDuration": {
-        "message": "Mostrar la duración restante del video"
-    },
-    "showVersion": {
-        "message": "Mostrar versión"
-    },
-    "shuffle": {
-        "message": "Aleatorio"
-    },
-    "sidebar": {
-        "message": "Barra lateral"
-    },
-    "softwareInformation": {
-        "message": "Información del Software"
-    },
-    "spacebar": {
-        "message": "Espacio"
-    },
-    "squaredUserImages": {
-        "message": "Fotos de perfil cuadradas"
-    },
-    "static": {
-        "message": "Estático"
-    },
-    "statsForNerds": {
-        "message": "Mostrar estadísticas para Nerds"
-    },
-    "step": {
-        "message": "Paso"
-    },
-    "stop": {
-        "message": "Detener"
-    },
-    "style": {
-        "message": "Estilo"
-    },
-    "styles": {
-        "message": "Estilos"
-    },
-    "subscribe": {
-        "message": "Suscribirse"
-    },
-    "subscriptions": {
-        "message": "Suscripciones"
-    },
-    "subtitles": {
-        "message": "Subtítulos"
-    },
-    "sunset": {
-        "message": "Atardecer"
-    },
-    "sunsetToSunrise": {
-        "message": "De atardecer a amanecer"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferencia del sistema: Oscuro"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferencia del sistema: Claro"
-    },
-    "teal": {
-        "message": "Verde azulado"
-    },
-    "textColor": {
-        "message": "Color del texto"
-    },
-    "themes": {
-        "message": "Temas"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Esto borrará todas las cookies."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Esto borrará todos los videos vistos."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Esto borrará todas las cookies de YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Esto restablecerá todos los ajustes"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Esto restablecerá todos los atajos"
-    },
-    "thumbnails": {
-        "message": "Miniaturas"
-    },
-    "thumbnailsQuality": {
-        "message": "Calidad de miniaturas"
-    },
-    "timeFrom": {
-        "message": "Desde"
-    },
-    "timeTo": {
-        "message": "Hasta"
-    },
-    "todayAt": {
-        "message": "Hoy a las"
-    },
-    "toggleAutoplay": {
-        "message": "Activar/Desactivar reproducción automática"
-    },
-    "toggleCards": {
-        "message": "Activar/Desactivar tarjetas"
-    },
-    "toggleControls": {
-        "message": "Activar/Desactivar controles"
-    },
-    "trackWatchedVideos": {
-        "message": "Seguimiento de videos vistos"
-    },
-    "trailerAutoplay": {
-        "message": "Reproducción automática de trailer"
-    },
-    "Transcript": {
-        "message": "Transcripción"
-    },
-    "translations": {
-        "message": "Traducciones"
-    },
-    "transparentBackground": {
-        "message": "Fondo transparente"
-    },
-    "transparentColor": {
-        "message": "Transparente"
-    },
-    "trending": {
-        "message": "Tendencias"
-    },
-    "tryToReloadThePage": {
-        "message": "Intentar recargar la página"
-    },
-    "type": {
-        "message": "Tipo"
-    },
-    "upNextAutoplay": {
-        "message": "Siguiente reproducción automática"
-    },
-    "use24HourFormat": {
-        "message": "Usar formato 24 horas"
-    },
-    "version": {
-        "message": "Versión"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "La descripción del video se expandirá para obtener el nombre de la categoría."
-    },
-    "videoFormats": {
-        "message": "Formatos de video"
-    },
-    "volume": {
-        "message": "Volumen"
-    },
-    "watchLater": {
-        "message": "Ver más tarde"
-    },
-    "watchTime": {
-        "message": "Visualizaciones"
-    },
-    "whenTabIsChanged": {
-        "message": "Al cambiar de pestaña"
-    },
-    "white": {
-        "message": "Blanco"
-    },
-    "windowOpacity": {
-        "message": "Opacidad de la ventana"
-    },
-    "yellow": {
-        "message": "Amarillo"
-    },
-    "youTubeButtons": {
-        "message": "Botones de YouTube"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Encabezado YouTube (izq)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Encabezado YouTube (der)"
-    },
-    "youtubeHomePage": {
-        "message": "Página de inicio de YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Idioma de YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limita calidad de video a 1080p para el codec h.264"
-    }
+	"about": {
+		"message": "Acerca de"
+	},
+	"accept": {
+		"message": "Aceptar"
+	},
+	"activate": {
+		"message": "Activar"
+	},
+	"activateCaptions": {
+		"message": "Activar subtítulos"
+	},
+	"activated": {
+		"message": "Activado"
+	},
+	"activatedFeatures": {
+		"message": "Características activadas"
+	},
+	"activateFullscreen": {
+		"message": "Activar pantalla completa"
+	},
+	"activeFeatures": {
+		"message": "Activar características"
+	},
+	"addScrollToTop": {
+		"message": "Añadir «Volver arriba»"
+	},
+	"ads": {
+		"message": "Anuncios"
+	},
+	"all": {
+		"message": "Todo"
+	},
+	"allow": {
+		"message": "Permitir"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todos tus atajos serán borrados y no podrán ser recuperados"
+	},
+	"always": {
+		"message": "Siempre"
+	},
+	"alwaysActive": {
+		"message": "Siempre activo"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Siempre mostrar barra de progreso"
+	},
+	"amber": {
+		"message": "Ámbar"
+	},
+	"analyzer": {
+		"message": "Analizador"
+	},
+	"appearance": {
+		"message": "Apariencia"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "¿Estas seguro que deseas exportar la informacion?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "¿Estas seguro que deseas importar la informacion?"
+	},
+	"areYouSureYouWantToSyncTheData": {
+		"message": "¿Está seguro que desea sincronizar la configuración actual?"
+	},
+	"audio": {
+		"message": "Sonido"
+	},
+	"audioFormats": {
+		"message": "Formatos de audio"
+	},
+	"auto": {
+		"message": "Automático"
+	},
+	"autoFullscreen": {
+		"message": "Pantalla completa automática"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausar al cambiar de pestaña"
+	},
+	"autoplay": {
+		"message": "Reproducción automática"
+	},
+	"avoidAv1": {
+		"message": "Evitar AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Evitar AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Evitar AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Evitar renderizar con CPU cuando sea posible"
+	},
+	"backgroundColor": {
+		"message": "Color de fondo"
+	},
+	"backgroundOpacity": {
+		"message": "Opacidad de fondo"
+	},
+	"backupAndReset": {
+		"message": "Copia de seguridad y reinicio"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Según tema del sistema"
+	},
+	"belowPlayer": {
+		"message": "Debajo del reproductor"
+	},
+	"black": {
+		"message": "Negro"
+	},
+	"block_Codec_Alert_h264": {
+		"message": "Necesita activar VP9 o H.264 para que Youtube reproduzca videos."
+	},
+	"blockAll": {
+		"message": "Bloquear todo"
+	},
+	"blockAv1": {
+		"message": "Bloquear AV1"
+	},
+	"blockH264": {
+		"message": "Bloquear H.264"
+	},
+	"blocklist": {
+		"message": "Lista negra"
+	},
+	"blockMusic": {
+		"message": "Bloquear musica"
+	},
+	"blockVp8": {
+		"message": "Bloquear VP8"
+	},
+	"blockVp9": {
+		"message": "Bloquear VP9"
+	},
+	"blue": {
+		"message": "Azul"
+	},
+	"blueGray": {
+		"message": "Gris azulado"
+	},
+	"bluelight": {
+		"message": "Luz azul"
+	},
+	"brightness": {
+		"message": "Luminosidad"
+	},
+	"brown": {
+		"message": "Marrón"
+	},
+	"browser": {
+		"message": "Navegador"
+	},
+	"browserAccountSync": {
+		"message": "Sincronizar (Cuenta del Navegador)"
+	},
+	"browserVersion": {
+		"message": "Version del navegador"
+	},
+	"bubbles": {
+		"message": "Burbujas"
+	},
+	"bug": {
+		"message": "Error (Bug)"
+	},
+	"buttons": {
+		"message": "Botones"
+	},
+	"cancel": {
+		"message": "Cancelar"
+	},
+	"categories": {
+		"message": "Categorías"
+	},
+	"channel": {
+		"message": "Canal"
+	},
+	"channels": {
+		"message": "Canales"
+	},
+	"clipboard": {
+		"message": "Portapapeles"
+	},
+	"codecH264": {
+		"message": "Códec h.264"
+	},
+	"collapsed": {
+		"message": "Compacto"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Compactar sección de suscripciones"
+	},
+	"columns": {
+		"message": "Columna lateral extra (sin mover los vídeos relacionados, si la ventana es suficientemente ancha)"
+	},
+	"comments": {
+		"message": "Comentarios"
+	},
+	"compact_spacing": {
+		"message": "espaciamiento compacto"
+	},
+	"compactTheme": {
+		"message": "tema compacto"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Confirmar antes de cerrar"
+	},
+	"cores": {
+		"message": "Núcleos"
+	},
+	"cropChapterTitles": {
+		"message": "Recortar título de capítulos"
+	},
+	"custom": {
+		"message": "Personalizado"
+	},
+	"customCss": {
+		"message": "CSS personalizado"
+	},
+	"customJs": {
+		"message": "JS personalizado"
+	},
+	"customMiniPlayer": {
+		"message": "Mini-Reproductor personalizado"
+	},
+	"cyan": {
+		"message": "Cian"
+	},
+	"dark": {
+		"message": "Oscuro"
+	},
+	"darkTheme": {
+		"message": "Tema oscuro"
+	},
+	"dateAndTime": {
+		"message": "Fecha y hora"
+	},
+	"dawn": {
+		"message": "Amanecer"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Disminuir velocidad de reproducción"
+	},
+	"decreaseVolume": {
+		"message": "Bajar volumen"
+	},
+	"deepOrange": {
+		"message": "Naranja profundo"
+	},
+	"deepPurple": {
+		"message": "Violeta profundo"
+	},
+	"default": {
+		"message": "Por defecto"
+	},
+	"default_CC": {
+		"message": "predeterminado"
+	},
+	"default_theme": {
+		"message": "predeterminado"
+	},
+	"defaultChannelTab": {
+		"message": "Pestaña del canal por defecto"
+	},
+	"defaultContentCountry": {
+		"message": "Contenido del pais por defecto"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Velocidad de reproducción predeterminada"
+	},
+	"deleteWatchedVideos": {
+		"message": "Eliminar videos vistos"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Borrar cookies de YouTube"
+	},
+	"description": {
+		"message": "Descripcion"
+	},
+	"description_ext": {
+		"message": "YouTube, marea + inteligente? Video Youtube que el reproductor de youtube tamaño color color youtube saltar la velocidad de reproducción de las etiquetas skipper del canal de volumen ocultar"
+	},
+	"desert": {
+		"message": "Desierto"
+	},
+	"details": {
+		"message": "Detalles"
+	},
+	"developerOptions": {
+		"message": "Opciones de desarrollador"
+	},
+	"device": {
+		"message": "Dispositivo"
+	},
+	"dim": {
+		"message": "Oscuro"
+	},
+	"disabled": {
+		"message": "Desactivado"
+	},
+	"disableThumbnailPlayback": {
+		"message": "Desactivar la reproducción de vídeo al pasar el cursor"
+	},
+	"dislike": {
+		"message": "No me gusta"
+	},
+	"donate": {
+		"message": "Donar"
+	},
+	"doNotChange": {
+		"message": "No cambiar"
+	},
+	"download": {
+		"message": "Descargar"
+	},
+	"draggable": {
+		"message": "Arrastrable"
+	},
+	"email": {
+		"message": "Correo electrónico"
+	},
+	"embedded_Hide_Share": {
+		"message": "Ocultar compartimiento incrustado"
+	},
+	"empty": {
+		"message": "Vacío"
+	},
+	"enabled": {
+		"message": "Activado"
+	},
+	"enabledForced": {
+		"message": "Activado (forzado)"
+	},
+	"expanded": {
+		"message": "Expandido"
+	},
+	"exportSettings": {
+		"message": "Exportar configuración"
+	},
+	"extension": {
+		"message": "Extensión"
+	},
+	"ExtraButtons": {
+		"message": "Botones extra"
+	},
+	"extraButtonsBelowThePlayer": {
+		"message": "Botones adicionales bajo el reproductor"
+	},
+	"file": {
+		"message": "Archivo"
+	},
+	"filters": {
+		"message": "Filtros"
+	},
+	"fitToWindow": {
+		"message": "Ajustar a la ventana"
+	},
+	"font": {
+		"message": "Fuente"
+	},
+	"fontColor": {
+		"message": "Color de fuente"
+	},
+	"fontFamily": {
+		"message": "Tipografia de fuente"
+	},
+	"fontOpacity": {
+		"message": "Opacidad de fuente"
+	},
+	"fontSize": {
+		"message": "Tamaño de fuente"
+	},
+	"footer": {
+		"message": "Pie de pagina"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Forzar velocidad de reproducción"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(¿Forzar velocidad de reproducción incluso para la música?)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Forzar la reproduccion del video desde el inicio"
+	},
+	"forcedTheaterMode": {
+		"message": "Forzar modo teatro"
+	},
+	"forcedVolume": {
+		"message": "Forzar volumen"
+	},
+	"forceSDR": {
+		"message": "Forzar SDR"
+	},
+	"foundABug": {
+		"message": "¿Encontraste un error (bug)?"
+	},
+	"fullWindow": {
+		"message": "Pantalla completa"
+	},
+	"geoPreference": {
+		"message": "Preferencia de Geo"
+	},
+	"goToSearchBox": {
+		"message": "Ir a la barra de búsqueda"
+	},
+	"GPUnotindatabase": {
+		"message": "GPU no está en la base de datos"
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"hardwareInformation": {
+		"message": "Información de hardware"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura HD"
+	},
+	"header": {
+		"message": "Encabezado"
+	},
+	"hidden": {
+		"message": "Oculto"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Oculto en la página de video"
+	},
+	"hide_author_avatars": {
+		"message": "Ocultar avatares del autor"
+	},
+	"hide_labels": {
+		"message": "Ocultar nombres"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Ocultar miniaturas animadas"
+	},
+	"hideAnnotations": {
+		"message": "Ocultar anotaciones"
+	},
+	"hideCards": {
+		"message": "Ocultar tarjetas"
+	},
+	"hideCommentsCount": {
+		"message": "Ocultar contador de comentarios"
+	},
+	"hideCountryCode": {
+		"message": "Ocultar código de país"
+	},
+	"hideDate": {
+		"message": "Ocultar fecha"
+	},
+	"hideDetailButton": {
+		"message": "Botones (debajo del reproductor)"
+	},
+	"hideDetails": {
+		"message": "Ocultar detalles"
+	},
+	"hideEndscreen": {
+		"message": "Ocultar pantalla final"
+	},
+	"hideFeaturedContent": {
+		"message": "Ocultar contenido destacado"
+	},
+	"hideFooter": {
+		"message": "Ocultar pie de página"
+	},
+	"hideGradientBottom": {
+		"message": "Ocultar parte inferior degradada"
+	},
+	"hideHomePageShorts": {
+		"message": "Eliminar Shorts de la página de inicio"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ocultar la barra del reproductor"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ocultar los controles de la barra del reproductor"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ocultar opciones de control del reproductor"
+	},
+	"hidePlaylist": {
+		"message": "Ocultar playlist"
+	},
+	"hideRightButtons": {
+		"message": "Ocultar botones de la derecha"
+	},
+	"hideScrollForDetails": {
+		"message": "Ocultar «Desliza hacia abajo para ver más detalles»"
+	},
+	"hideSkipOverlay": {
+		"message": "Ocultar superposición de saltar"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ocultar la superposición de miniaturas"
+	},
+	"hideThumbnails": {
+		"message": "Ocultar miniaturas"
+	},
+	"hideVideoTitleFullScreen": {
+		"message": "Ocultar título de vídeo en pantalla completa"
+	},
+	"hideViewsCount": {
+		"message": "Ocultar contador de visitas"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ocultar boton de busqueda por voz"
+	},
+	"high": {
+		"message": "Alto"
+	},
+	"history": {
+		"message": "Historial"
+	},
+	"home": {
+		"message": "Inicio"
+	},
+	"hover": {
+		"message": "Cursor sobre (hover)"
+	},
+	"hoverOnVideoPage": {
+		"message": "Cursor sobre (hover) en página de video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Hace cuánto tiempo se subió el video"
+	},
+	"icons": {
+		"message": "Iconos"
+	},
+	"iconsOnly": {
+		"message": "Solo iconos"
+	},
+	"importSettings": {
+		"message": "Importar configuración"
+	},
+	"improvedtubeButtons": {
+		"message": "Botones ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Icono ImprovedTube en YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Idioma de ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Version de ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Mejorar logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Aumentar velocidad de reproducción"
+	},
+	"increaseVolume": {
+		"message": "Subir volumen"
+	},
+	"indigo": {
+		"message": "Índigo"
+	},
+	"language": {
+		"message": "Idioma"
+	},
+	"language_closed_caption": {
+		"message": "Idioma predeterminado - Closed Captions"
+	},
+	"languages": {
+		"message": "Idiomas"
+	},
+	"layout": {
+		"message": "Estilo"
+	},
+	"legacyYoutube": {
+		"message": "YouTube antiguo"
+	},
+	"library": {
+		"message": "Biblioteca"
+	},
+	"light": {
+		"message": "Claro"
+	},
+	"lightBlue": {
+		"message": "Azul claro"
+	},
+	"lightGreen": {
+		"message": "Verde claro"
+	},
+	"like": {
+		"message": "Me gusta"
+	},
+	"liked": {
+		"message": "Me gusta"
+	},
+	"likes": {
+		"message": "Gustos"
+	},
+	"lime": {
+		"message": "Lima"
+	},
+	"limitPageWidth": {
+		"message": "Limitar ancho de la pagina"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Chat en directo"
+	},
+	"liveChatType": {
+		"message": "Tipo de chat en directo"
+	},
+	"location": {
+		"message": "Ubicación"
+	},
+	"loop": {
+		"message": "Bucle"
+	},
+	"loudnessNormalization": {
+		"message": "Normalización de volumen"
+	},
+	"low": {
+		"message": "Bajo"
+	},
+	"markWatchedVideos": {
+		"message": "Marcar videos vistos"
+	},
+	"medium": {
+		"message": "Medio"
+	},
+	"mixer": {
+		"message": "Mezclador"
+	},
+	"more": {
+		"message": "Más"
+	},
+	"mostViewedChannels": {
+		"message": "Canales más vistos"
+	},
+	"moveSidebarLeft": {
+		"message": "Mover barra lateral a la izquierda"
+	},
+	"moveThumbnailsRight": {
+		"message": "Mover miniaturas a la derecha"
+	},
+	"My_specs": {
+		"message": "Mis especificaciones"
+	},
+	"myColors": {
+		"message": "Mis colores"
+	},
+	"name": {
+		"message": "Nombre"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini-Reproductor nativo"
+	},
+	"new": {
+		"message": "Nuevo"
+	},
+	"nextVideo": {
+		"message": "Siguiente video"
+	},
+	"night": {
+		"message": "Noche"
+	},
+	"nightMode": {
+		"message": "Modo nocturno"
+	},
+	"noActiveFeatures": {
+		"message": "Sin características activas"
+	},
+	"none": {
+		"message": "Ninguno"
+	},
+	"noOpenVideoTabs": {
+		"message": "Sin pestañas de video abiertas"
+	},
+	"off": {
+		"message": "Desactivado"
+	},
+	"ok": {
+		"message": "Aceptar"
+	},
+	"old": {
+		"message": "Viejo"
+	},
+	"onAllVideos": {
+		"message": "En todos los videos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Solo activo en YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Solo una pestaña reproduciendo"
+	},
+	"onSmallCreators": {
+		"message": "Desactivado, excepto para canales pequeños"
+	},
+	"onSubscribedChannels": {
+		"message": "En canales suscritos"
+	},
+	"openNewTab": {
+		"message": "Abrir en una pestaña nueva"
+	},
+	"openPopupPlayer": {
+		"message": "Abrir video/lista de reproduccion en una nueva ventana"
+	},
+	"orange": {
+		"message": "Naranja"
+	},
+	"other": {
+		"message": "Otro"
+	},
+	"permissions": {
+		"message": "Permisos"
+	},
+	"pictureInPicture": {
+		"message": "Imagen en imagen"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Plano"
+	},
+	"platform": {
+		"message": "Plataforma"
+	},
+	"playAllButton": {
+		"message": "Boton \"Reproducir todo\""
+	},
+	"playbackSpeed": {
+		"message": "Velocidad de reproducción"
+	},
+	"player": {
+		"message": "Reproductor"
+	},
+	"playerColor": {
+		"message": "Color del reproductor"
+	},
+	"playerSize": {
+		"message": "Tamaño del reproductor"
+	},
+	"playlist": {
+		"message": "Lista de reproducción"
+	},
+	"playlists": {
+		"message": "Listas de reproducción"
+	},
+	"playPause": {
+		"message": "Reproducir / pausar"
+	},
+	"popupPlayer": {
+		"message": "Reproductor emergente"
+	},
+	"popupWindowButtons": {
+		"message": "Añade un botón de reproductor emergente a cada miniatura"
+	},
+	"position": {
+		"message": "Posición"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Aprieta una tecla o haz scroll"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Aprieta una tecla o usa la rueda del ratón"
+	},
+	"previousVideo": {
+		"message": "Reproducir video anterior"
+	},
+	"primaryColor": {
+		"message": "Color Primario"
+	},
+	"purple": {
+		"message": "Morado"
+	},
+	"quality": {
+		"message": "Calidad"
+	},
+	"qualityWithoutFocus": {
+		"message": "Calidad sin enfoque"
+	},
+	"rateMe": {
+		"message": "Califícame"
+	},
+	"rateUs": {
+		"message": "Califíquenos"
+	},
+	"red": {
+		"message": "Rojo"
+	},
+	"redDislikeButton": {
+		"message": "Mostrar el botón de dislike de color rojo"
+	},
+	"relatedVideos": {
+		"message": "Vídeos relacionados"
+	},
+	"remote": {
+		"message": "Reproducir en el televisor"
+	},
+	"Remove": {
+		"message": "Eliminar"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Quitar resultados relacionados"
+	},
+	"repeat": {
+		"message": "Repetir"
+	},
+	"report": {
+		"message": "Reportar"
+	},
+	"reset": {
+		"message": "Reiniciar"
+	},
+	"resetAllSettings": {
+		"message": "Restablecer todos los ajustes"
+	},
+	"resetAllShortcuts": {
+		"message": "Restablecer todos los atajos"
+	},
+	"reverse": {
+		"message": "Revertir"
+	},
+	"rotate": {
+		"message": "Rotar"
+	},
+	"save": {
+		"message": "Guardar"
+	},
+	"saveAs": {
+		"message": "Guardar como"
+	},
+	"schedule": {
+		"message": "Programar"
+	},
+	"screen": {
+		"message": "Pantalla"
+	},
+	"screenshot": {
+		"message": "Captura de pantalla"
+	},
+	"scrollBar": {
+		"message": "Barra de desplazamiento"
+	},
+	"sd": {
+		"message": "SD - baja Qualidade"
+	},
+	"search": {
+		"message": "Búsqueda"
+	},
+	"searchBarOnly": {
+		"message": "Solo barra de búsqueda"
+	},
+	"seekBackward10Seconds": {
+		"message": "Retroceder 10 segundos"
+	},
+	"seekForward10Seconds": {
+		"message": "Adelantar 10 segundos"
+	},
+	"seekNextChapter": {
+		"message": "Saltar al siguiente capítulo"
+	},
+	"seekPreviousChapter": {
+		"message": "Saltar al capítulo anterior"
+	},
+	"settings": {
+		"message": "Ajustes"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Ajustes importados correctamente"
+	},
+	"share": {
+		"message": "Compartir"
+	},
+	"shortcut_screenshot": {
+		"message": "Captura de pantalla"
+	},
+	"shortcuts": {
+		"message": "Atajos"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Mostrar tarjetas al pasar el ratón"
+	},
+	"showChannelVideosCount": {
+		"message": "Mostrar recuento de videos del canal"
+	},
+	"showLess": {
+		"message": "Mostrar menos"
+	},
+	"showMore": {
+		"message": "Mostrar mas"
+	},
+	"showRemainingDuration": {
+		"message": "Mostrar la duración restante del video"
+	},
+	"showVersion": {
+		"message": "Mostrar versión"
+	},
+	"shuffle": {
+		"message": "Aleatorio"
+	},
+	"sidebar": {
+		"message": "Barra lateral"
+	},
+	"softwareInformation": {
+		"message": "Información del Software"
+	},
+	"spacebar": {
+		"message": "Espacio"
+	},
+	"squaredUserImages": {
+		"message": "Fotos de perfil cuadradas"
+	},
+	"static": {
+		"message": "Estático"
+	},
+	"statsForNerds": {
+		"message": "Mostrar estadísticas para Nerds"
+	},
+	"step": {
+		"message": "Paso"
+	},
+	"stop": {
+		"message": "Detener"
+	},
+	"style": {
+		"message": "Estilo"
+	},
+	"styles": {
+		"message": "Estilos"
+	},
+	"subscribe": {
+		"message": "Suscribirse"
+	},
+	"subscriptions": {
+		"message": "Suscripciones"
+	},
+	"subtitles": {
+		"message": "Subtítulos"
+	},
+	"sunset": {
+		"message": "Atardecer"
+	},
+	"sunsetToSunrise": {
+		"message": "De atardecer a amanecer"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferencia del sistema: Oscuro"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferencia del sistema: Claro"
+	},
+	"teal": {
+		"message": "Verde azulado"
+	},
+	"textColor": {
+		"message": "Color del texto"
+	},
+	"themes": {
+		"message": "Temas"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Esto borrará todas las cookies."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Esto borrará todos los videos vistos."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Esto borrará todas las cookies de YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Esto restablecerá todos los ajustes"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Esto restablecerá todos los atajos"
+	},
+	"thumbnails": {
+		"message": "Miniaturas"
+	},
+	"thumbnailsQuality": {
+		"message": "Calidad de miniaturas"
+	},
+	"timeFrom": {
+		"message": "Desde"
+	},
+	"timeTo": {
+		"message": "Hasta"
+	},
+	"todayAt": {
+		"message": "Hoy a las"
+	},
+	"toggleAutoplay": {
+		"message": "Activar/Desactivar reproducción automática"
+	},
+	"toggleCards": {
+		"message": "Activar/Desactivar tarjetas"
+	},
+	"toggleControls": {
+		"message": "Activar/Desactivar controles"
+	},
+	"trackWatchedVideos": {
+		"message": "Seguimiento de videos vistos"
+	},
+	"trailerAutoplay": {
+		"message": "Reproducción automática de trailer"
+	},
+	"Transcript": {
+		"message": "Transcripción"
+	},
+	"translations": {
+		"message": "Traducciones"
+	},
+	"transparentBackground": {
+		"message": "Fondo transparente"
+	},
+	"transparentColor": {
+		"message": "Transparente"
+	},
+	"trending": {
+		"message": "Tendencias"
+	},
+	"tryToReloadThePage": {
+		"message": "Intentar recargar la página"
+	},
+	"type": {
+		"message": "Tipo"
+	},
+	"upNextAutoplay": {
+		"message": "Siguiente reproducción automática"
+	},
+	"use24HourFormat": {
+		"message": "Usar formato 24 horas"
+	},
+	"version": {
+		"message": "Versión"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "La descripción del video se expandirá para obtener el nombre de la categoría."
+	},
+	"videoFormats": {
+		"message": "Formatos de video"
+	},
+	"volume": {
+		"message": "Volumen"
+	},
+	"watchLater": {
+		"message": "Ver más tarde"
+	},
+	"watchTime": {
+		"message": "Visualizaciones"
+	},
+	"whenTabIsChanged": {
+		"message": "Al cambiar de pestaña"
+	},
+	"white": {
+		"message": "Blanco"
+	},
+	"windowOpacity": {
+		"message": "Opacidad de la ventana"
+	},
+	"yellow": {
+		"message": "Amarillo"
+	},
+	"youTubeButtons": {
+		"message": "Botones de YouTube"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Encabezado YouTube (izq)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Encabezado YouTube (der)"
+	},
+	"youtubeHomePage": {
+		"message": "Página de inicio de YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Idioma de YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube limita calidad de video a 1080p para el codec h.264"
+	}
 }

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -1,947 +1,947 @@
 {
-    "about": {
-        "message": "Acerca de"
-    },
-    "accept": {
-        "message": "Aceptar"
-    },
-    "activate": {
-        "message": "Activar"
-    },
-    "activateCaptions": {
-        "message": "Activar subtítulos"
-    },
-    "activated": {
-        "message": "Activado"
-    },
-    "activatedFeatures": {
-        "message": "Características activadas"
-    },
-    "activateFullscreen": {
-        "message": "Activar pantalla completa"
-    },
-    "activeFeatures": {
-        "message": "Activar características"
-    },
-    "addScrollToTop": {
-        "message": "Añadir «Volver arriba»"
-    },
-    "ads": {
-        "message": "Anuncios"
-    },
-    "all": {
-        "message": "Todo"
-    },
-    "allow": {
-        "message": "Permitir"
-    },
-    "alwaysActive": {
-        "message": "Siempre activo"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Siempre mostrar barra de progreso"
-    },
-    "amber": {
-        "message": "Ámbar"
-    },
-    "analyzer": {
-        "message": "Analizador"
-    },
-    "appearance": {
-        "message": "Apariencia"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "¿Estas seguro que deseas exportar la informacion?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "¿Estas seguro que deseas importar la informacion?"
-    },
-    "audioFormats": {
-        "message": "Formatos de audio"
-    },
-    "auto": {
-        "message": "Automático"
-    },
-    "autoFullscreen": {
-        "message": "Pantalla completa automática"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausar al cambiar de pestaña"
-    },
-    "autoplay": {
-        "message": "Reproducción automática"
-    },
-    "avoidAv1": {
-        "message": "Evitar AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Evitar AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Evitar AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Evitar renderizar con CPU cuando sea posible"
-    },
-    "backgroundColor": {
-        "message": "Color de fondo"
-    },
-    "backgroundOpacity": {
-        "message": "Opacidad de fondo"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Según tema del sistema"
-    },
-    "belowPlayer": {
-        "message": "Debajo del reproductor"
-    },
-    "black": {
-        "message": "Negro"
-    },
-    "blockAll": {
-        "message": "Bloquear todo"
-    },
-    "blockAv1": {
-        "message": "Bloquear AV1"
-    },
-    "blockH264": {
-        "message": "Bloquear H.264"
-    },
-    "blocklist": {
-        "message": "Lista negra"
-    },
-    "blockMusic": {
-        "message": "Bloquear musica"
-    },
-    "blockVp8": {
-        "message": "Bloquear VP8"
-    },
-    "blockVp9": {
-        "message": "Bloquear VP9"
-    },
-    "blue": {
-        "message": "Azul"
-    },
-    "blueGray": {
-        "message": "Gris azulado"
-    },
-    "bluelight": {
-        "message": "Luz azul"
-    },
-    "brown": {
-        "message": "Marrón"
-    },
-    "browser": {
-        "message": "Navegador"
-    },
-    "browserVersion": {
-        "message": "Version del navegador"
-    },
-    "bubbles": {
-        "message": "Burbujas"
-    },
-    "bug": {
-        "message": "Error (Bug)"
-    },
-    "buttons": {
-        "message": "Botones"
-    },
-    "cancel": {
-        "message": "Cancelar"
-    },
-    "categories": {
-        "message": "Categorías"
-    },
-    "channel": {
-        "message": "Canal"
-    },
-    "channels": {
-        "message": "Canales"
-    },
-    "clipboard": {
-        "message": "Portapapeles"
-    },
-    "codecH264": {
-        "message": "Códec h.264"
-    },
-    "collapsed": {
-        "message": "Compacto"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Compactar sección de suscripciones"
-    },
-    "comments": {
-        "message": "Comentarios"
-    },
-    "compactTheme": {
-        "message": "Tema compacto"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Confirmar antes de cerrar"
-    },
-    "cores": {
-        "message": "Núcleos"
-    },
-    "cropChapterTitles": {
-        "message": "Recortar título de capítulos"
-    },
-    "custom": {
-        "message": "Personalizado"
-    },
-    "customCss": {
-        "message": "CSS personalizado"
-    },
-    "customJs": {
-        "message": "JS personalizado"
-    },
-    "customMiniPlayer": {
-        "message": "Mini-Reproductor personalizado"
-    },
-    "cyan": {
-        "message": "Cian"
-    },
-    "dark": {
-        "message": "Oscuro"
-    },
-    "darkTheme": {
-        "message": "Tema oscuro"
-    },
-    "dateAndTime": {
-        "message": "Fecha y hora"
-    },
-    "dawn": {
-        "message": "Amanecer"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Disminuir velocidad de reproducción"
-    },
-    "decreaseVolume": {
-        "message": "Bajar volumen"
-    },
-    "deepOrange": {
-        "message": "Naranja profundo"
-    },
-    "deepPurple": {
-        "message": "Violeta profundo"
-    },
-    "default": {
-        "message": "Por defecto"
-    },
-    "defaultChannelTab": {
-        "message": "Pestaña del canal por defecto"
-    },
-    "defaultContentCountry": {
-        "message": "Contenido del pais por defecto"
-    },
-    "deleteWatchedVideos": {
-        "message": "Eliminar videos vistos"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Borrar cookies de YouTube"
-    },
-    "description": {
-        "message": "Descripcion"
-    },
-    "desert": {
-        "message": "Desierto"
-    },
-    "details": {
-        "message": "Detalles"
-    },
-    "developerOptions": {
-        "message": "Opciones de desarrollador"
-    },
-    "device": {
-        "message": "Dispositivo"
-    },
-    "dim": {
-        "message": "Oscuro"
-    },
-    "disabled": {
-        "message": "Desactivado"
-    },
-    "dislike": {
-        "message": "No me gusta"
-    },
-    "donate": {
-        "message": "Donar"
-    },
-    "doNotChange": {
-        "message": "No cambiar"
-    },
-    "draggable": {
-        "message": "Arrastrable"
-    },
-    "empty": {
-        "message": "Vacío"
-    },
-    "enabled": {
-        "message": "Activado"
-    },
-    "enabledForced": {
-        "message": "Activado (forzado)"
-    },
-    "expanded": {
-        "message": "Expandido"
-    },
-    "exportSettings": {
-        "message": "Exportar configuración"
-    },
-    "extension": {
-        "message": "Extensión"
-    },
-    "file": {
-        "message": "Archivo"
-    },
-    "filters": {
-        "message": "Filtros"
-    },
-    "fitToWindow": {
-        "message": "Ajustar a la ventana"
-    },
-    "font": {
-        "message": "Fuente"
-    },
-    "fontColor": {
-        "message": "Color de fuente"
-    },
-    "fontFamily": {
-        "message": "Tipografia de fuente"
-    },
-    "fontOpacity": {
-        "message": "Opacidad de fuente"
-    },
-    "fontSize": {
-        "message": "Tamaño de fuente"
-    },
-    "footer": {
-        "message": "Pie de pagina"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Forzar velocidad de reproducción"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forzar la reproduccion del video desde el inicio"
-    },
-    "forcedTheaterMode": {
-        "message": "Forzar modo teatro"
-    },
-    "forcedVolume": {
-        "message": "Forzar volumen"
-    },
-    "forceSDR": {
-        "message": "Forzar SDR"
-    },
-    "foundABug": {
-        "message": "¿Encontraste un error (bug)?"
-    },
-    "fullWindow": {
-        "message": "Pantalla completa"
-    },
-    "goToSearchBox": {
-        "message": "Ir a la barra de búsqueda"
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura HD"
-    },
-    "header": {
-        "message": "Encabezado"
-    },
-    "hidden": {
-        "message": "Oculto"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Oculto en la página de video"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Ocultar miniaturas animadas"
-    },
-    "hideAnnotations": {
-        "message": "Ocultar anotaciones"
-    },
-    "hideCards": {
-        "message": "Ocultar tarjetas"
-    },
-    "hideCountryCode": {
-        "message": "Ocultar código de país"
-    },
-    "hideDate": {
-        "message": "Ocultar fecha"
-    },
-    "hideDetails": {
-        "message": "Ocultar detalles"
-    },
-    "hideEndscreen": {
-        "message": "Ocultar pantalla final"
-    },
-    "hideFeaturedContent": {
-        "message": "Ocultar contenido destacado"
-    },
-    "hideFooter": {
-        "message": "Ocultar pie de página"
-    },
-    "hideGradientBottom": {
-        "message": "Ocultar parte inferior degradada"
-    },
-    "hideHomePageShorts": {
-        "message": "Eliminar Shorts de la página de inicio"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ocultar la barra del reproductor"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ocultar los controles de la barra del reproductor"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ocultar opciones de control del reproductor"
-    },
-    "hidePlaylist": {
-        "message": "Ocultar playlist"
-    },
-    "hideRightButtons": {
-        "message": "Ocultar botones de la derecha"
-    },
-    "hideScrollForDetails": {
-        "message": "Ocultar «Desliza hacia abajo para ver más detalles»"
-    },
-    "hideSkipOverlay": {
-        "message": "Ocultar superposición de saltar"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ocultar la superposición de miniaturas"
-    },
-    "hideThumbnails": {
-        "message": "Ocultar miniaturas"
-    },
-    "hideViewsCount": {
-        "message": "Ocultar contador de visitas"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ocultar boton de busqueda por voz"
-    },
-    "high": {
-        "message": "Alto"
-    },
-    "history": {
-        "message": "Historial"
-    },
-    "home": {
-        "message": "Inicio"
-    },
-    "hover": {
-        "message": "Cursor sobre (hover)"
-    },
-    "hoverOnVideoPage": {
-        "message": "Cursor sobre (hover) en página de video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Hace cuánto tiempo se subió el video"
-    },
-    "icons": {
-        "message": "Iconos"
-    },
-    "iconsOnly": {
-        "message": "Solo iconos"
-    },
-    "importSettings": {
-        "message": "Importar configuración"
-    },
-    "improvedtubeButtons": {
-        "message": "Botones ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Icono ImprovedTube en YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Idioma de ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Version de ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Mejorar logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Aumentar velocidad de reproducción"
-    },
-    "increaseVolume": {
-        "message": "Subir volumen"
-    },
-    "indigo": {
-        "message": "Índigo"
-    },
-    "language": {
-        "message": "Idioma"
-    },
-    "languages": {
-        "message": "Idiomas"
-    },
-    "legacyYoutube": {
-        "message": "YouTube antiguo"
-    },
-    "library": {
-        "message": "Biblioteca"
-    },
-    "light": {
-        "message": "Claro"
-    },
-    "lightBlue": {
-        "message": "Azul claro"
-    },
-    "lightGreen": {
-        "message": "Verde claro"
-    },
-    "like": {
-        "message": "Me gusta"
-    },
-    "liked": {
-        "message": "Me gusta"
-    },
-    "lime": {
-        "message": "Lima"
-    },
-    "limitPageWidth": {
-        "message": "Limitar ancho de la pagina"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Chat en directo"
-    },
-    "liveChatType": {
-        "message": "Tipo de chat en directo"
-    },
-    "location": {
-        "message": "Ubicación"
-    },
-    "loop": {
-        "message": "Bucle"
-    },
-    "loudnessNormalization": {
-        "message": "Normalización de volumen"
-    },
-    "low": {
-        "message": "Bajo"
-    },
-    "markWatchedVideos": {
-        "message": "Marcar videos vistos"
-    },
-    "medium": {
-        "message": "Medio"
-    },
-    "mixer": {
-        "message": "Mezclador"
-    },
-    "more": {
-        "message": "Más"
-    },
-    "moveSidebarLeft": {
-        "message": "Mover barra lateral a la izquierda"
-    },
-    "moveThumbnailsRight": {
-        "message": "Mover miniaturas a la derecha"
-    },
-    "myColors": {
-        "message": "Mis colores"
-    },
-    "name": {
-        "message": "Nombre"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini-Reproductor nativo"
-    },
-    "new": {
-        "message": "Nuevo"
-    },
-    "nextVideo": {
-        "message": "Siguiente video"
-    },
-    "night": {
-        "message": "Noche"
-    },
-    "noActiveFeatures": {
-        "message": "Sin características activas"
-    },
-    "none": {
-        "message": "Ninguno"
-    },
-    "noOpenVideoTabs": {
-        "message": "Sin pestañas de video abiertas"
-    },
-    "old": {
-        "message": "Viejo"
-    },
-    "onAllVideos": {
-        "message": "En todos los videos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Solo activo en YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Solo una pestaña reproduciendo"
-    },
-    "onSubscribedChannels": {
-        "message": "En canales suscritos"
-    },
-    "openNewTab": {
-        "message": "Abrir en una pestaña nueva"
-    },
-    "openPopupPlayer": {
-        "message": "Abrir video/lista de reproduccion en una nueva ventana"
-    },
-    "orange": {
-        "message": "Naranja"
-    },
-    "other": {
-        "message": "Otro"
-    },
-    "permissions": {
-        "message": "Permisos"
-    },
-    "pictureInPicture": {
-        "message": "Imagen en imagen"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Plano"
-    },
-    "platform": {
-        "message": "Plataforma"
-    },
-    "playAllButton": {
-        "message": "Boton \"Reproducir todo\""
-    },
-    "playbackSpeed": {
-        "message": "Velocidad de reproducción"
-    },
-    "player": {
-        "message": "Reproductor"
-    },
-    "playerColor": {
-        "message": "Color del reproductor"
-    },
-    "playerSize": {
-        "message": "Tamaño del reproductor"
-    },
-    "playlist": {
-        "message": "Lista de reproducción"
-    },
-    "playlists": {
-        "message": "Listas de reproducción"
-    },
-    "playPause": {
-        "message": "Reproducir / pausar"
-    },
-    "popupPlayer": {
-        "message": "Reproductor emergente"
-    },
-    "popupWindowButtons": {
-        "message": "Añade un botón de reproductor emergente a cada miniatura"
-    },
-    "position": {
-        "message": "Posición"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Aprieta una tecla o haz scroll"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Aprieta una tecla o usa la rueda del ratón"
-    },
-    "previousVideo": {
-        "message": "Reproducir video anterior"
-    },
-    "primaryColor": {
-        "message": "Color Primario"
-    },
-    "purple": {
-        "message": "Morado"
-    },
-    "quality": {
-        "message": "Calidad"
-    },
-    "qualityWithoutFocus": {
-        "message": "Calidad sin enfoque"
-    },
-    "rateMe": {
-        "message": "Califícame"
-    },
-    "rateUs": {
-        "message": "Califíquenos"
-    },
-    "red": {
-        "message": "Rojo"
-    },
-    "redDislikeButton": {
-        "message": "Mostrar el botón de dislike de color rojo"
-    },
-    "relatedVideos": {
-        "message": "Vídeos relacionados"
-    },
-    "remote": {
-        "message": "Reproducir en el televisor"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Quitar resultados relacionados"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Eliminar el carrusel de Shorts de los resultados de búsqueda"
-    },
-    "repeat": {
-        "message": "Repetir"
-    },
-    "report": {
-        "message": "Reportar"
-    },
-    "reset": {
-        "message": "Reiniciar"
-    },
-    "resetAllSettings": {
-        "message": "Restablecer todos los ajustes"
-    },
-    "resetAllShortcuts": {
-        "message": "Restablecer todos los atajos"
-    },
-    "reverse": {
-        "message": "Revertir"
-    },
-    "rotate": {
-        "message": "Rotar"
-    },
-    "save": {
-        "message": "Guardar"
-    },
-    "saveAs": {
-        "message": "Guardar como"
-    },
-    "schedule": {
-        "message": "Programar"
-    },
-    "screen": {
-        "message": "Pantalla"
-    },
-    "screenshot": {
-        "message": "Captura de pantalla"
-    },
-    "scrollBar": {
-        "message": "Barra de desplazamiento"
-    },
-    "search": {
-        "message": "Búsqueda"
-    },
-    "searchBarOnly": {
-        "message": "Solo barra de búsqueda"
-    },
-    "seekBackward10Seconds": {
-        "message": "Retroceder 10 segundos"
-    },
-    "seekForward10Seconds": {
-        "message": "Adelantar 10 segundos"
-    },
-    "seekNextChapter": {
-        "message": "Saltar al siguiente capítulo"
-    },
-    "seekPreviousChapter": {
-        "message": "Saltar al capítulo anterior"
-    },
-    "settings": {
-        "message": "Ajustes"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Ajustes importados correctamente"
-    },
-    "shortcuts": {
-        "message": "Atajos"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Mostrar tarjetas al pasar el ratón"
-    },
-    "showChannelVideosCount": {
-        "message": "Mostrar recuento de videos del canal"
-    },
-    "showLess": {
-        "message": "Mostrar menos"
-    },
-    "showMore": {
-        "message": "Mostrar mas"
-    },
-    "showRemainingDuration": {
-        "message": "Mostrar la duración restante del video"
-    },
-    "shuffle": {
-        "message": "Aleatorio"
-    },
-    "sidebar": {
-        "message": "Barra lateral"
-    },
-    "spacebar": {
-        "message": "Espacio"
-    },
-    "squaredUserImages": {
-        "message": "Fotos de perfil cuadradas"
-    },
-    "static": {
-        "message": "Estático"
-    },
-    "statsForNerds": {
-        "message": "Mostrar estadísticas para Nerds"
-    },
-    "step": {
-        "message": "Paso"
-    },
-    "stop": {
-        "message": "Detener"
-    },
-    "style": {
-        "message": "Estilo"
-    },
-    "styles": {
-        "message": "Estilos"
-    },
-    "subscribe": {
-        "message": "Suscribirse"
-    },
-    "subscriptions": {
-        "message": "Suscripciones"
-    },
-    "subtitles": {
-        "message": "Subtítulos"
-    },
-    "sunset": {
-        "message": "Atardecer"
-    },
-    "sunsetToSunrise": {
-        "message": "De atardecer a amanecer"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferencia del sistema: Oscuro"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferencia del sistema: Claro"
-    },
-    "teal": {
-        "message": "Verde azulado"
-    },
-    "textColor": {
-        "message": "Color del texto"
-    },
-    "themes": {
-        "message": "Temas"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Esto borrará todas las cookies."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Esto borrará todos los videos vistos."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Esto borrará todas las cookies de YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Esto restablecerá todos los ajustes"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Esto restablecerá todos los atajos"
-    },
-    "thumbnails": {
-        "message": "Miniaturas"
-    },
-    "thumbnailsQuality": {
-        "message": "Calidad de miniaturas"
-    },
-    "timeFrom": {
-        "message": "Desde"
-    },
-    "timeTo": {
-        "message": "Hasta"
-    },
-    "todayAt": {
-        "message": "Hoy a las"
-    },
-    "toggleAutoplay": {
-        "message": "Activar/Desactivar reproducción automática"
-    },
-    "toggleCards": {
-        "message": "Activar/Desactivar tarjetas"
-    },
-    "toggleControls": {
-        "message": "Activar/Desactivar controles"
-    },
-    "trackWatchedVideos": {
-        "message": "Seguimiento de videos vistos"
-    },
-    "trailerAutoplay": {
-        "message": "Reproducción automática de trailer"
-    },
-    "translations": {
-        "message": "Traducciones"
-    },
-    "transparentBackground": {
-        "message": "Fondo transparente"
-    },
-    "trending": {
-        "message": "Tendencias"
-    },
-    "tryToReloadThePage": {
-        "message": "Intentar recargar la página"
-    },
-    "type": {
-        "message": "Tipo"
-    },
-    "upNextAutoplay": {
-        "message": "Siguiente reproducción automática"
-    },
-    "use24HourFormat": {
-        "message": "Usar formato 24 horas"
-    },
-    "version": {
-        "message": "Versión"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "La descripción del video se expandirá para obtener el nombre de la categoría."
-    },
-    "videoFormats": {
-        "message": "Formatos de video"
-    },
-    "volume": {
-        "message": "Volumen"
-    },
-    "watchLater": {
-        "message": "Ver más tarde"
-    },
-    "watchTime": {
-        "message": "Visualizaciones"
-    },
-    "whenTabIsChanged": {
-        "message": "Al cambiar de pestaña"
-    },
-    "white": {
-        "message": "Blanco"
-    },
-    "windowOpacity": {
-        "message": "Opacidad de la ventana"
-    },
-    "yellow": {
-        "message": "Amarillo"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Encabezado YouTube (izq)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Encabezado YouTube (der)"
-    },
-    "youtubeHomePage": {
-        "message": "Página de inicio de YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Idioma de YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limita calidad de video a 1080p para el codec h.264"
-    }
+	"about": {
+		"message": "Acerca de"
+	},
+	"accept": {
+		"message": "Aceptar"
+	},
+	"activate": {
+		"message": "Activar"
+	},
+	"activateCaptions": {
+		"message": "Activar subtítulos"
+	},
+	"activated": {
+		"message": "Activado"
+	},
+	"activatedFeatures": {
+		"message": "Características activadas"
+	},
+	"activateFullscreen": {
+		"message": "Activar pantalla completa"
+	},
+	"activeFeatures": {
+		"message": "Activar características"
+	},
+	"addScrollToTop": {
+		"message": "Añadir «Volver arriba»"
+	},
+	"ads": {
+		"message": "Anuncios"
+	},
+	"all": {
+		"message": "Todo"
+	},
+	"allow": {
+		"message": "Permitir"
+	},
+	"alwaysActive": {
+		"message": "Siempre activo"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Siempre mostrar barra de progreso"
+	},
+	"amber": {
+		"message": "Ámbar"
+	},
+	"analyzer": {
+		"message": "Analizador"
+	},
+	"appearance": {
+		"message": "Apariencia"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "¿Estas seguro que deseas exportar la informacion?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "¿Estas seguro que deseas importar la informacion?"
+	},
+	"audioFormats": {
+		"message": "Formatos de audio"
+	},
+	"auto": {
+		"message": "Automático"
+	},
+	"autoFullscreen": {
+		"message": "Pantalla completa automática"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausar al cambiar de pestaña"
+	},
+	"autoplay": {
+		"message": "Reproducción automática"
+	},
+	"avoidAv1": {
+		"message": "Evitar AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Evitar AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Evitar AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Evitar renderizar con CPU cuando sea posible"
+	},
+	"backgroundColor": {
+		"message": "Color de fondo"
+	},
+	"backgroundOpacity": {
+		"message": "Opacidad de fondo"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Según tema del sistema"
+	},
+	"belowPlayer": {
+		"message": "Debajo del reproductor"
+	},
+	"black": {
+		"message": "Negro"
+	},
+	"blockAll": {
+		"message": "Bloquear todo"
+	},
+	"blockAv1": {
+		"message": "Bloquear AV1"
+	},
+	"blockH264": {
+		"message": "Bloquear H.264"
+	},
+	"blocklist": {
+		"message": "Lista negra"
+	},
+	"blockMusic": {
+		"message": "Bloquear musica"
+	},
+	"blockVp8": {
+		"message": "Bloquear VP8"
+	},
+	"blockVp9": {
+		"message": "Bloquear VP9"
+	},
+	"blue": {
+		"message": "Azul"
+	},
+	"blueGray": {
+		"message": "Gris azulado"
+	},
+	"bluelight": {
+		"message": "Luz azul"
+	},
+	"brown": {
+		"message": "Marrón"
+	},
+	"browser": {
+		"message": "Navegador"
+	},
+	"browserVersion": {
+		"message": "Version del navegador"
+	},
+	"bubbles": {
+		"message": "Burbujas"
+	},
+	"bug": {
+		"message": "Error (Bug)"
+	},
+	"buttons": {
+		"message": "Botones"
+	},
+	"cancel": {
+		"message": "Cancelar"
+	},
+	"categories": {
+		"message": "Categorías"
+	},
+	"channel": {
+		"message": "Canal"
+	},
+	"channels": {
+		"message": "Canales"
+	},
+	"clipboard": {
+		"message": "Portapapeles"
+	},
+	"codecH264": {
+		"message": "Códec h.264"
+	},
+	"collapsed": {
+		"message": "Compacto"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Compactar sección de suscripciones"
+	},
+	"comments": {
+		"message": "Comentarios"
+	},
+	"compactTheme": {
+		"message": "Tema compacto"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Confirmar antes de cerrar"
+	},
+	"cores": {
+		"message": "Núcleos"
+	},
+	"cropChapterTitles": {
+		"message": "Recortar título de capítulos"
+	},
+	"custom": {
+		"message": "Personalizado"
+	},
+	"customCss": {
+		"message": "CSS personalizado"
+	},
+	"customJs": {
+		"message": "JS personalizado"
+	},
+	"customMiniPlayer": {
+		"message": "Mini-Reproductor personalizado"
+	},
+	"cyan": {
+		"message": "Cian"
+	},
+	"dark": {
+		"message": "Oscuro"
+	},
+	"darkTheme": {
+		"message": "Tema oscuro"
+	},
+	"dateAndTime": {
+		"message": "Fecha y hora"
+	},
+	"dawn": {
+		"message": "Amanecer"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Disminuir velocidad de reproducción"
+	},
+	"decreaseVolume": {
+		"message": "Bajar volumen"
+	},
+	"deepOrange": {
+		"message": "Naranja profundo"
+	},
+	"deepPurple": {
+		"message": "Violeta profundo"
+	},
+	"default": {
+		"message": "Por defecto"
+	},
+	"defaultChannelTab": {
+		"message": "Pestaña del canal por defecto"
+	},
+	"defaultContentCountry": {
+		"message": "Contenido del pais por defecto"
+	},
+	"deleteWatchedVideos": {
+		"message": "Eliminar videos vistos"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Borrar cookies de YouTube"
+	},
+	"description": {
+		"message": "Descripcion"
+	},
+	"desert": {
+		"message": "Desierto"
+	},
+	"details": {
+		"message": "Detalles"
+	},
+	"developerOptions": {
+		"message": "Opciones de desarrollador"
+	},
+	"device": {
+		"message": "Dispositivo"
+	},
+	"dim": {
+		"message": "Oscuro"
+	},
+	"disabled": {
+		"message": "Desactivado"
+	},
+	"dislike": {
+		"message": "No me gusta"
+	},
+	"donate": {
+		"message": "Donar"
+	},
+	"doNotChange": {
+		"message": "No cambiar"
+	},
+	"draggable": {
+		"message": "Arrastrable"
+	},
+	"empty": {
+		"message": "Vacío"
+	},
+	"enabled": {
+		"message": "Activado"
+	},
+	"enabledForced": {
+		"message": "Activado (forzado)"
+	},
+	"expanded": {
+		"message": "Expandido"
+	},
+	"exportSettings": {
+		"message": "Exportar configuración"
+	},
+	"extension": {
+		"message": "Extensión"
+	},
+	"file": {
+		"message": "Archivo"
+	},
+	"filters": {
+		"message": "Filtros"
+	},
+	"fitToWindow": {
+		"message": "Ajustar a la ventana"
+	},
+	"font": {
+		"message": "Fuente"
+	},
+	"fontColor": {
+		"message": "Color de fuente"
+	},
+	"fontFamily": {
+		"message": "Tipografia de fuente"
+	},
+	"fontOpacity": {
+		"message": "Opacidad de fuente"
+	},
+	"fontSize": {
+		"message": "Tamaño de fuente"
+	},
+	"footer": {
+		"message": "Pie de pagina"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Forzar velocidad de reproducción"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Forzar la reproduccion del video desde el inicio"
+	},
+	"forcedTheaterMode": {
+		"message": "Forzar modo teatro"
+	},
+	"forcedVolume": {
+		"message": "Forzar volumen"
+	},
+	"forceSDR": {
+		"message": "Forzar SDR"
+	},
+	"foundABug": {
+		"message": "¿Encontraste un error (bug)?"
+	},
+	"fullWindow": {
+		"message": "Pantalla completa"
+	},
+	"goToSearchBox": {
+		"message": "Ir a la barra de búsqueda"
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura HD"
+	},
+	"header": {
+		"message": "Encabezado"
+	},
+	"hidden": {
+		"message": "Oculto"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Oculto en la página de video"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Ocultar miniaturas animadas"
+	},
+	"hideAnnotations": {
+		"message": "Ocultar anotaciones"
+	},
+	"hideCards": {
+		"message": "Ocultar tarjetas"
+	},
+	"hideCountryCode": {
+		"message": "Ocultar código de país"
+	},
+	"hideDate": {
+		"message": "Ocultar fecha"
+	},
+	"hideDetails": {
+		"message": "Ocultar detalles"
+	},
+	"hideEndscreen": {
+		"message": "Ocultar pantalla final"
+	},
+	"hideFeaturedContent": {
+		"message": "Ocultar contenido destacado"
+	},
+	"hideFooter": {
+		"message": "Ocultar pie de página"
+	},
+	"hideGradientBottom": {
+		"message": "Ocultar parte inferior degradada"
+	},
+	"hideHomePageShorts": {
+		"message": "Eliminar Shorts de la página de inicio"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ocultar la barra del reproductor"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ocultar los controles de la barra del reproductor"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ocultar opciones de control del reproductor"
+	},
+	"hidePlaylist": {
+		"message": "Ocultar playlist"
+	},
+	"hideRightButtons": {
+		"message": "Ocultar botones de la derecha"
+	},
+	"hideScrollForDetails": {
+		"message": "Ocultar «Desliza hacia abajo para ver más detalles»"
+	},
+	"hideSkipOverlay": {
+		"message": "Ocultar superposición de saltar"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ocultar la superposición de miniaturas"
+	},
+	"hideThumbnails": {
+		"message": "Ocultar miniaturas"
+	},
+	"hideViewsCount": {
+		"message": "Ocultar contador de visitas"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ocultar boton de busqueda por voz"
+	},
+	"high": {
+		"message": "Alto"
+	},
+	"history": {
+		"message": "Historial"
+	},
+	"home": {
+		"message": "Inicio"
+	},
+	"hover": {
+		"message": "Cursor sobre (hover)"
+	},
+	"hoverOnVideoPage": {
+		"message": "Cursor sobre (hover) en página de video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Hace cuánto tiempo se subió el video"
+	},
+	"icons": {
+		"message": "Iconos"
+	},
+	"iconsOnly": {
+		"message": "Solo iconos"
+	},
+	"importSettings": {
+		"message": "Importar configuración"
+	},
+	"improvedtubeButtons": {
+		"message": "Botones ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Icono ImprovedTube en YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Idioma de ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Version de ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Mejorar logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Aumentar velocidad de reproducción"
+	},
+	"increaseVolume": {
+		"message": "Subir volumen"
+	},
+	"indigo": {
+		"message": "Índigo"
+	},
+	"language": {
+		"message": "Idioma"
+	},
+	"languages": {
+		"message": "Idiomas"
+	},
+	"legacyYoutube": {
+		"message": "YouTube antiguo"
+	},
+	"library": {
+		"message": "Biblioteca"
+	},
+	"light": {
+		"message": "Claro"
+	},
+	"lightBlue": {
+		"message": "Azul claro"
+	},
+	"lightGreen": {
+		"message": "Verde claro"
+	},
+	"like": {
+		"message": "Me gusta"
+	},
+	"liked": {
+		"message": "Me gusta"
+	},
+	"lime": {
+		"message": "Lima"
+	},
+	"limitPageWidth": {
+		"message": "Limitar ancho de la pagina"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Chat en directo"
+	},
+	"liveChatType": {
+		"message": "Tipo de chat en directo"
+	},
+	"location": {
+		"message": "Ubicación"
+	},
+	"loop": {
+		"message": "Bucle"
+	},
+	"loudnessNormalization": {
+		"message": "Normalización de volumen"
+	},
+	"low": {
+		"message": "Bajo"
+	},
+	"markWatchedVideos": {
+		"message": "Marcar videos vistos"
+	},
+	"medium": {
+		"message": "Medio"
+	},
+	"mixer": {
+		"message": "Mezclador"
+	},
+	"more": {
+		"message": "Más"
+	},
+	"moveSidebarLeft": {
+		"message": "Mover barra lateral a la izquierda"
+	},
+	"moveThumbnailsRight": {
+		"message": "Mover miniaturas a la derecha"
+	},
+	"myColors": {
+		"message": "Mis colores"
+	},
+	"name": {
+		"message": "Nombre"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini-Reproductor nativo"
+	},
+	"new": {
+		"message": "Nuevo"
+	},
+	"nextVideo": {
+		"message": "Siguiente video"
+	},
+	"night": {
+		"message": "Noche"
+	},
+	"noActiveFeatures": {
+		"message": "Sin características activas"
+	},
+	"none": {
+		"message": "Ninguno"
+	},
+	"noOpenVideoTabs": {
+		"message": "Sin pestañas de video abiertas"
+	},
+	"old": {
+		"message": "Viejo"
+	},
+	"onAllVideos": {
+		"message": "En todos los videos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Solo activo en YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Solo una pestaña reproduciendo"
+	},
+	"onSubscribedChannels": {
+		"message": "En canales suscritos"
+	},
+	"openNewTab": {
+		"message": "Abrir en una pestaña nueva"
+	},
+	"openPopupPlayer": {
+		"message": "Abrir video/lista de reproduccion en una nueva ventana"
+	},
+	"orange": {
+		"message": "Naranja"
+	},
+	"other": {
+		"message": "Otro"
+	},
+	"permissions": {
+		"message": "Permisos"
+	},
+	"pictureInPicture": {
+		"message": "Imagen en imagen"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Plano"
+	},
+	"platform": {
+		"message": "Plataforma"
+	},
+	"playAllButton": {
+		"message": "Boton \"Reproducir todo\""
+	},
+	"playbackSpeed": {
+		"message": "Velocidad de reproducción"
+	},
+	"player": {
+		"message": "Reproductor"
+	},
+	"playerColor": {
+		"message": "Color del reproductor"
+	},
+	"playerSize": {
+		"message": "Tamaño del reproductor"
+	},
+	"playlist": {
+		"message": "Lista de reproducción"
+	},
+	"playlists": {
+		"message": "Listas de reproducción"
+	},
+	"playPause": {
+		"message": "Reproducir / pausar"
+	},
+	"popupPlayer": {
+		"message": "Reproductor emergente"
+	},
+	"popupWindowButtons": {
+		"message": "Añade un botón de reproductor emergente a cada miniatura"
+	},
+	"position": {
+		"message": "Posición"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Aprieta una tecla o haz scroll"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Aprieta una tecla o usa la rueda del ratón"
+	},
+	"previousVideo": {
+		"message": "Reproducir video anterior"
+	},
+	"primaryColor": {
+		"message": "Color Primario"
+	},
+	"purple": {
+		"message": "Morado"
+	},
+	"quality": {
+		"message": "Calidad"
+	},
+	"qualityWithoutFocus": {
+		"message": "Calidad sin enfoque"
+	},
+	"rateMe": {
+		"message": "Califícame"
+	},
+	"rateUs": {
+		"message": "Califíquenos"
+	},
+	"red": {
+		"message": "Rojo"
+	},
+	"redDislikeButton": {
+		"message": "Mostrar el botón de dislike de color rojo"
+	},
+	"relatedVideos": {
+		"message": "Vídeos relacionados"
+	},
+	"remote": {
+		"message": "Reproducir en el televisor"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Quitar resultados relacionados"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Eliminar el carrusel de Shorts de los resultados de búsqueda"
+	},
+	"repeat": {
+		"message": "Repetir"
+	},
+	"report": {
+		"message": "Reportar"
+	},
+	"reset": {
+		"message": "Reiniciar"
+	},
+	"resetAllSettings": {
+		"message": "Restablecer todos los ajustes"
+	},
+	"resetAllShortcuts": {
+		"message": "Restablecer todos los atajos"
+	},
+	"reverse": {
+		"message": "Revertir"
+	},
+	"rotate": {
+		"message": "Rotar"
+	},
+	"save": {
+		"message": "Guardar"
+	},
+	"saveAs": {
+		"message": "Guardar como"
+	},
+	"schedule": {
+		"message": "Programar"
+	},
+	"screen": {
+		"message": "Pantalla"
+	},
+	"screenshot": {
+		"message": "Captura de pantalla"
+	},
+	"scrollBar": {
+		"message": "Barra de desplazamiento"
+	},
+	"search": {
+		"message": "Búsqueda"
+	},
+	"searchBarOnly": {
+		"message": "Solo barra de búsqueda"
+	},
+	"seekBackward10Seconds": {
+		"message": "Retroceder 10 segundos"
+	},
+	"seekForward10Seconds": {
+		"message": "Adelantar 10 segundos"
+	},
+	"seekNextChapter": {
+		"message": "Saltar al siguiente capítulo"
+	},
+	"seekPreviousChapter": {
+		"message": "Saltar al capítulo anterior"
+	},
+	"settings": {
+		"message": "Ajustes"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Ajustes importados correctamente"
+	},
+	"shortcuts": {
+		"message": "Atajos"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Mostrar tarjetas al pasar el ratón"
+	},
+	"showChannelVideosCount": {
+		"message": "Mostrar recuento de videos del canal"
+	},
+	"showLess": {
+		"message": "Mostrar menos"
+	},
+	"showMore": {
+		"message": "Mostrar mas"
+	},
+	"showRemainingDuration": {
+		"message": "Mostrar la duración restante del video"
+	},
+	"shuffle": {
+		"message": "Aleatorio"
+	},
+	"sidebar": {
+		"message": "Barra lateral"
+	},
+	"spacebar": {
+		"message": "Espacio"
+	},
+	"squaredUserImages": {
+		"message": "Fotos de perfil cuadradas"
+	},
+	"static": {
+		"message": "Estático"
+	},
+	"statsForNerds": {
+		"message": "Mostrar estadísticas para Nerds"
+	},
+	"step": {
+		"message": "Paso"
+	},
+	"stop": {
+		"message": "Detener"
+	},
+	"style": {
+		"message": "Estilo"
+	},
+	"styles": {
+		"message": "Estilos"
+	},
+	"subscribe": {
+		"message": "Suscribirse"
+	},
+	"subscriptions": {
+		"message": "Suscripciones"
+	},
+	"subtitles": {
+		"message": "Subtítulos"
+	},
+	"sunset": {
+		"message": "Atardecer"
+	},
+	"sunsetToSunrise": {
+		"message": "De atardecer a amanecer"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferencia del sistema: Oscuro"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferencia del sistema: Claro"
+	},
+	"teal": {
+		"message": "Verde azulado"
+	},
+	"textColor": {
+		"message": "Color del texto"
+	},
+	"themes": {
+		"message": "Temas"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Esto borrará todas las cookies."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Esto borrará todos los videos vistos."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Esto borrará todas las cookies de YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Esto restablecerá todos los ajustes"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Esto restablecerá todos los atajos"
+	},
+	"thumbnails": {
+		"message": "Miniaturas"
+	},
+	"thumbnailsQuality": {
+		"message": "Calidad de miniaturas"
+	},
+	"timeFrom": {
+		"message": "Desde"
+	},
+	"timeTo": {
+		"message": "Hasta"
+	},
+	"todayAt": {
+		"message": "Hoy a las"
+	},
+	"toggleAutoplay": {
+		"message": "Activar/Desactivar reproducción automática"
+	},
+	"toggleCards": {
+		"message": "Activar/Desactivar tarjetas"
+	},
+	"toggleControls": {
+		"message": "Activar/Desactivar controles"
+	},
+	"trackWatchedVideos": {
+		"message": "Seguimiento de videos vistos"
+	},
+	"trailerAutoplay": {
+		"message": "Reproducción automática de trailer"
+	},
+	"translations": {
+		"message": "Traducciones"
+	},
+	"transparentBackground": {
+		"message": "Fondo transparente"
+	},
+	"trending": {
+		"message": "Tendencias"
+	},
+	"tryToReloadThePage": {
+		"message": "Intentar recargar la página"
+	},
+	"type": {
+		"message": "Tipo"
+	},
+	"upNextAutoplay": {
+		"message": "Siguiente reproducción automática"
+	},
+	"use24HourFormat": {
+		"message": "Usar formato 24 horas"
+	},
+	"version": {
+		"message": "Versión"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "La descripción del video se expandirá para obtener el nombre de la categoría."
+	},
+	"videoFormats": {
+		"message": "Formatos de video"
+	},
+	"volume": {
+		"message": "Volumen"
+	},
+	"watchLater": {
+		"message": "Ver más tarde"
+	},
+	"watchTime": {
+		"message": "Visualizaciones"
+	},
+	"whenTabIsChanged": {
+		"message": "Al cambiar de pestaña"
+	},
+	"white": {
+		"message": "Blanco"
+	},
+	"windowOpacity": {
+		"message": "Opacidad de la ventana"
+	},
+	"yellow": {
+		"message": "Amarillo"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Encabezado YouTube (izq)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Encabezado YouTube (der)"
+	},
+	"youtubeHomePage": {
+		"message": "Página de inicio de YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Idioma de YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube limita calidad de video a 1080p para el codec h.264"
+	}
 }

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Eemalda kodulehe Shortsid"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Eemaldage Shorts-rull otsingutulemustest"
-    }
+	"hideHomePageShorts": {
+		"message": "Eemalda kodulehe Shortsid"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Eemaldage Shorts-rull otsingutulemustest"
+	}
 }

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "حذف کردن شورت‌های صفحه اصلی"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "حذف کردن ریل Shorts از نتایج جستجو"
-    }
+	"hideHomePageShorts": {
+		"message": "حذف کردن شورت‌های صفحه اصلی"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "حذف کردن ریل Shorts از نتایج جستجو"
+	}
 }

--- a/_locales/fa_IR/messages.json
+++ b/_locales/fa_IR/messages.json
@@ -1,1103 +1,1103 @@
 {
-    "about": {
-        "message": "درباره"
-    },
-    "accept": {
-        "message": "پذیرش"
-    },
-    "activate": {
-        "message": "فعال کردن"
-    },
-    "activateCaptions": {
-        "message": "فعال کردن زیرنویس"
-    },
-    "activated": {
-        "message": "فعال شده"
-    },
-    "activatedFeatures": {
-        "message": "ویژگی‌های فعال شده"
-    },
-    "activateFullscreen": {
-        "message": "فعال کردن تمام صفحه"
-    },
-    "activeFeatures": {
-        "message": "ویژگی‌های فعال من"
-    },
-    "addScrollToTop": {
-        "message": "اضافه کردن «اسکرول به بالا»"
-    },
-    "ads": {
-        "message": "تبلیغات"
-    },
-    "all": {
-        "message": "همه"
-    },
-    "allow": {
-        "message": "اجازه دادن"
-    },
-    "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "تمام تنظیمات شما پاک می‌شوند و قابل بازیابی نیستند"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "تمام میان‌برهای شما پاک می‌شوند و قابل بازیابی نیستند"
-    },
-    "always": {
-        "message": "همیشه"
-    },
-    "alwaysActive": {
-        "message": "همیشه فعال"
-    },
-    "alwaysShowProgressBar": {
-        "message": "همیشه نشان دادن نوار پیشرفت"
-    },
-    "amber": {
-        "message": "عنبری"
-    },
-    "analyzer": {
-        "message": "آنالیزگر"
-    },
-    "animations": {
-        "message": "انیمیشن‌ها"
-    },
-    "appearance": {
-        "message": "ظاهر"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "آیا از صدور داده‌ها اطمینان دارید؟"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "آیا از وارد کردن این داده‌ها اطمینان دارید؟"
-    },
-    "audio": {
-        "message": "صدا"
-    },
-    "audioFormats": {
-        "message": "فرمت های صوتی"
-    },
-    "auto": {
-        "message": "خودکار"
-    },
-    "autoFullscreen": {
-        "message": "تمام صفحه خودکار"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "توقف خودکار در حالی که در تب نیستم"
-    },
-    "autoplay": {
-        "message": "پخش خودکار"
-    },
-    "avoidAv1": {
-        "message": "اجتناب از AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "اجتناب از AV1، VP8، VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "اجتناب از AV1، VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "اجتناب از رندر کردن توسط CPU وقتی ممکن است"
-    },
-    "backgroundColor": {
-        "message": "رنگ پس زمینه"
-    },
-    "backgroundOpacity": {
-        "message": "شفافیت پس زمینه"
-    },
-    "backupAndReset": {
-        "message": "پشتیبان گیری و بازنشانی"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "بر اساس طرح رنگی سیستم"
-    },
-    "belowPlayer": {
-        "message": "زیر پخش کننده"
-    },
-    "bitness": {
-        "message": "بیت"
-    },
-    "black": {
-        "message": "سیاه"
-    },
-    "blockAll": {
-        "message": "خاموش (بلاک یا پرش)"
-    },
-    "blockAv1": {
-        "message": "بلاک AV1"
-    },
-    "blockH264": {
-        "message": "بلاک H.264"
-    },
-    "blocklist": {
-        "message": "لیست سیاه"
-    },
-    "blockMusic": {
-        "message": "پرش تبلیغات در حالی که موسیقی پخش می‌شود"
-    },
-    "blockVp8": {
-        "message": "بلاک VP8"
-    },
-    "blockVp9": {
-        "message": "بلاک VP9"
-    },
-    "blue": {
-        "message": "آبی"
-    },
-    "blueGray": {
-        "message": "آبی خاکستری"
-    },
-    "bluelight": {
-        "message": "آبی روشن"
-    },
-    "brightness": {
-        "message": "روشنایی"
-    },
-    "brown": {
-        "message": "قهوه‌ای"
-    },
-    "browser": {
-        "message": "مرورگر"
-    },
-    "browserVersion": {
-        "message": "نسخه مرورگر"
-    },
-    "bubbles": {
-        "message": "حباب‌ها"
-    },
-    "bug": {
-        "message": "اشکال"
-    },
-    "buttons": {
-        "message": "دکمه‌ها"
-    },
-    "cancel": {
-        "message": "لغو"
-    },
-    "categories": {
-        "message": "دسته‌بندی‌ها"
-    },
-    "channel": {
-        "message": "کانال"
-    },
-    "channels": {
-        "message": "کانال‌ها"
-    },
-    "characterEdgeStyle": {
-        "message": "استایل لبه کاراکتر"
-    },
-    "clip": {
-        "message": "کلیپ"
-    },
-    "clipboard": {
-        "message": "تخته‌برد"
-    },
-    "codecH264": {
-        "message": "کدک H.264"
-    },
-    "codecs": {
-        "message": "کدک‌ها"
-    },
-    "collapsed": {
-        "message": "جمع شده"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "جمع‌بندی بخش‌های اشتراک‌ها (آکاردئون جمع شده)"
-    },
-    "comments": {
-        "message": "نظرات"
-    },
-    "confirmationBeforeClosing": {
-        "message": "تایید قبل از بستن"
-    },
-    "cookies": {
-        "message": "کوکی‌ها"
-    },
-    "cores": {
-        "message": "هسته‌ها"
-    },
-    "cropChapterTitles": {
-        "message": "برش عناوین فصل"
-    },
-    "custom": {
-        "message": "سفارشی"
-    },
-    "customCss": {
-        "message": "CSS سفارشی"
-    },
-    "customJs": {
-        "message": "JS سفارشی"
-    },
-    "customMiniPlayer": {
-        "message": "مینی‌پلیر سفارشی"
-    },
-    "cyan": {
-        "message": "فیروزه‌ای"
-    },
-    "dark": {
-        "message": "تاریک"
-    },
-    "darkTheme": {
-        "message": "تم تاریک"
-    },
-    "dateAndTime": {
-        "message": "تاریخ و زمان"
-    },
-    "dawn": {
-        "message": "طلوع"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "کاهش سرعت پخش"
-    },
-    "decreaseVolume": {
-        "message": "کاهش صدا"
-    },
-    "deepOrange": {
-        "message": "نارنجی عمیق"
-    },
-    "deepPurple": {
-        "message": "بنفش عمیق"
-    },
-    "default": {
-        "message": "پیش فرض"
-    },
-    "defaultChannelTab": {
-        "message": "تب کانال پیش فرض"
-    },
-    "defaultContentCountry": {
-        "message": "کشور (سفر مجازی)"
-    },
-    "defaultPlaybackSpeed": {
-        "message": "سرعت پخش پیش فرض"
-    },
-    "deleteWatchedVideos": {
-        "message": "حذف ویدیوهای تماشا شده"
-    },
-    "deleteYoutubeCookies": {
-        "message": "حذف کوکی‌های YouTube"
-    },
-    "depressed": {
-        "message": "افسرده"
-    },
-    "description": {
-        "message": "توضیحات"
-    },
-    "description_ext": {
-        "message": "تمیز و هوشمند کردن یوتیوب! رنگ ویدیو، عبور از تبلیغات، حجم، سرعت، ابزار کانال، استیل، HD، تبلیغات، مسدود کننده تبلیغات، برچسب ها، کلمات کلیدی، لیست پخش"
-    },
-    "desert": {
-        "message": "بیابان"
-    },
-    "details": {
-        "message": "جزئیات"
-    },
-    "developerOptions": {
-        "message": "گزینه‌های توسعه‌دهنده"
-    },
-    "device": {
-        "message": "دستگاه"
-    },
-    "dim": {
-        "message": "تاریک"
-    },
-    "disabled": {
-        "message": "غیرفعال"
-    },
-    "dislike": {
-        "message": "عدم پسند"
-    },
-    "displayDayOfTheWeak": {
-        "message": "نمایش روز هفته"
-    },
-    "donate": {
-        "message": "کمک مالی"
-    },
-    "doNotChange": {
-        "message": "تغییر نده"
-    },
-    "download": {
-        "message": "دانلود"
-    },
-    "draggable": {
-        "message": "قابل جابجایی"
-    },
-    "dropShadow": {
-        "message": "سایه نما"
-    },
-    "durationWithSpeed": {
-        "message": "نمایش زمان باقی‌مانده با توجه به سرعت پخش"
-    },
-    "email": {
-        "message": "ایمیل"
-    },
-    "empty": {
-        "message": "خالی"
-    },
-    "enabled": {
-        "message": "فعال"
-    },
-    "enabledForced": {
-        "message": "فعال (اجباری)"
-    },
-    "expanded": {
-        "message": "گسترده"
-    },
-    "exportSettings": {
-        "message": "صدور تنظیمات"
-    },
-    "extension": {
-        "message": "افزونه"
-    },
-    "file": {
-        "message": "فایل"
-    },
-    "filters": {
-        "message": "فیلترها"
-    },
-    "fitToWindow": {
-        "message": "در گزینه قبلی ('تناسب با پنجره')"
-    },
-    "flash": {
-        "message": "فلش"
-    },
-    "font": {
-        "message": "قلم"
-    },
-    "fontColor": {
-        "message": "رنگ قلم"
-    },
-    "fontFamily": {
-        "message": "خانواده قلم"
-    },
-    "fontOpacity": {
-        "message": "تاریکی قلم"
-    },
-    "fontSize": {
-        "message": "اندازه قلم"
-    },
-    "footer": {
-        "message": "پاورقی"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "سرعت پخش اجباری، سرعت دیدن"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(سرعت پخش اجباری حتی برای موسیقی؟)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "اجبار پخش ویدیو از ابتدا"
-    },
-    "forcedTheaterMode": {
-        "message": "حالت تئاتر اجباری"
-    },
-    "forcedVolume": {
-        "message": "حجم اجباری"
-    },
-    "forceSDR": {
-        "message": "هرگز HDR، بلکه SDR"
-    },
-    "foundABug": {
-        "message": "باگی پیدا کردید؟"
-    },
-    "fullWindow": {
-        "message": "ارتفاع کامل"
-    },
-    "general": {
-        "message": "عمومی"
-    },
-    "geoPreference": {
-        "message": "ترجیح جغرافیایی"
-    },
-    "github": {
-        "message": "گیت‌هاب"
-    },
-    "googleApiKey": {
-        "message": "کلید API Google"
-    },
-    "goToSearchBox": {
-        "message": "برو به جعبه جستجو"
-    },
-    "green": {
-        "message": "سبز"
-    },
-    "hardwareInformation": {
-        "message": "اطلاعات سخت‌افزاری"
-    },
-    "hdThumbnail": {
-        "message": "تصویر بندانگشتی HD"
-    },
-    "header": {
-        "message": "سربرگ"
-    },
-    "hidden": {
-        "message": "پنهان شده"
-    },
-    "hiddenOnVideoPage": {
-        "message": "پنهان در صفحه ویدیو"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "مخفی کردن تصاویر کوچک متحرک"
-    },
-    "hideAnnotations": {
-        "message": "مخفی کردن حاشیه نویسی‌ها"
-    },
-    "hideCards": {
-        "message": "مخفی کردن کارت‌ها"
-    },
-    "hideCategories": {
-        "message": "مخفی کردن دسته‌بندی‌ها"
-    },
-    "hideCommentsCount": {
-        "message": "مخفی کردن تعداد نظرات"
-    },
-    "hideCountryCode": {
-        "message": "مخفی کردن کد کشور"
-    },
-    "hideDate": {
-        "message": "مخفی کردن تاریخ"
-    },
-    "hideDetailButton": {
-        "message": "دکمه‌ها"
-    },
-    "hideDetails": {
-        "message": "مخفی کردن جزئیات"
-    },
-    "hideEndscreen": {
-        "message": "مخفی کردن انتهای ویدیو"
-    },
-    "hideFeaturedContent": {
-        "message": "مخفی کردن محتوای ویژه"
-    },
-    "hideFooter": {
-        "message": "مخفی کردن پانویس"
-    },
-    "hideGradientBottom": {
-        "message": "مخفی کردن سایه در اطراف نوار پخش کننده"
-    },
-    "hidePlayerControlsBar": {
-        "message": "مخفی کردن نوار کنترل پخش کننده"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "مخفی کردن دکمه‌های نوار کنترل پخش کننده"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "مخفی کردن گزینه‌های نوار کنترل پخش کننده"
-    },
-    "hidePlaylist": {
-        "message": "مخفی کردن لیست پخش"
-    },
-    "hideRightButtons": {
-        "message": "مخفی کردن دکمه‌های سمت راست"
-    },
-    "hideScrollForDetails": {
-        "message": "مخفی کردن «پیمایش برای جزئیات»"
-    },
-    "hideSkipOverlay": {
-        "message": "مخفی کردن انیمیشن پرش پنج ثانیه‌ای"
-    },
-    "hideThumbnailOverlay": {
-        "message": "پنهان کردن دکمه ها در بندانگشتی ها"
-    },
-    "hideThumbnails": {
-        "message": "پنهان کردن بندانگشتی ها"
-    },
-    "hideViewsCount": {
-        "message": "پنهان کردن تعداد بازدیدها"
-    },
-    "hideVoiceSearchButton": {
-        "message": "پنهان کردن دکمه جستجوی صوتی"
-    },
-    "high": {
-        "message": "بالا"
-    },
-    "history": {
-        "message": "تاریخچه"
-    },
-    "home": {
-        "message": "خانه"
-    },
-    "homeScreen": {
-        "message": "صفحه خانه"
-    },
-    "hover": {
-        "message": "هاور"
-    },
-    "hoverOnVideoPage": {
-        "message": "هاور در صفحه ویدیو"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "نشان دادن سن ویدیو (چقدر وقت قبل آپلود شده)"
-    },
-    "icons": {
-        "message": "آیکون ها"
-    },
-    "iconsOnly": {
-        "message": "فقط آیکون"
-    },
-    "importSettings": {
-        "message": "ورود تنظیمات"
-    },
-    "improvedtubeButtons": {
-        "message": "دکمه های ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "آیکون ImprovedTube در YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "زبان ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "نسخه ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "بهبود لوگو"
-    },
-    "increasePlaybackSpeed": {
-        "message": "افزایش سرعت پخش"
-    },
-    "increaseVolume": {
-        "message": "افزایش صدا"
-    },
-    "indigo": {
-        "message": "آبی نفتی"
-    },
-    "items": {
-        "message": "موارد"
-    },
-    "language": {
-        "message": "زبان"
-    },
-    "languages": {
-        "message": "زبان ها"
-    },
-    "layerAnimationScale": {
-        "message": "مقیاس انیمیشن لایه"
-    },
-    "layout": {
-        "message": "طرح بندی"
-    },
-    "legacyYoutube": {
-        "message": "YouTube قدیمی"
-    },
-    "library": {
-        "message": "کتابخانه"
-    },
-    "light": {
-        "message": "روشن"
-    },
-    "lightBlue": {
-        "message": "آبی روشن"
-    },
-    "lightGreen": {
-        "message": "سبز روشن"
-    },
-    "like": {
-        "message": "پسندیدن"
-    },
-    "liked": {
-        "message": "پسندیده شد"
-    },
-    "likes": {
-        "message": "پسندیده‌ها"
-    },
-    "lime": {
-        "message": "لیمویی"
-    },
-    "limitPageWidth": {
-        "message": "محدود کردن عرض صفحه"
-    },
-    "list": {
-        "message": "لیست"
-    },
-    "liveChat": {
-        "message": "گفتگوی زنده"
-    },
-    "liveChatType": {
-        "message": "نوع گفتگوی زنده"
-    },
-    "location": {
-        "message": "مکان"
-    },
-    "loop": {
-        "message": "تکرار"
-    },
-    "loudnessNormalization": {
-        "message": "تنظیم صدای بلند"
-    },
-    "low": {
-        "message": "پایین"
-    },
-    "markWatchedVideos": {
-        "message": "نشانه گذاری ویدیوهای تماشا شده"
-    },
-    "medium": {
-        "message": "متوسط"
-    },
-    "mixer": {
-        "message": "میکسر"
-    },
-    "more": {
-        "message": "بیشتر"
-    },
-    "mostViewedChannels": {
-        "message": "پربازدیدترین کانال‌ها"
-    },
-    "moveSidebarLeft": {
-        "message": "به سمت چپ حرکت کن!"
-    },
-    "moveThumbnailsRight": {
-        "message": "تصاویر کوچک به سمت راست حرکت کن!"
-    },
-    "myColors": {
-        "message": "رنگ‌های من"
-    },
-    "name": {
-        "message": "نام"
-    },
-    "nativeMiniPlayer": {
-        "message": "پخش کننده کوچک محلی"
-    },
-    "new": {
-        "message": "جدید"
-    },
-    "nextVideo": {
-        "message": "ویدیو بعدی"
-    },
-    "night": {
-        "message": "شب"
-    },
-    "nightMode": {
-        "message": "حالت شب"
-    },
-    "noActiveFeatures": {
-        "message": "هیچ ویژگی فعالی وجود ندارد"
-    },
-    "none": {
-        "message": "هیچکدام"
-    },
-    "noOpenVideoTabs": {
-        "message": "هیچ تب ویدیوی بازی وجود ندارد"
-    },
-    "normal": {
-        "message": "عادی"
-    },
-    "off": {
-        "message": "خاموش"
-    },
-    "ok": {
-        "message": "تایید"
-    },
-    "old": {
-        "message": "قدیمی"
-    },
-    "onAllVideos": {
-        "message": "روشن"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "فقط فعال در یوتیوب"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "توقف در حالی که دارم ویدیوی دومی را تماشا می‌کنم"
-    },
-    "onSubscribedChannels": {
-        "message": "خاموش، به جز کانال‌های مشترک شده من"
-    },
-    "openPopupPlayer": {
-        "message": "باز کردن ویدیو / لیست پخش در پنجره‌ای جدید"
-    },
-    "orange": {
-        "message": "نارنجی"
-    },
-    "os": {
-        "message": "سیستم عامل"
-    },
-    "other": {
-        "message": "دیگر"
-    },
-    "outline": {
-        "message": "حاشیه"
-    },
-    "overlay": {
-        "message": "نوار روی ویدیو"
-    },
-    "permissions": {
-        "message": "مجوزها"
-    },
-    "pictureInPicture": {
-        "message": "تصویر در تصویر"
-    },
-    "pink": {
-        "message": "صورتی"
-    },
-    "plain": {
-        "message": "ساده"
-    },
-    "platform": {
-        "message": "پلتفرم"
-    },
-    "playAllButton": {
-        "message": "دکمه پخش همه"
-    },
-    "playbackSpeed": {
-        "message": "سرعت پخش"
-    },
-    "player": {
-        "message": "پخش کننده"
-    },
-    "playerColor": {
-        "message": "رنگ نوار پیشرفت"
-    },
-    "playerSize": {
-        "message": "اندازه پخش کننده"
-    },
-    "playlist": {
-        "message": "لیست پخش"
-    },
-    "playlists": {
-        "message": "لیست‌های پخش"
-    },
-    "playPause": {
-        "message": "پخش / توقف"
-    },
-    "popupPlayer": {
-        "message": "پخش کننده پنجره‌ای"
-    },
-    "popupWindowButtons": {
-        "message": "افزودن دکمه پخش کننده پنجره‌ای به هر بندانگشتی"
-    },
-    "position": {
-        "message": "موقعیت"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "هر کلیدی را فشار دهید یا از اسکرول موس استفاده کنید."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "هر کلیدی را فشار دهید یا از اسکرول موس استفاده کنید"
-    },
-    "previousVideo": {
-        "message": "ویدیو قبلی"
-    },
-    "primaryColor": {
-        "message": "رنگ اصلی"
-    },
-    "purple": {
-        "message": "بنفش"
-    },
-    "quality": {
-        "message": "کیفیت"
-    },
-    "raised": {
-        "message": "بالا بردن"
-    },
-    "ram": {
-        "message": "حافظه RAM"
-    },
-    "rateMe": {
-        "message": "امتیاز دهید"
-    },
-    "rateUs": {
-        "message": "امتیاز دهید"
-    },
-    "red": {
-        "message": "قرمز"
-    },
-    "redDislikeButton": {
-        "message": "قرمز در هنگام نپسندیدن"
-    },
-    "relatedVideos": {
-        "message": "ویدیوهای مرتبط"
-    },
-    "remote": {
-        "message": "پخش در تلویزیون"
-    },
-    "removeRelatedSearchResults": {
-        "message": "حذف نتایج جستجوی مرتبط"
-    },
-    "repeat": {
-        "message": "تکرار"
-    },
-    "report": {
-        "message": "گزارش"
-    },
-    "reset": {
-        "message": "بازنشانی"
-    },
-    "resetAllSettings": {
-        "message": "بازنشانی تمام تنظیمات"
-    },
-    "resetAllShortcuts": {
-        "message": "بازنشانی همه میانبرها"
-    },
-    "reverse": {
-        "message": "برعکس کردن"
-    },
-    "rotate": {
-        "message": "چرخاندن"
-    },
-    "save": {
-        "message": "ذخیره"
-    },
-    "saveAs": {
-        "message": "ذخیره به عنوان"
-    },
-    "schedule": {
-        "message": "زمانبندی"
-    },
-    "screen": {
-        "message": "صفحه نمایش"
-    },
-    "screenshot": {
-        "message": "عکس از صفحه"
-    },
-    "scrollBar": {
-        "message": "نوار پیمایش"
-    },
-    "sd": {
-        "message": "کیفیت پایین"
-    },
-    "search": {
-        "message": "جستجو"
-    },
-    "searchBarOnly": {
-        "message": "فقط نوار جستجو"
-    },
-    "seekBackward10Seconds": {
-        "message": "جستجو به عقب 10 ثانیه"
-    },
-    "seekForward10Seconds": {
-        "message": "جستجو به جلو 10 ثانیه"
-    },
-    "seekNextChapter": {
-        "message": "جستجو به فصل بعدی"
-    },
-    "seekPreviousChapter": {
-        "message": "جستجو به فصل قبلی"
-    },
-    "settings": {
-        "message": "تنظیمات"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "تنظیمات با موفقیت وارد شد"
-    },
-    "share": {
-        "message": "اشتراک‌گذاری"
-    },
-    "shortcuts": {
-        "message": "میانبرها"
-    },
-    "showCardsOnMouseHover": {
-        "message": "نمایش کارت‌ها با حرکت ماوس"
-    },
-    "showChannelVideosCount": {
-        "message": "نمایش تعداد ویدیوهای کانال"
-    },
-    "showLess": {
-        "message": "نمایش کمتر"
-    },
-    "showMore": {
-        "message": "نمایش بیشتر"
-    },
-    "showRemainingDuration": {
-        "message": "نمایش مدت زمان باقی‌مانده ویدیو"
-    },
-    "showVersion": {
-        "message": "نمایش نسخه"
-    },
-    "shuffle": {
-        "message": "تصادفی"
-    },
-    "sidebar": {
-        "message": "نوار کناری"
-    },
-    "softwareInformation": {
-        "message": "اطلاعات نرم‌افزار"
-    },
-    "spacebar": {
-        "message": "دکمه فضا"
-    },
-    "squaredUserImages": {
-        "message": "تصاویر کاربران مربع"
-    },
-    "static": {
-        "message": "ثابت"
-    },
-    "statsForNerds": {
-        "message": "نمایش آمار برای علاقه‌مندان"
-    },
-    "step": {
-        "message": "گام"
-    },
-    "stop": {
-        "message": "توقف"
-    },
-    "style": {
-        "message": "استیل"
-    },
-    "styles": {
-        "message": "استایل‌ها"
-    },
-    "subscribe": {
-        "message": "اشتراک‌گیری"
-    },
-    "subscriptions": {
-        "message": "اشتراک‌ها"
-    },
-    "subtitles": {
-        "message": "زیرنویس‌ها"
-    },
-    "sunset": {
-        "message": "غروب"
-    },
-    "sunsetToSunrise": {
-        "message": "از غروب تا طلوع"
-    },
-    "systemPeferenceDark": {
-        "message": "ترجیحات سیستم: تیره"
-    },
-    "systemPeferenceLight": {
-        "message": "ترجیحات سیستم: روشن"
-    },
-    "teal": {
-        "message": "فیروزه‌ای"
-    },
-    "textColor": {
-        "message": "رنگ متن"
-    },
-    "thanks": {
-        "message": "با تشکر"
-    },
-    "themes": {
-        "message": "تم‌ها"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "این کار کلیه کوکی ها را حذف می‌کند."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "این کار تمام ویدیوهای تماشا شده را حذف می‌کند."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "این کار کلیه کوکی‌های یوتیوب را حذف می‌کند."
-    },
-    "thisWillResetAllSettings": {
-        "message": "این کار تمام تنظیمات را بازنشانی می‌کند."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "این کار تمام میانبرها را بازنشانی می‌کند."
-    },
-    "thumbnails": {
-        "message": "تصاویر کوچک"
-    },
-    "thumbnailsQuality": {
-        "message": "کیفیت تصاویر کوچک"
-    },
-    "timeFrom": {
-        "message": "زمان از"
-    },
-    "timeTo": {
-        "message": "زمان تا"
-    },
-    "todayAt": {
-        "message": "امروز در"
-    },
-    "toggleAutoplay": {
-        "message": "تغییر وضعیت پخش خودکار"
-    },
-    "toggleCards": {
-        "message": "تغییر وضعیت کارت‌ها"
-    },
-    "toggleControls": {
-        "message": "تغییر وضعیت کنترل‌های پخش کننده"
-    },
-    "topChat": {
-        "message": "گفتگوی برتر"
-    },
-    "trackWatchedVideos": {
-        "message": "پیگیری ویدیوهای تماشا شده"
-    },
-    "trailerAutoplay": {
-        "message": "پخش خودکار تریلر"
-    },
-    "translations": {
-        "message": "ترجمه‌ها"
-    },
-    "transparentBackground": {
-        "message": "پس‌زمینه شفاف"
-    },
-    "trending": {
-        "message": "محبوبیت"
-    },
-    "tryToReloadThePage": {
-        "message": "سعی در بارگذاری مجدد صفحه"
-    },
-    "type": {
-        "message": "نوع"
-    },
-    "upNextAutoplay": {
-        "message": "پخش خودکار بعدی"
-    },
-    "use24HourFormat": {
-        "message": "استفاده از فرمت ۲۴ ساعته"
-    },
-    "version": {
-        "message": "نسخه"
-    },
-    "video": {
-        "message": "ویدیو"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "توضیحات ویدیو برای دریافت نام دسته بندی گسترش خواهد یافت"
-    },
-    "videoFormats": {
-        "message": "فرمت‌های ویدیو"
-    },
-    "videos": {
-        "message": "ویدیوها"
-    },
-    "viewMode": {
-        "message": "حالت نمایش"
-    },
-    "volume": {
-        "message": "صدا"
-    },
-    "watchedVideos": {
-        "message": "ویدیوهای تماشا شده"
-    },
-    "watchLater": {
-        "message": "تماشای بعدی"
-    },
-    "watchTime": {
-        "message": "زمان تماشا"
-    },
-    "whenPaused": {
-        "message": "وقتی مکث شود"
-    },
-    "whenTabIsChanged": {
-        "message": "وقتی تب تغییر کند"
-    },
-    "white": {
-        "message": "سفید"
-    },
-    "windowColor": {
-        "message": "رنگ پنجره"
-    },
-    "windowOpacity": {
-        "message": "شفافیت پنجره"
-    },
-    "yellow": {
-        "message": "زرد"
-    },
-    "youtubeHeaderLeft": {
-        "message": "سربرگ یوتیوب (چپ)"
-    },
-    "youtubeHeaderRight": {
-        "message": "سربرگ یوتیوب (راست)"
-    },
-    "youtubeHomePage": {
-        "message": "صفحه اصلی یوتیوب"
-    },
-    "youtubeLanguage": {
-        "message": "زبان یوتیوب"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "یوتیوب محدودیت کیفیت ویدیو را برای کدک h.264 به 1080p قرار می دهد"
-    }
+	"about": {
+		"message": "درباره"
+	},
+	"accept": {
+		"message": "پذیرش"
+	},
+	"activate": {
+		"message": "فعال کردن"
+	},
+	"activateCaptions": {
+		"message": "فعال کردن زیرنویس"
+	},
+	"activated": {
+		"message": "فعال شده"
+	},
+	"activatedFeatures": {
+		"message": "ویژگی‌های فعال شده"
+	},
+	"activateFullscreen": {
+		"message": "فعال کردن تمام صفحه"
+	},
+	"activeFeatures": {
+		"message": "ویژگی‌های فعال من"
+	},
+	"addScrollToTop": {
+		"message": "اضافه کردن «اسکرول به بالا»"
+	},
+	"ads": {
+		"message": "تبلیغات"
+	},
+	"all": {
+		"message": "همه"
+	},
+	"allow": {
+		"message": "اجازه دادن"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "تمام تنظیمات شما پاک می‌شوند و قابل بازیابی نیستند"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "تمام میان‌برهای شما پاک می‌شوند و قابل بازیابی نیستند"
+	},
+	"always": {
+		"message": "همیشه"
+	},
+	"alwaysActive": {
+		"message": "همیشه فعال"
+	},
+	"alwaysShowProgressBar": {
+		"message": "همیشه نشان دادن نوار پیشرفت"
+	},
+	"amber": {
+		"message": "عنبری"
+	},
+	"analyzer": {
+		"message": "آنالیزگر"
+	},
+	"animations": {
+		"message": "انیمیشن‌ها"
+	},
+	"appearance": {
+		"message": "ظاهر"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "آیا از صدور داده‌ها اطمینان دارید؟"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "آیا از وارد کردن این داده‌ها اطمینان دارید؟"
+	},
+	"audio": {
+		"message": "صدا"
+	},
+	"audioFormats": {
+		"message": "فرمت های صوتی"
+	},
+	"auto": {
+		"message": "خودکار"
+	},
+	"autoFullscreen": {
+		"message": "تمام صفحه خودکار"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "توقف خودکار در حالی که در تب نیستم"
+	},
+	"autoplay": {
+		"message": "پخش خودکار"
+	},
+	"avoidAv1": {
+		"message": "اجتناب از AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "اجتناب از AV1، VP8، VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "اجتناب از AV1، VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "اجتناب از رندر کردن توسط CPU وقتی ممکن است"
+	},
+	"backgroundColor": {
+		"message": "رنگ پس زمینه"
+	},
+	"backgroundOpacity": {
+		"message": "شفافیت پس زمینه"
+	},
+	"backupAndReset": {
+		"message": "پشتیبان گیری و بازنشانی"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "بر اساس طرح رنگی سیستم"
+	},
+	"belowPlayer": {
+		"message": "زیر پخش کننده"
+	},
+	"bitness": {
+		"message": "بیت"
+	},
+	"black": {
+		"message": "سیاه"
+	},
+	"blockAll": {
+		"message": "خاموش (بلاک یا پرش)"
+	},
+	"blockAv1": {
+		"message": "بلاک AV1"
+	},
+	"blockH264": {
+		"message": "بلاک H.264"
+	},
+	"blocklist": {
+		"message": "لیست سیاه"
+	},
+	"blockMusic": {
+		"message": "پرش تبلیغات در حالی که موسیقی پخش می‌شود"
+	},
+	"blockVp8": {
+		"message": "بلاک VP8"
+	},
+	"blockVp9": {
+		"message": "بلاک VP9"
+	},
+	"blue": {
+		"message": "آبی"
+	},
+	"blueGray": {
+		"message": "آبی خاکستری"
+	},
+	"bluelight": {
+		"message": "آبی روشن"
+	},
+	"brightness": {
+		"message": "روشنایی"
+	},
+	"brown": {
+		"message": "قهوه‌ای"
+	},
+	"browser": {
+		"message": "مرورگر"
+	},
+	"browserVersion": {
+		"message": "نسخه مرورگر"
+	},
+	"bubbles": {
+		"message": "حباب‌ها"
+	},
+	"bug": {
+		"message": "اشکال"
+	},
+	"buttons": {
+		"message": "دکمه‌ها"
+	},
+	"cancel": {
+		"message": "لغو"
+	},
+	"categories": {
+		"message": "دسته‌بندی‌ها"
+	},
+	"channel": {
+		"message": "کانال"
+	},
+	"channels": {
+		"message": "کانال‌ها"
+	},
+	"characterEdgeStyle": {
+		"message": "استایل لبه کاراکتر"
+	},
+	"clip": {
+		"message": "کلیپ"
+	},
+	"clipboard": {
+		"message": "تخته‌برد"
+	},
+	"codecH264": {
+		"message": "کدک H.264"
+	},
+	"codecs": {
+		"message": "کدک‌ها"
+	},
+	"collapsed": {
+		"message": "جمع شده"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "جمع‌بندی بخش‌های اشتراک‌ها (آکاردئون جمع شده)"
+	},
+	"comments": {
+		"message": "نظرات"
+	},
+	"confirmationBeforeClosing": {
+		"message": "تایید قبل از بستن"
+	},
+	"cookies": {
+		"message": "کوکی‌ها"
+	},
+	"cores": {
+		"message": "هسته‌ها"
+	},
+	"cropChapterTitles": {
+		"message": "برش عناوین فصل"
+	},
+	"custom": {
+		"message": "سفارشی"
+	},
+	"customCss": {
+		"message": "CSS سفارشی"
+	},
+	"customJs": {
+		"message": "JS سفارشی"
+	},
+	"customMiniPlayer": {
+		"message": "مینی‌پلیر سفارشی"
+	},
+	"cyan": {
+		"message": "فیروزه‌ای"
+	},
+	"dark": {
+		"message": "تاریک"
+	},
+	"darkTheme": {
+		"message": "تم تاریک"
+	},
+	"dateAndTime": {
+		"message": "تاریخ و زمان"
+	},
+	"dawn": {
+		"message": "طلوع"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "کاهش سرعت پخش"
+	},
+	"decreaseVolume": {
+		"message": "کاهش صدا"
+	},
+	"deepOrange": {
+		"message": "نارنجی عمیق"
+	},
+	"deepPurple": {
+		"message": "بنفش عمیق"
+	},
+	"default": {
+		"message": "پیش فرض"
+	},
+	"defaultChannelTab": {
+		"message": "تب کانال پیش فرض"
+	},
+	"defaultContentCountry": {
+		"message": "کشور (سفر مجازی)"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "سرعت پخش پیش فرض"
+	},
+	"deleteWatchedVideos": {
+		"message": "حذف ویدیوهای تماشا شده"
+	},
+	"deleteYoutubeCookies": {
+		"message": "حذف کوکی‌های YouTube"
+	},
+	"depressed": {
+		"message": "افسرده"
+	},
+	"description": {
+		"message": "توضیحات"
+	},
+	"description_ext": {
+		"message": "تمیز و هوشمند کردن یوتیوب! رنگ ویدیو، عبور از تبلیغات، حجم، سرعت، ابزار کانال، استیل، HD، تبلیغات، مسدود کننده تبلیغات، برچسب ها، کلمات کلیدی، لیست پخش"
+	},
+	"desert": {
+		"message": "بیابان"
+	},
+	"details": {
+		"message": "جزئیات"
+	},
+	"developerOptions": {
+		"message": "گزینه‌های توسعه‌دهنده"
+	},
+	"device": {
+		"message": "دستگاه"
+	},
+	"dim": {
+		"message": "تاریک"
+	},
+	"disabled": {
+		"message": "غیرفعال"
+	},
+	"dislike": {
+		"message": "عدم پسند"
+	},
+	"displayDayOfTheWeak": {
+		"message": "نمایش روز هفته"
+	},
+	"donate": {
+		"message": "کمک مالی"
+	},
+	"doNotChange": {
+		"message": "تغییر نده"
+	},
+	"download": {
+		"message": "دانلود"
+	},
+	"draggable": {
+		"message": "قابل جابجایی"
+	},
+	"dropShadow": {
+		"message": "سایه نما"
+	},
+	"durationWithSpeed": {
+		"message": "نمایش زمان باقی‌مانده با توجه به سرعت پخش"
+	},
+	"email": {
+		"message": "ایمیل"
+	},
+	"empty": {
+		"message": "خالی"
+	},
+	"enabled": {
+		"message": "فعال"
+	},
+	"enabledForced": {
+		"message": "فعال (اجباری)"
+	},
+	"expanded": {
+		"message": "گسترده"
+	},
+	"exportSettings": {
+		"message": "صدور تنظیمات"
+	},
+	"extension": {
+		"message": "افزونه"
+	},
+	"file": {
+		"message": "فایل"
+	},
+	"filters": {
+		"message": "فیلترها"
+	},
+	"fitToWindow": {
+		"message": "در گزینه قبلی ('تناسب با پنجره')"
+	},
+	"flash": {
+		"message": "فلش"
+	},
+	"font": {
+		"message": "قلم"
+	},
+	"fontColor": {
+		"message": "رنگ قلم"
+	},
+	"fontFamily": {
+		"message": "خانواده قلم"
+	},
+	"fontOpacity": {
+		"message": "تاریکی قلم"
+	},
+	"fontSize": {
+		"message": "اندازه قلم"
+	},
+	"footer": {
+		"message": "پاورقی"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "سرعت پخش اجباری، سرعت دیدن"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(سرعت پخش اجباری حتی برای موسیقی؟)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "اجبار پخش ویدیو از ابتدا"
+	},
+	"forcedTheaterMode": {
+		"message": "حالت تئاتر اجباری"
+	},
+	"forcedVolume": {
+		"message": "حجم اجباری"
+	},
+	"forceSDR": {
+		"message": "هرگز HDR، بلکه SDR"
+	},
+	"foundABug": {
+		"message": "باگی پیدا کردید؟"
+	},
+	"fullWindow": {
+		"message": "ارتفاع کامل"
+	},
+	"general": {
+		"message": "عمومی"
+	},
+	"geoPreference": {
+		"message": "ترجیح جغرافیایی"
+	},
+	"github": {
+		"message": "گیت‌هاب"
+	},
+	"googleApiKey": {
+		"message": "کلید API Google"
+	},
+	"goToSearchBox": {
+		"message": "برو به جعبه جستجو"
+	},
+	"green": {
+		"message": "سبز"
+	},
+	"hardwareInformation": {
+		"message": "اطلاعات سخت‌افزاری"
+	},
+	"hdThumbnail": {
+		"message": "تصویر بندانگشتی HD"
+	},
+	"header": {
+		"message": "سربرگ"
+	},
+	"hidden": {
+		"message": "پنهان شده"
+	},
+	"hiddenOnVideoPage": {
+		"message": "پنهان در صفحه ویدیو"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "مخفی کردن تصاویر کوچک متحرک"
+	},
+	"hideAnnotations": {
+		"message": "مخفی کردن حاشیه نویسی‌ها"
+	},
+	"hideCards": {
+		"message": "مخفی کردن کارت‌ها"
+	},
+	"hideCategories": {
+		"message": "مخفی کردن دسته‌بندی‌ها"
+	},
+	"hideCommentsCount": {
+		"message": "مخفی کردن تعداد نظرات"
+	},
+	"hideCountryCode": {
+		"message": "مخفی کردن کد کشور"
+	},
+	"hideDate": {
+		"message": "مخفی کردن تاریخ"
+	},
+	"hideDetailButton": {
+		"message": "دکمه‌ها"
+	},
+	"hideDetails": {
+		"message": "مخفی کردن جزئیات"
+	},
+	"hideEndscreen": {
+		"message": "مخفی کردن انتهای ویدیو"
+	},
+	"hideFeaturedContent": {
+		"message": "مخفی کردن محتوای ویژه"
+	},
+	"hideFooter": {
+		"message": "مخفی کردن پانویس"
+	},
+	"hideGradientBottom": {
+		"message": "مخفی کردن سایه در اطراف نوار پخش کننده"
+	},
+	"hidePlayerControlsBar": {
+		"message": "مخفی کردن نوار کنترل پخش کننده"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "مخفی کردن دکمه‌های نوار کنترل پخش کننده"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "مخفی کردن گزینه‌های نوار کنترل پخش کننده"
+	},
+	"hidePlaylist": {
+		"message": "مخفی کردن لیست پخش"
+	},
+	"hideRightButtons": {
+		"message": "مخفی کردن دکمه‌های سمت راست"
+	},
+	"hideScrollForDetails": {
+		"message": "مخفی کردن «پیمایش برای جزئیات»"
+	},
+	"hideSkipOverlay": {
+		"message": "مخفی کردن انیمیشن پرش پنج ثانیه‌ای"
+	},
+	"hideThumbnailOverlay": {
+		"message": "پنهان کردن دکمه ها در بندانگشتی ها"
+	},
+	"hideThumbnails": {
+		"message": "پنهان کردن بندانگشتی ها"
+	},
+	"hideViewsCount": {
+		"message": "پنهان کردن تعداد بازدیدها"
+	},
+	"hideVoiceSearchButton": {
+		"message": "پنهان کردن دکمه جستجوی صوتی"
+	},
+	"high": {
+		"message": "بالا"
+	},
+	"history": {
+		"message": "تاریخچه"
+	},
+	"home": {
+		"message": "خانه"
+	},
+	"homeScreen": {
+		"message": "صفحه خانه"
+	},
+	"hover": {
+		"message": "هاور"
+	},
+	"hoverOnVideoPage": {
+		"message": "هاور در صفحه ویدیو"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "نشان دادن سن ویدیو (چقدر وقت قبل آپلود شده)"
+	},
+	"icons": {
+		"message": "آیکون ها"
+	},
+	"iconsOnly": {
+		"message": "فقط آیکون"
+	},
+	"importSettings": {
+		"message": "ورود تنظیمات"
+	},
+	"improvedtubeButtons": {
+		"message": "دکمه های ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "آیکون ImprovedTube در YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "زبان ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "نسخه ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "بهبود لوگو"
+	},
+	"increasePlaybackSpeed": {
+		"message": "افزایش سرعت پخش"
+	},
+	"increaseVolume": {
+		"message": "افزایش صدا"
+	},
+	"indigo": {
+		"message": "آبی نفتی"
+	},
+	"items": {
+		"message": "موارد"
+	},
+	"language": {
+		"message": "زبان"
+	},
+	"languages": {
+		"message": "زبان ها"
+	},
+	"layerAnimationScale": {
+		"message": "مقیاس انیمیشن لایه"
+	},
+	"layout": {
+		"message": "طرح بندی"
+	},
+	"legacyYoutube": {
+		"message": "YouTube قدیمی"
+	},
+	"library": {
+		"message": "کتابخانه"
+	},
+	"light": {
+		"message": "روشن"
+	},
+	"lightBlue": {
+		"message": "آبی روشن"
+	},
+	"lightGreen": {
+		"message": "سبز روشن"
+	},
+	"like": {
+		"message": "پسندیدن"
+	},
+	"liked": {
+		"message": "پسندیده شد"
+	},
+	"likes": {
+		"message": "پسندیده‌ها"
+	},
+	"lime": {
+		"message": "لیمویی"
+	},
+	"limitPageWidth": {
+		"message": "محدود کردن عرض صفحه"
+	},
+	"list": {
+		"message": "لیست"
+	},
+	"liveChat": {
+		"message": "گفتگوی زنده"
+	},
+	"liveChatType": {
+		"message": "نوع گفتگوی زنده"
+	},
+	"location": {
+		"message": "مکان"
+	},
+	"loop": {
+		"message": "تکرار"
+	},
+	"loudnessNormalization": {
+		"message": "تنظیم صدای بلند"
+	},
+	"low": {
+		"message": "پایین"
+	},
+	"markWatchedVideos": {
+		"message": "نشانه گذاری ویدیوهای تماشا شده"
+	},
+	"medium": {
+		"message": "متوسط"
+	},
+	"mixer": {
+		"message": "میکسر"
+	},
+	"more": {
+		"message": "بیشتر"
+	},
+	"mostViewedChannels": {
+		"message": "پربازدیدترین کانال‌ها"
+	},
+	"moveSidebarLeft": {
+		"message": "به سمت چپ حرکت کن!"
+	},
+	"moveThumbnailsRight": {
+		"message": "تصاویر کوچک به سمت راست حرکت کن!"
+	},
+	"myColors": {
+		"message": "رنگ‌های من"
+	},
+	"name": {
+		"message": "نام"
+	},
+	"nativeMiniPlayer": {
+		"message": "پخش کننده کوچک محلی"
+	},
+	"new": {
+		"message": "جدید"
+	},
+	"nextVideo": {
+		"message": "ویدیو بعدی"
+	},
+	"night": {
+		"message": "شب"
+	},
+	"nightMode": {
+		"message": "حالت شب"
+	},
+	"noActiveFeatures": {
+		"message": "هیچ ویژگی فعالی وجود ندارد"
+	},
+	"none": {
+		"message": "هیچکدام"
+	},
+	"noOpenVideoTabs": {
+		"message": "هیچ تب ویدیوی بازی وجود ندارد"
+	},
+	"normal": {
+		"message": "عادی"
+	},
+	"off": {
+		"message": "خاموش"
+	},
+	"ok": {
+		"message": "تایید"
+	},
+	"old": {
+		"message": "قدیمی"
+	},
+	"onAllVideos": {
+		"message": "روشن"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "فقط فعال در یوتیوب"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "توقف در حالی که دارم ویدیوی دومی را تماشا می‌کنم"
+	},
+	"onSubscribedChannels": {
+		"message": "خاموش، به جز کانال‌های مشترک شده من"
+	},
+	"openPopupPlayer": {
+		"message": "باز کردن ویدیو / لیست پخش در پنجره‌ای جدید"
+	},
+	"orange": {
+		"message": "نارنجی"
+	},
+	"os": {
+		"message": "سیستم عامل"
+	},
+	"other": {
+		"message": "دیگر"
+	},
+	"outline": {
+		"message": "حاشیه"
+	},
+	"overlay": {
+		"message": "نوار روی ویدیو"
+	},
+	"permissions": {
+		"message": "مجوزها"
+	},
+	"pictureInPicture": {
+		"message": "تصویر در تصویر"
+	},
+	"pink": {
+		"message": "صورتی"
+	},
+	"plain": {
+		"message": "ساده"
+	},
+	"platform": {
+		"message": "پلتفرم"
+	},
+	"playAllButton": {
+		"message": "دکمه پخش همه"
+	},
+	"playbackSpeed": {
+		"message": "سرعت پخش"
+	},
+	"player": {
+		"message": "پخش کننده"
+	},
+	"playerColor": {
+		"message": "رنگ نوار پیشرفت"
+	},
+	"playerSize": {
+		"message": "اندازه پخش کننده"
+	},
+	"playlist": {
+		"message": "لیست پخش"
+	},
+	"playlists": {
+		"message": "لیست‌های پخش"
+	},
+	"playPause": {
+		"message": "پخش / توقف"
+	},
+	"popupPlayer": {
+		"message": "پخش کننده پنجره‌ای"
+	},
+	"popupWindowButtons": {
+		"message": "افزودن دکمه پخش کننده پنجره‌ای به هر بندانگشتی"
+	},
+	"position": {
+		"message": "موقعیت"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "هر کلیدی را فشار دهید یا از اسکرول موس استفاده کنید."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "هر کلیدی را فشار دهید یا از اسکرول موس استفاده کنید"
+	},
+	"previousVideo": {
+		"message": "ویدیو قبلی"
+	},
+	"primaryColor": {
+		"message": "رنگ اصلی"
+	},
+	"purple": {
+		"message": "بنفش"
+	},
+	"quality": {
+		"message": "کیفیت"
+	},
+	"raised": {
+		"message": "بالا بردن"
+	},
+	"ram": {
+		"message": "حافظه RAM"
+	},
+	"rateMe": {
+		"message": "امتیاز دهید"
+	},
+	"rateUs": {
+		"message": "امتیاز دهید"
+	},
+	"red": {
+		"message": "قرمز"
+	},
+	"redDislikeButton": {
+		"message": "قرمز در هنگام نپسندیدن"
+	},
+	"relatedVideos": {
+		"message": "ویدیوهای مرتبط"
+	},
+	"remote": {
+		"message": "پخش در تلویزیون"
+	},
+	"removeRelatedSearchResults": {
+		"message": "حذف نتایج جستجوی مرتبط"
+	},
+	"repeat": {
+		"message": "تکرار"
+	},
+	"report": {
+		"message": "گزارش"
+	},
+	"reset": {
+		"message": "بازنشانی"
+	},
+	"resetAllSettings": {
+		"message": "بازنشانی تمام تنظیمات"
+	},
+	"resetAllShortcuts": {
+		"message": "بازنشانی همه میانبرها"
+	},
+	"reverse": {
+		"message": "برعکس کردن"
+	},
+	"rotate": {
+		"message": "چرخاندن"
+	},
+	"save": {
+		"message": "ذخیره"
+	},
+	"saveAs": {
+		"message": "ذخیره به عنوان"
+	},
+	"schedule": {
+		"message": "زمانبندی"
+	},
+	"screen": {
+		"message": "صفحه نمایش"
+	},
+	"screenshot": {
+		"message": "عکس از صفحه"
+	},
+	"scrollBar": {
+		"message": "نوار پیمایش"
+	},
+	"sd": {
+		"message": "کیفیت پایین"
+	},
+	"search": {
+		"message": "جستجو"
+	},
+	"searchBarOnly": {
+		"message": "فقط نوار جستجو"
+	},
+	"seekBackward10Seconds": {
+		"message": "جستجو به عقب 10 ثانیه"
+	},
+	"seekForward10Seconds": {
+		"message": "جستجو به جلو 10 ثانیه"
+	},
+	"seekNextChapter": {
+		"message": "جستجو به فصل بعدی"
+	},
+	"seekPreviousChapter": {
+		"message": "جستجو به فصل قبلی"
+	},
+	"settings": {
+		"message": "تنظیمات"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "تنظیمات با موفقیت وارد شد"
+	},
+	"share": {
+		"message": "اشتراک‌گذاری"
+	},
+	"shortcuts": {
+		"message": "میانبرها"
+	},
+	"showCardsOnMouseHover": {
+		"message": "نمایش کارت‌ها با حرکت ماوس"
+	},
+	"showChannelVideosCount": {
+		"message": "نمایش تعداد ویدیوهای کانال"
+	},
+	"showLess": {
+		"message": "نمایش کمتر"
+	},
+	"showMore": {
+		"message": "نمایش بیشتر"
+	},
+	"showRemainingDuration": {
+		"message": "نمایش مدت زمان باقی‌مانده ویدیو"
+	},
+	"showVersion": {
+		"message": "نمایش نسخه"
+	},
+	"shuffle": {
+		"message": "تصادفی"
+	},
+	"sidebar": {
+		"message": "نوار کناری"
+	},
+	"softwareInformation": {
+		"message": "اطلاعات نرم‌افزار"
+	},
+	"spacebar": {
+		"message": "دکمه فضا"
+	},
+	"squaredUserImages": {
+		"message": "تصاویر کاربران مربع"
+	},
+	"static": {
+		"message": "ثابت"
+	},
+	"statsForNerds": {
+		"message": "نمایش آمار برای علاقه‌مندان"
+	},
+	"step": {
+		"message": "گام"
+	},
+	"stop": {
+		"message": "توقف"
+	},
+	"style": {
+		"message": "استیل"
+	},
+	"styles": {
+		"message": "استایل‌ها"
+	},
+	"subscribe": {
+		"message": "اشتراک‌گیری"
+	},
+	"subscriptions": {
+		"message": "اشتراک‌ها"
+	},
+	"subtitles": {
+		"message": "زیرنویس‌ها"
+	},
+	"sunset": {
+		"message": "غروب"
+	},
+	"sunsetToSunrise": {
+		"message": "از غروب تا طلوع"
+	},
+	"systemPeferenceDark": {
+		"message": "ترجیحات سیستم: تیره"
+	},
+	"systemPeferenceLight": {
+		"message": "ترجیحات سیستم: روشن"
+	},
+	"teal": {
+		"message": "فیروزه‌ای"
+	},
+	"textColor": {
+		"message": "رنگ متن"
+	},
+	"thanks": {
+		"message": "با تشکر"
+	},
+	"themes": {
+		"message": "تم‌ها"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "این کار کلیه کوکی ها را حذف می‌کند."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "این کار تمام ویدیوهای تماشا شده را حذف می‌کند."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "این کار کلیه کوکی‌های یوتیوب را حذف می‌کند."
+	},
+	"thisWillResetAllSettings": {
+		"message": "این کار تمام تنظیمات را بازنشانی می‌کند."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "این کار تمام میانبرها را بازنشانی می‌کند."
+	},
+	"thumbnails": {
+		"message": "تصاویر کوچک"
+	},
+	"thumbnailsQuality": {
+		"message": "کیفیت تصاویر کوچک"
+	},
+	"timeFrom": {
+		"message": "زمان از"
+	},
+	"timeTo": {
+		"message": "زمان تا"
+	},
+	"todayAt": {
+		"message": "امروز در"
+	},
+	"toggleAutoplay": {
+		"message": "تغییر وضعیت پخش خودکار"
+	},
+	"toggleCards": {
+		"message": "تغییر وضعیت کارت‌ها"
+	},
+	"toggleControls": {
+		"message": "تغییر وضعیت کنترل‌های پخش کننده"
+	},
+	"topChat": {
+		"message": "گفتگوی برتر"
+	},
+	"trackWatchedVideos": {
+		"message": "پیگیری ویدیوهای تماشا شده"
+	},
+	"trailerAutoplay": {
+		"message": "پخش خودکار تریلر"
+	},
+	"translations": {
+		"message": "ترجمه‌ها"
+	},
+	"transparentBackground": {
+		"message": "پس‌زمینه شفاف"
+	},
+	"trending": {
+		"message": "محبوبیت"
+	},
+	"tryToReloadThePage": {
+		"message": "سعی در بارگذاری مجدد صفحه"
+	},
+	"type": {
+		"message": "نوع"
+	},
+	"upNextAutoplay": {
+		"message": "پخش خودکار بعدی"
+	},
+	"use24HourFormat": {
+		"message": "استفاده از فرمت ۲۴ ساعته"
+	},
+	"version": {
+		"message": "نسخه"
+	},
+	"video": {
+		"message": "ویدیو"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "توضیحات ویدیو برای دریافت نام دسته بندی گسترش خواهد یافت"
+	},
+	"videoFormats": {
+		"message": "فرمت‌های ویدیو"
+	},
+	"videos": {
+		"message": "ویدیوها"
+	},
+	"viewMode": {
+		"message": "حالت نمایش"
+	},
+	"volume": {
+		"message": "صدا"
+	},
+	"watchedVideos": {
+		"message": "ویدیوهای تماشا شده"
+	},
+	"watchLater": {
+		"message": "تماشای بعدی"
+	},
+	"watchTime": {
+		"message": "زمان تماشا"
+	},
+	"whenPaused": {
+		"message": "وقتی مکث شود"
+	},
+	"whenTabIsChanged": {
+		"message": "وقتی تب تغییر کند"
+	},
+	"white": {
+		"message": "سفید"
+	},
+	"windowColor": {
+		"message": "رنگ پنجره"
+	},
+	"windowOpacity": {
+		"message": "شفافیت پنجره"
+	},
+	"yellow": {
+		"message": "زرد"
+	},
+	"youtubeHeaderLeft": {
+		"message": "سربرگ یوتیوب (چپ)"
+	},
+	"youtubeHeaderRight": {
+		"message": "سربرگ یوتیوب (راست)"
+	},
+	"youtubeHomePage": {
+		"message": "صفحه اصلی یوتیوب"
+	},
+	"youtubeLanguage": {
+		"message": "زبان یوتیوب"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "یوتیوب محدودیت کیفیت ویدیو را برای کدک h.264 به 1080p قرار می دهد"
+	}
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Poista etusivun Shorts"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Poista Shorts-reel hakutuloksista"
-    }
+	"hideHomePageShorts": {
+		"message": "Poista etusivun Shorts"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Poista Shorts-reel hakutuloksista"
+	}
 }

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Alisin ang Shorts mula sa homepage"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Alisin ang Shorts reel mula sa mga resulta ng paghahanap"
-    }
+	"hideHomePageShorts": {
+		"message": "Alisin ang Shorts mula sa homepage"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Alisin ang Shorts reel mula sa mga resulta ng paghahanap"
+	}
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,740 +1,731 @@
 {
-    "about": {
-        "message": "À propos"
-    },
-    "accept": {
-        "message": "Accepter"
-    },
-    "activate": {
-        "message": "Activer"
-    },
-    "activateCaptions": {
-        "message": "Activer les sous-titres"
-    },
-    "activated": {
-        "message": "Activé"
-    },
-    "activatedFeatures": {
-        "message": "Fonctionnalités activées"
-    },
-    "activateFullscreen": {
-        "message": "Activer le plein écran"
-    },
-    "activeFeatures": {
-        "message": "Fonctionnalités actives"
-    },
-    "addScrollToTop": {
-        "message": "Ajouter « Remonter en haut »"
-    },
-    "ads": {
-        "message": "Publicités"
-    },
-    "all": {
-        "message": "Voir tout"
-    },
-    "allow": {
-        "message": "Permettre"
-    },
-    "alwaysActive": {
-        "message": "Toujours activé"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Toujours afficher la barre de progression"
-    },
-    "amber": {
-        "message": "Ambre"
-    },
-    "analyzer": {
-        "message": "Analyser"
-    },
-    "appearance": {
-        "message": "Apparence"
-    },
-    "audioFormats": {
-        "message": "Formats de fichier audio"
-    },
-    "autoFullscreen": {
-        "message": "Plein écran automatique"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pause automatique lors d'un changement d'onglet"
-    },
-    "autoplay": {
-        "message": "Lecture automatique"
-    },
-    "backupAndReset": {
-        "message": "Sauvegarde et réinitialisation"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Selon les paramètres du système"
-    },
-    "belowPlayer": {
-        "message": "Sous le player"
-    },
-    "black": {
-        "message": "Noir"
-    },
-    "blockAll": {
-        "message": "Tout bloquer"
-    },
-    "blocklist": {
-        "message": "Liste noire"
-    },
-    "blue": {
-        "message": "Bleu"
-    },
-    "blueGray": {
-        "message": "Gris-bleu"
-    },
-    "bluelight": {
-        "message": "Bleu pâle"
-    },
-    "brown": {
-        "message": "Brun"
-    },
-    "browser": {
-        "message": "Navigateur web"
-    },
-    "browserVersion": {
-        "message": "Version du navigateur web"
-    },
-    "bubbles": {
-        "message": "Bulles"
-    },
-    "bug": {
-        "message": "Bogue"
-    },
-    "buttons": {
-        "message": "Boutons"
-    },
-    "cancel": {
-        "message": "Retour"
-    },
-    "categories": {
-        "message": "Catégories"
-    },
-    "channel": {
-        "message": "Chaîne"
-    },
-    "channels": {
-        "message": "Chaînes"
-    },
-    "clipboard": {
-        "message": "Presse-papiers"
-    },
-    "collapsed": {
-        "message": "Réduire"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Réduire la section des abonnements"
-    },
-    "comments": {
-        "message": "Commentaires"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Confirmation avant la fermeture"
-    },
-    "cores": {
-        "message": "Noyaux"
-    },
-    "cropChapterTitles": {
-        "message": "Couper les titres des chapitres"
-    },
-    "customCss": {
-        "message": "CSS customisé"
-    },
-    "customJs": {
-        "message": "JS customisé"
-    },
-    "customMiniPlayer": {
-        "message": "Mini-lecteur personnalisé"
-    },
-    "dark": {
-        "message": "Sombre"
-    },
-    "darkTheme": {
-        "message": "Thème sombre"
-    },
-    "dateAndTime": {
-        "message": "Date et temps"
-    },
-    "dawn": {
-        "message": "Aube"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Réduire la vitesse de lecture"
-    },
-    "decreaseVolume": {
-        "message": "Réduire le volume"
-    },
-    "deepOrange": {
-        "message": "Orange foncé"
-    },
-    "deepPurple": {
-        "message": "Violet foncé"
-    },
-    "defaultChannelTab": {
-        "message": "Onglet par défaut d'une chaîne"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Supprimer les cookies YouTube"
-    },
-    "details": {
-        "message": "Détails"
-    },
-    "developerOptions": {
-        "message": "Options de développeur"
-    },
-    "device": {
-        "message": "Appareil"
-    },
-    "dim": {
-        "message": "Assombrir"
-    },
-    "disabled": {
-        "message": "Désactivé"
-    },
-    "dislike": {
-        "message": "Je n'aime pas"
-    },
-    "donate": {
-        "message": "Donner"
-    },
-    "doNotChange": {
-        "message": "Ne pas changer"
-    },
-    "email": {
-        "message": "Courriel"
-    },
-    "empty": {
-        "message": "Vide"
-    },
-    "enabled": {
-        "message": "Activé"
-    },
-    "enabledForced": {
-        "message": "Activé (forcé)"
-    },
-    "expanded": {
-        "message": "Étendu"
-    },
-    "exportSettings": {
-        "message": "Exporter les réglages"
-    },
-    "ExtraButtons": {
-        "message": "Boutons supplémentaires"
-    },
-    "file": {
-        "message": "Fichier"
-    },
-    "filters": {
-        "message": "Filtres"
-    },
-    "fitToWindow": {
-        "message": "Ajuster à la fenêtre"
-    },
-    "flash": {
-        "message": "Clignoter"
-    },
-    "font": {
-        "message": "Police"
-    },
-    "footer": {
-        "message": "Bas de page"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Vitesse de lecture forcée"
-    },
-    "forcedTheaterMode": {
-        "message": "Forcer le mode théâtre"
-    },
-    "forcedVolume": {
-        "message": "Forcer le volume"
-    },
-    "foundABug": {
-        "message": "Un bogue?"
-    },
-    "fullWindow": {
-        "message": "Fenêtre pleine"
-    },
-    "general": {
-        "message": "Général"
-    },
-    "goToSearchBox": {
-        "message": "Barre de recherche"
-    },
-    "green": {
-        "message": "Vert"
-    },
-    "hdThumbnail": {
-        "message": "Miniature HD"
-    },
-    "header": {
-        "message": "Tête de page"
-    },
-    "hidden": {
-        "message": "Caché"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Caché sur la page de la vidéo"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Miniatures sans animation"
-    },
-    "hideAnnotations": {
-        "message": "Cacher les annotations"
-    },
-    "hideCards": {
-        "message": "Cacher les cartes"
-    },
-    "hideDetails": {
-        "message": "Cacher les détails"
-    },
-    "hideEndscreen": {
-        "message": "Cacher l'écran de fin"
-    },
-    "hideFeaturedContent": {
-        "message": "Cacher le contenu recommandé"
-    },
-    "hideFooter": {
-        "message": "Cacher le pied de page"
-    },
-    "hideGradientBottom": {
-        "message": "Masquer le dégradé du bas"
-    },
-    "hideHomePageShorts": {
-        "message": "Supprimer les Shorts de la page d'accueil"
-    },
-    "hidePlaylist": {
-        "message": "Cacher la liste de lecture"
-    },
-    "hideRightButtons": {
-        "message": "Cacher les boutons à droite"
-    },
-    "hideScrollForDetails": {
-        "message": "Cacher « Faire défiler pour les détails »"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "Voir le compte des vues"
-    },
-    "history": {
-        "message": "Historique"
-    },
-    "home": {
-        "message": "Accueil"
-    },
-    "hover": {
-        "message": "Survoler"
-    },
-    "hoverOnVideoPage": {
-        "message": "Survoler la page de la vidéo"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Depuis combien de temps la vidéo a été téléversé?"
-    },
-    "icons": {
-        "message": "Icônes"
-    },
-    "iconsOnly": {
-        "message": "Uniquement les icônes"
-    },
-    "importSettings": {
-        "message": "Importer les réglages"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Afficher l'icône ImprovedTube sur YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Langue d'ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Version d'ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Améliorer le logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Accélérer la vitesse de lecture"
-    },
-    "increaseVolume": {
-        "message": "Augmenter le volume"
-    },
-    "items": {
-        "message": "Objets"
-    },
-    "languages": {
-        "message": "Langues"
-    },
-    "legacyYoutube": {
-        "message": "Ancienne version de Youtube"
-    },
-    "light": {
-        "message": "Clair"
-    },
-    "lightBlue": {
-        "message": "Bleu clair"
-    },
-    "lightGreen": {
-        "message": "Vert clair"
-    },
-    "like": {
-        "message": "J'aime"
-    },
-    "lime": {
-        "message": "Citron vert"
-    },
-    "list": {
-        "message": "Liste"
-    },
-    "liveChat": {
-        "message": "Chat en direct"
-    },
-    "liveChatType": {
-        "message": "Type de chat en direct"
-    },
-    "loudnessNormalization": {
-        "message": "Normalisation de l'intensité sonore"
-    },
-    "markWatchedVideos": {
-        "message": "Marquer les vidéos déjà visionnées"
-    },
-    "mixer": {
-        "message": "Mélangeur de volume"
-    },
-    "myColors": {
-        "message": "Mes couleurs"
-    },
-    "name": {
-        "message": "Nom"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini-lecteur natif"
-    },
-    "new": {
-        "message": "Nouveau"
-    },
-    "nextVideo": {
-        "message": "Prochaine vidéo"
-    },
-    "night": {
-        "message": "Nuit"
-    },
-    "noActiveFeatures": {
-        "message": "Pas de fonctionalité active"
-    },
-    "none": {
-        "message": "Aucun"
-    },
-    "noOpenVideoTabs": {
-        "message": "Aucun onglet de vidéo ouvert"
-    },
-    "old": {
-        "message": "Vieux"
-    },
-    "onAllVideos": {
-        "message": "Pour toutes les vidéos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Uniquement actif sur YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Une seule instance à la fois"
-    },
-    "onSubscribedChannels": {
-        "message": "Sur les chaînes auxquelles je suis abonné"
-    },
-    "openPopupPlayer": {
-        "message": "Ouvrir Video/playlist dans un nouvelle onglet"
-    },
-    "other": {
-        "message": "Autres"
-    },
-    "pictureInPicture": {
-        "message": "Image dans l'image"
-    },
-    "pink": {
-        "message": "Rose"
-    },
-    "plain": {
-        "message": "Ordinaire"
-    },
-    "platform": {
-        "message": "Platforme"
-    },
-    "playbackSpeed": {
-        "message": "Vitesse de lecture"
-    },
-    "player": {
-        "message": "Lecteur"
-    },
-    "playerColor": {
-        "message": "Couleur du lecteur"
-    },
-    "playerSize": {
-        "message": "Taille du lecteur"
-    },
-    "playlist": {
-        "message": "Liste de lecture"
-    },
-    "playlists": {
-        "message": "Listes de lecture"
-    },
-    "playPause": {
-        "message": "Lire / Pause"
-    },
-    "popupPlayer": {
-        "message": "Détacher le lecteur"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Appuyez sur n'importe quelle touche ou utilisez la molette de la souris."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Appuyez sur n'importe quelle touche ou utilisez la molette de la souris."
-    },
-    "previousVideo": {
-        "message": "Vidéo précédente"
-    },
-    "primaryColor": {
-        "message": "Couleur primaire"
-    },
-    "purple": {
-        "message": "Violet"
-    },
-    "quality": {
-        "message": "Qualité"
-    },
-    "qualityWithoutFocus": {
-        "message": "Qualité sans concentration"
-    },
-    "rateUs": {
-        "message": "Nous évaluer"
-    },
-    "red": {
-        "message": "Rouge"
-    },
-    "redDislikeButton": {
-        "message": "Afficher la couleur rouge du bouton Je n'aime pas"
-    },
-    "relatedVideos": {
-        "message": "Vidéos associés"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Supprimer les résultats de recherche associés"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Supprimer la liste de Shorts des résultats de recherche"
-    },
-    "repeat": {
-        "message": "Lire en boucle"
-    },
-    "reset": {
-        "message": "Réintialiser"
-    },
-    "resetAllSettings": {
-        "message": "Annuler réglages"
-    },
-    "resetAllShortcuts": {
-        "message": "Annuler raccourcis"
-    },
-    "reverse": {
-        "message": "Inverser"
-    },
-    "rotate": {
-        "message": "Faire pivoter la vidéo"
-    },
-    "save": {
-        "message": "Ok"
-    },
-    "saveAs": {
-        "message": "Sauvegarder sous"
-    },
-    "schedule": {
-        "message": "Plage horaire"
-    },
-    "screen": {
-        "message": "Écran"
-    },
-    "screenshot": {
-        "message": "Capture d'écran"
-    },
-    "search": {
-        "message": "Rechercher"
-    },
-    "searchBarOnly": {
-        "message": "Uniquement la barre de recherche"
-    },
-    "seekBackward10Seconds": {
-        "message": "Reculer de 10 secondes"
-    },
-    "seekForward10Seconds": {
-        "message": "Avancer de 10 secondes"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Réglages"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Importation des réglages réussie"
-    },
-    "shortcuts": {
-        "message": "Raccourcis"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Afficher les cartes au survol de la souris"
-    },
-    "showChannelVideosCount": {
-        "message": "Afficher le nombre de vidéos de la chaîne"
-    },
-    "shuffle": {
-        "message": "Aléatoire"
-    },
-    "sidebar": {
-        "message": "Barre latérale"
-    },
-    "spacebar": {
-        "message": "Barre d'espace"
-    },
-    "squaredUserImages": {
-        "message": "Images des utilisateurs carrées"
-    },
-    "static": {
-        "message": "Statique"
-    },
-    "statsForNerds": {
-        "message": "Statistiques pour nerd"
-    },
-    "step": {
-        "message": "Étape"
-    },
-    "stop": {
-        "message": "Arrêter"
-    },
-    "subscriptions": {
-        "message": "Abonnements"
-    },
-    "subtitles": {
-        "message": "Activer les sous-titres"
-    },
-    "sunset": {
-        "message": "Coucher de soleil"
-    },
-    "sunsetToSunrise": {
-        "message": "Du coucher au lever du Soleil"
-    },
-    "systemPeferenceDark": {
-        "message": "Préférence système : sombre"
-    },
-    "systemPeferenceLight": {
-        "message": "Préférence système : clair"
-    },
-    "teal": {
-        "message": "Sarcelle"
-    },
-    "textColor": {
-        "message": "Couleur du texte"
-    },
-    "themes": {
-        "message": "Thèmes"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Supprimer tous les cookies."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Supprimer tous les cookies Youtube."
-    },
-    "thisWillResetAllSettings": {
-        "message": "Réintialiser les réglages."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Réintialiser les raccourcis."
-    },
-    "thumbnails": {
-        "message": "Miniature"
-    },
-    "timeFrom": {
-        "message": "Temps de"
-    },
-    "timeTo": {
-        "message": "Temps au"
-    },
-    "todayAt": {
-        "message": "Aujourd'hui à"
-    },
-    "toggleAutoplay": {
-        "message": "Basculer lecture auto"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "trailerAutoplay": {
-        "message": "Démarrage automatique des annonces"
-    },
-    "translations": {
-        "message": "Traductions"
-    },
-    "transparentBackground": {
-        "message": "Arrière-plan transparent"
-    },
-    "trending": {
-        "message": "Tendances"
-    },
-    "tryToReloadThePage": {
-        "message": "Essayez de rafraîchir la page"
-    },
-    "upNextAutoplay": {
-        "message": "Prochaine lecture automatique"
-    },
-    "use24HourFormat": {
-        "message": "Utiliser le format 24 h"
-    },
-    "video": {
-        "message": "Vidéo"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "La description de la vidéo sera développée pour obtenir le nom de la catégorie"
-    },
-    "videoFormats": {
-        "message": "Formats de vidéo"
-    },
-    "watchLater": {
-        "message": "À regarder plus tard"
-    },
-    "watchTime": {
-        "message": "Temps de visionnage"
-    },
-    "whenTabIsChanged": {
-        "message": "Quand l'onglet change"
-    },
-    "white": {
-        "message": "Blanc"
-    },
-    "yellow": {
-        "message": "Jaune"
-    },
-    "youtubeHeaderLeft": {
-        "message": "En-tête YouTube (à gauche)"
-    },
-    "youtubeHeaderRight": {
-        "message": "En-tête YouTube (à droite)"
-    },
-    "youtubeHomePage": {
-        "message": "Page d'accueil de YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Langue de YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limite la qualité vidéo à 1080p pour le codec h.264"
-    }
+	"about": {
+		"message": "À propos"
+	},
+	"accept": {
+		"message": "Accepter"
+	},
+	"activate": {
+		"message": "Activer"
+	},
+	"activateCaptions": {
+		"message": "Activer les sous-titres"
+	},
+	"activated": {
+		"message": "Activé"
+	},
+	"activatedFeatures": {
+		"message": "Fonctionnalités activées"
+	},
+	"activateFullscreen": {
+		"message": "Activer le plein écran"
+	},
+	"activeFeatures": {
+		"message": "Fonctionnalités actives"
+	},
+	"addScrollToTop": {
+		"message": "Ajouter « Remonter en haut »"
+	},
+	"ads": {
+		"message": "Publicités"
+	},
+	"all": {
+		"message": "Voir tout"
+	},
+	"allow": {
+		"message": "Permettre"
+	},
+	"alwaysActive": {
+		"message": "Toujours activé"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Toujours afficher la barre de progression"
+	},
+	"amber": {
+		"message": "Ambre"
+	},
+	"analyzer": {
+		"message": "Analyser"
+	},
+	"appearance": {
+		"message": "Apparence"
+	},
+	"audioFormats": {
+		"message": "Formats de fichier audio"
+	},
+	"autoFullscreen": {
+		"message": "Plein écran automatique"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pause automatique lors d'un changement d'onglet"
+	},
+	"autoplay": {
+		"message": "Lecture automatique"
+	},
+	"backupAndReset": {
+		"message": "Sauvegarde et réinitialisation"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Selon les paramètres du système"
+	},
+	"belowPlayer": {
+		"message": "Sous le player"
+	},
+	"black": {
+		"message": "Noir"
+	},
+	"blockAll": {
+		"message": "Tout bloquer"
+	},
+	"blocklist": {
+		"message": "Liste noire"
+	},
+	"blue": {
+		"message": "Bleu"
+	},
+	"blueGray": {
+		"message": "Gris-bleu"
+	},
+	"bluelight": {
+		"message": "Bleu pâle"
+	},
+	"brown": {
+		"message": "Brun"
+	},
+	"browser": {
+		"message": "Navigateur web"
+	},
+	"browserVersion": {
+		"message": "Version du navigateur web"
+	},
+	"bubbles": {
+		"message": "Bulles"
+	},
+	"bug": {
+		"message": "Bogue"
+	},
+	"buttons": {
+		"message": "Boutons"
+	},
+	"cancel": {
+		"message": "Retour"
+	},
+	"categories": {
+		"message": "Catégories"
+	},
+	"channel": {
+		"message": "Chaîne"
+	},
+	"channels": {
+		"message": "Chaînes"
+	},
+	"clipboard": {
+		"message": "Presse-papiers"
+	},
+	"collapsed": {
+		"message": "Réduire"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Réduire la section des abonnements"
+	},
+	"comments": {
+		"message": "Commentaires"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Confirmation avant la fermeture"
+	},
+	"cores": {
+		"message": "Noyaux"
+	},
+	"cropChapterTitles": {
+		"message": "Couper les titres des chapitres"
+	},
+	"customCss": {
+		"message": "CSS customisé"
+	},
+	"customJs": {
+		"message": "JS customisé"
+	},
+	"customMiniPlayer": {
+		"message": "Mini-lecteur personnalisé"
+	},
+	"dark": {
+		"message": "Sombre"
+	},
+	"darkTheme": {
+		"message": "Thème sombre"
+	},
+	"dateAndTime": {
+		"message": "Date et temps"
+	},
+	"dawn": {
+		"message": "Aube"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Réduire la vitesse de lecture"
+	},
+	"decreaseVolume": {
+		"message": "Réduire le volume"
+	},
+	"deepOrange": {
+		"message": "Orange foncé"
+	},
+	"deepPurple": {
+		"message": "Violet foncé"
+	},
+	"defaultChannelTab": {
+		"message": "Onglet par défaut d'une chaîne"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Supprimer les cookies YouTube"
+	},
+	"details": {
+		"message": "Détails"
+	},
+	"developerOptions": {
+		"message": "Options de développeur"
+	},
+	"device": {
+		"message": "Appareil"
+	},
+	"dim": {
+		"message": "Assombrir"
+	},
+	"disabled": {
+		"message": "Désactivé"
+	},
+	"dislike": {
+		"message": "Je n'aime pas"
+	},
+	"donate": {
+		"message": "Donner"
+	},
+	"doNotChange": {
+		"message": "Ne pas changer"
+	},
+	"email": {
+		"message": "Courriel"
+	},
+	"empty": {
+		"message": "Vide"
+	},
+	"enabled": {
+		"message": "Activé"
+	},
+	"enabledForced": {
+		"message": "Activé (forcé)"
+	},
+	"expanded": {
+		"message": "Étendu"
+	},
+	"exportSettings": {
+		"message": "Exporter les réglages"
+	},
+	"ExtraButtons": {
+		"message": "Boutons supplémentaires"
+	},
+	"file": {
+		"message": "Fichier"
+	},
+	"filters": {
+		"message": "Filtres"
+	},
+	"fitToWindow": {
+		"message": "Ajuster à la fenêtre"
+	},
+	"flash": {
+		"message": "Clignoter"
+	},
+	"font": {
+		"message": "Police"
+	},
+	"footer": {
+		"message": "Bas de page"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Vitesse de lecture forcée"
+	},
+	"forcedTheaterMode": {
+		"message": "Forcer le mode théâtre"
+	},
+	"forcedVolume": {
+		"message": "Forcer le volume"
+	},
+	"foundABug": {
+		"message": "Un bogue?"
+	},
+	"fullWindow": {
+		"message": "Fenêtre pleine"
+	},
+	"general": {
+		"message": "Général"
+	},
+	"goToSearchBox": {
+		"message": "Barre de recherche"
+	},
+	"green": {
+		"message": "Vert"
+	},
+	"hdThumbnail": {
+		"message": "Miniature HD"
+	},
+	"header": {
+		"message": "Tête de page"
+	},
+	"hidden": {
+		"message": "Caché"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Caché sur la page de la vidéo"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Miniatures sans animation"
+	},
+	"hideAnnotations": {
+		"message": "Cacher les annotations"
+	},
+	"hideCards": {
+		"message": "Cacher les cartes"
+	},
+	"hideDetails": {
+		"message": "Cacher les détails"
+	},
+	"hideEndscreen": {
+		"message": "Cacher l'écran de fin"
+	},
+	"hideFeaturedContent": {
+		"message": "Cacher le contenu recommandé"
+	},
+	"hideFooter": {
+		"message": "Cacher le pied de page"
+	},
+	"hideGradientBottom": {
+		"message": "Masquer le dégradé du bas"
+	},
+	"hideHomePageShorts": {
+		"message": "Supprimer les Shorts de la page d'accueil"
+	},
+	"hidePlaylist": {
+		"message": "Cacher la liste de lecture"
+	},
+	"hideRightButtons": {
+		"message": "Cacher les boutons à droite"
+	},
+	"hideScrollForDetails": {
+		"message": "Cacher « Faire défiler pour les détails »"
+	},
+	"hideViewsCount": {
+		"message": "Voir le compte des vues"
+	},
+	"history": {
+		"message": "Historique"
+	},
+	"home": {
+		"message": "Accueil"
+	},
+	"hover": {
+		"message": "Survoler"
+	},
+	"hoverOnVideoPage": {
+		"message": "Survoler la page de la vidéo"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Depuis combien de temps la vidéo a été téléversé?"
+	},
+	"icons": {
+		"message": "Icônes"
+	},
+	"iconsOnly": {
+		"message": "Uniquement les icônes"
+	},
+	"importSettings": {
+		"message": "Importer les réglages"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Afficher l'icône ImprovedTube sur YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Langue d'ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Version d'ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Améliorer le logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Accélérer la vitesse de lecture"
+	},
+	"increaseVolume": {
+		"message": "Augmenter le volume"
+	},
+	"items": {
+		"message": "Objets"
+	},
+	"languages": {
+		"message": "Langues"
+	},
+	"legacyYoutube": {
+		"message": "Ancienne version de Youtube"
+	},
+	"light": {
+		"message": "Clair"
+	},
+	"lightBlue": {
+		"message": "Bleu clair"
+	},
+	"lightGreen": {
+		"message": "Vert clair"
+	},
+	"like": {
+		"message": "J'aime"
+	},
+	"lime": {
+		"message": "Citron vert"
+	},
+	"list": {
+		"message": "Liste"
+	},
+	"liveChat": {
+		"message": "Chat en direct"
+	},
+	"liveChatType": {
+		"message": "Type de chat en direct"
+	},
+	"loudnessNormalization": {
+		"message": "Normalisation de l'intensité sonore"
+	},
+	"markWatchedVideos": {
+		"message": "Marquer les vidéos déjà visionnées"
+	},
+	"mixer": {
+		"message": "Mélangeur de volume"
+	},
+	"myColors": {
+		"message": "Mes couleurs"
+	},
+	"name": {
+		"message": "Nom"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini-lecteur natif"
+	},
+	"new": {
+		"message": "Nouveau"
+	},
+	"nextVideo": {
+		"message": "Prochaine vidéo"
+	},
+	"night": {
+		"message": "Nuit"
+	},
+	"noActiveFeatures": {
+		"message": "Pas de fonctionalité active"
+	},
+	"none": {
+		"message": "Aucun"
+	},
+	"noOpenVideoTabs": {
+		"message": "Aucun onglet de vidéo ouvert"
+	},
+	"old": {
+		"message": "Vieux"
+	},
+	"onAllVideos": {
+		"message": "Pour toutes les vidéos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Uniquement actif sur YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Une seule instance à la fois"
+	},
+	"onSubscribedChannels": {
+		"message": "Sur les chaînes auxquelles je suis abonné"
+	},
+	"openPopupPlayer": {
+		"message": "Ouvrir Video/playlist dans un nouvelle onglet"
+	},
+	"other": {
+		"message": "Autres"
+	},
+	"pictureInPicture": {
+		"message": "Image dans l'image"
+	},
+	"pink": {
+		"message": "Rose"
+	},
+	"plain": {
+		"message": "Ordinaire"
+	},
+	"platform": {
+		"message": "Platforme"
+	},
+	"playbackSpeed": {
+		"message": "Vitesse de lecture"
+	},
+	"player": {
+		"message": "Lecteur"
+	},
+	"playerColor": {
+		"message": "Couleur du lecteur"
+	},
+	"playerSize": {
+		"message": "Taille du lecteur"
+	},
+	"playlist": {
+		"message": "Liste de lecture"
+	},
+	"playlists": {
+		"message": "Listes de lecture"
+	},
+	"playPause": {
+		"message": "Lire / Pause"
+	},
+	"popupPlayer": {
+		"message": "Détacher le lecteur"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Appuyez sur n'importe quelle touche ou utilisez la molette de la souris."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Appuyez sur n'importe quelle touche ou utilisez la molette de la souris."
+	},
+	"previousVideo": {
+		"message": "Vidéo précédente"
+	},
+	"primaryColor": {
+		"message": "Couleur primaire"
+	},
+	"purple": {
+		"message": "Violet"
+	},
+	"quality": {
+		"message": "Qualité"
+	},
+	"qualityWithoutFocus": {
+		"message": "Qualité sans concentration"
+	},
+	"rateUs": {
+		"message": "Nous évaluer"
+	},
+	"red": {
+		"message": "Rouge"
+	},
+	"redDislikeButton": {
+		"message": "Afficher la couleur rouge du bouton Je n'aime pas"
+	},
+	"relatedVideos": {
+		"message": "Vidéos associés"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Supprimer les résultats de recherche associés"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Supprimer la liste de Shorts des résultats de recherche"
+	},
+	"repeat": {
+		"message": "Lire en boucle"
+	},
+	"reset": {
+		"message": "Réintialiser"
+	},
+	"resetAllSettings": {
+		"message": "Annuler réglages"
+	},
+	"resetAllShortcuts": {
+		"message": "Annuler raccourcis"
+	},
+	"reverse": {
+		"message": "Inverser"
+	},
+	"rotate": {
+		"message": "Faire pivoter la vidéo"
+	},
+	"save": {
+		"message": "Ok"
+	},
+	"saveAs": {
+		"message": "Sauvegarder sous"
+	},
+	"schedule": {
+		"message": "Plage horaire"
+	},
+	"screen": {
+		"message": "Écran"
+	},
+	"screenshot": {
+		"message": "Capture d'écran"
+	},
+	"search": {
+		"message": "Rechercher"
+	},
+	"searchBarOnly": {
+		"message": "Uniquement la barre de recherche"
+	},
+	"seekBackward10Seconds": {
+		"message": "Reculer de 10 secondes"
+	},
+	"seekForward10Seconds": {
+		"message": "Avancer de 10 secondes"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Réglages"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Importation des réglages réussie"
+	},
+	"shortcuts": {
+		"message": "Raccourcis"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Afficher les cartes au survol de la souris"
+	},
+	"showChannelVideosCount": {
+		"message": "Afficher le nombre de vidéos de la chaîne"
+	},
+	"shuffle": {
+		"message": "Aléatoire"
+	},
+	"sidebar": {
+		"message": "Barre latérale"
+	},
+	"spacebar": {
+		"message": "Barre d'espace"
+	},
+	"squaredUserImages": {
+		"message": "Images des utilisateurs carrées"
+	},
+	"static": {
+		"message": "Statique"
+	},
+	"statsForNerds": {
+		"message": "Statistiques pour nerd"
+	},
+	"step": {
+		"message": "Étape"
+	},
+	"stop": {
+		"message": "Arrêter"
+	},
+	"subscriptions": {
+		"message": "Abonnements"
+	},
+	"subtitles": {
+		"message": "Activer les sous-titres"
+	},
+	"sunset": {
+		"message": "Coucher de soleil"
+	},
+	"sunsetToSunrise": {
+		"message": "Du coucher au lever du Soleil"
+	},
+	"systemPeferenceDark": {
+		"message": "Préférence système : sombre"
+	},
+	"systemPeferenceLight": {
+		"message": "Préférence système : clair"
+	},
+	"teal": {
+		"message": "Sarcelle"
+	},
+	"textColor": {
+		"message": "Couleur du texte"
+	},
+	"themes": {
+		"message": "Thèmes"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Supprimer tous les cookies."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Supprimer tous les cookies Youtube."
+	},
+	"thisWillResetAllSettings": {
+		"message": "Réintialiser les réglages."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Réintialiser les raccourcis."
+	},
+	"thumbnails": {
+		"message": "Miniature"
+	},
+	"timeFrom": {
+		"message": "Temps de"
+	},
+	"timeTo": {
+		"message": "Temps au"
+	},
+	"todayAt": {
+		"message": "Aujourd'hui à"
+	},
+	"toggleAutoplay": {
+		"message": "Basculer lecture auto"
+	},
+	"trailerAutoplay": {
+		"message": "Démarrage automatique des annonces"
+	},
+	"translations": {
+		"message": "Traductions"
+	},
+	"transparentBackground": {
+		"message": "Arrière-plan transparent"
+	},
+	"trending": {
+		"message": "Tendances"
+	},
+	"tryToReloadThePage": {
+		"message": "Essayez de rafraîchir la page"
+	},
+	"upNextAutoplay": {
+		"message": "Prochaine lecture automatique"
+	},
+	"use24HourFormat": {
+		"message": "Utiliser le format 24 h"
+	},
+	"video": {
+		"message": "Vidéo"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "La description de la vidéo sera développée pour obtenir le nom de la catégorie"
+	},
+	"videoFormats": {
+		"message": "Formats de vidéo"
+	},
+	"watchLater": {
+		"message": "À regarder plus tard"
+	},
+	"watchTime": {
+		"message": "Temps de visionnage"
+	},
+	"whenTabIsChanged": {
+		"message": "Quand l'onglet change"
+	},
+	"white": {
+		"message": "Blanc"
+	},
+	"yellow": {
+		"message": "Jaune"
+	},
+	"youtubeHeaderLeft": {
+		"message": "En-tête YouTube (à gauche)"
+	},
+	"youtubeHeaderRight": {
+		"message": "En-tête YouTube (à droite)"
+	},
+	"youtubeHomePage": {
+		"message": "Page d'accueil de YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Langue de YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube limite la qualité vidéo à 1080p pour le codec h.264"
+	}
 }

--- a/_locales/gu/messages.json
+++ b/_locales/gu/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "મુખ્ય પેજના શોર્ટ્સ કાઢો"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "શોધના પરિણામોમાંથી શોર્ટસ રીલ કાઢી નાખો"
-    }
+	"hideHomePageShorts": {
+		"message": "મુખ્ય પેજના શોર્ટ્સ કાઢો"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "શોધના પરિણામોમાંથી શોર્ટસ રીલ કાઢી નાખો"
+	}
 }

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -1,5 +1,5 @@
 {
-    "hideHomePageShorts": {
-        "message": "הסר Shorts מהדף הראשי"
-    }
+	"hideHomePageShorts": {
+		"message": "הסר Shorts מהדף הראשי"
+	}
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1,869 +1,857 @@
 {
-    "about": {
-        "message": "के बारे में"
-    },
-    "accept": {
-        "message": "स्वीकार"
-    },
-    "activate": {
-        "message": "सक्रिय"
-    },
-    "activateCaptions": {
-        "message": "कैप्शन सक्रिय करें"
-    },
-    "activated": {
-        "message": "सक्रिय"
-    },
-    "activatedFeatures": {
-        "message": "सक्रिय विशेषताएं"
-    },
-    "activateFullscreen": {
-        "message": "पूर्णस्क्रीन सक्रिय करें"
-    },
-    "activeFeatures": {
-        "message": "सक्रिय विशेषताएं"
-    },
-    "addScrollToTop": {
-        "message": "«शीर्ष पर स्क्रॉल करें» जोड़ें"
-    },
-    "ads": {
-        "message": "विज्ञापsन"
-    },
-    "all": {
-        "message": "सब"
-    },
-    "allow": {
-        "message": "अनुमति"
-    },
-    "alwaysActive": {
-        "message": "हमेशा सक्रिय"
-    },
-    "alwaysShowProgressBar": {
-        "message": "हमेशा प्रगति बार दिखाएं"
-    },
-    "amber": {
-        "message": "अंबर"
-    },
-    "analyzer": {
-        "message": "विश्लेषक"
-    },
-    "appearance": {
-        "message": "दिखावट"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Are you sure you want to import the data?"
-    },
-    "audio": {
-        "message": "ऑडियो"
-    },
-    "audioFormats": {
-        "message": "ऑडियो प्रारूप"
-    },
-    "auto": {
-        "message": "खुद ब खुद"
-    },
-    "autoFullscreen": {
-        "message": "स्वत: पूर्ण स्क्रीन"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "टैब स्विच करते समय ऑटोपॉज"
-    },
-    "autoplay": {
-        "message": "स्वत: प्ले"
-    },
-    "backgroundColor": {
-        "message": "पीछे का रंग"
-    },
-    "backgroundOpacity": {
-        "message": "पृष्ठभूमि अस्पष्टता"
-    },
-    "backupAndReset": {
-        "message": "बैकअप पुनर्स्थापित करना"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "सिस्टम रंग योजना के आधार पर"
-    },
-    "belowPlayer": {
-        "message": "प्लेयर के नीचे"
-    },
-    "black": {
-        "message": "काला"
-    },
-    "blockAll": {
-        "message": "सभी को अवरोधित करें"
-    },
-    "blocklist": {
-        "message": "काला सूची में डालना"
-    },
-    "blue": {
-        "message": "नीला"
-    },
-    "blueGray": {
-        "message": "नीला स्लेटी"
-    },
-    "bluelight": {
-        "message": "नीली बत्ती"
-    },
-    "brown": {
-        "message": "भूरा"
-    },
-    "browser": {
-        "message": "ब्राउज़र"
-    },
-    "browserVersion": {
-        "message": "ब्राउज़र संस्करण"
-    },
-    "bubbles": {
-        "message": "बुलबुले"
-    },
-    "bug": {
-        "message": "बग"
-    },
-    "cancel": {
-        "message": "रद्द"
-    },
-    "categories": {
-        "message": "श्रेणियाँ"
-    },
-    "channel": {
-        "message": "चैनल"
-    },
-    "channels": {
-        "message": "चैनल"
-    },
-    "characterEdgeStyle": {
-        "message": "कैरेक्टर एज स्टाइल"
-    },
-    "clipboard": {
-        "message": "क्लिपबोर्ड"
-    },
-    "codecH264": {
-        "message": "कोडक H264"
-    },
-    "collapsed": {
-        "message": "संक्षिप्त"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "सदस्यता वर्गों का पतन"
-    },
-    "comments": {
-        "message": "टिप्पणियाँ"
-    },
-    "confirmationBeforeClosing": {
-        "message": "बंद करने से पहले पुष्टि"
-    },
-    "cookies": {
-        "message": "कुकीज़"
-    },
-    "cores": {
-        "message": "कोर"
-    },
-    "cropChapterTitles": {
-        "message": "फसल अध्याय के शीर्षक"
-    },
-    "customCss": {
-        "message": "कस्टम सीएसएस"
-    },
-    "customJs": {
-        "message": "कस्टम जेएस"
-    },
-    "customMiniPlayer": {
-        "message": "कस्टम मिनी प्लेयर"
-    },
-    "cyan": {
-        "message": "सियान"
-    },
-    "dark": {
-        "message": "अंधेरा"
-    },
-    "darkTheme": {
-        "message": "डार्क थीम"
-    },
-    "dateAndTime": {
-        "message": "दिनांक और समय"
-    },
-    "dawn": {
-        "message": "भोर"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "पार्श्व गति में कमी"
-    },
-    "decreaseVolume": {
-        "message": "ध्वनि कम"
-    },
-    "deepOrange": {
-        "message": "गहरा नारंगी"
-    },
-    "deepPurple": {
-        "message": "गहरा बैंगनी"
-    },
-    "default": {
-        "message": "डिफ़ॉल्ट"
-    },
-    "defaultChannelTab": {
-        "message": "डिफ़ॉल्ट चैनल टैब"
-    },
-    "defaultContentCountry": {
-        "message": "डिफॉल्ट विषय देश"
-    },
-    "deleteYoutubeCookies": {
-        "message": "यूट्यूब कुकीज़ हटाएं"
-    },
-    "depressed": {
-        "message": "उदास"
-    },
-    "description_ext": {
-        "message": "YouTube को व्यवस्थित एवं स्मार्ट बनाएं! यूट्यूब वीडियो कलर एड स्किप वॉल्यूम स्पीड चैनल टूल स्टाइल एचडी विज्ञापन एडब्लॉकर टैग कीवर्ड प्लेलिस्ट"
-    },
-    "desert": {
-        "message": "रेगिस्तान"
-    },
-    "details": {
-        "message": "विवरण"
-    },
-    "developerOptions": {
-        "message": "डेवलपर विकल्प"
-    },
-    "device": {
-        "message": "युक्ति"
-    },
-    "dim": {
-        "message": "मंद"
-    },
-    "disabled": {
-        "message": "विकलांग"
-    },
-    "dislike": {
-        "message": "नापसन्द"
-    },
-    "donate": {
-        "message": "दान"
-    },
-    "doNotChange": {
-        "message": "मत बदलो"
-    },
-    "draggable": {
-        "message": "खींचने योग्य"
-    },
-    "dropShadow": {
-        "message": "परछाई डालना"
-    },
-    "email": {
-        "message": "ईमेल"
-    },
-    "empty": {
-        "message": "खाली"
-    },
-    "enabled": {
-        "message": "सक्रिय"
-    },
-    "enabledForced": {
-        "message": "सक्रिय(मजबूर)"
-    },
-    "expanded": {
-        "message": "विस्तारित"
-    },
-    "exportSettings": {
-        "message": "निर्यात सेटिंग्स"
-    },
-    "extension": {
-        "message": "एक्सटेंशन"
-    },
-    "file": {
-        "message": "फ़ाइल"
-    },
-    "filters": {
-        "message": "फिल्टर"
-    },
-    "fitToWindow": {
-        "message": "स्क्रीन फिट"
-    },
-    "flash": {
-        "message": "चमक"
-    },
-    "font": {
-        "message": "लिपि"
-    },
-    "fontColor": {
-        "message": "लिपि का रंग"
-    },
-    "fontFamily": {
-        "message": "लिपीओ का काि  संग्रह"
-    },
-    "fontOpacity": {
-        "message": "लिपि की अस्पष्टता"
-    },
-    "fontSize": {
-        "message": "लिपीओ का आकार"
-    },
-    "footer": {
-        "message": "पाद लेख"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "जबरन पार्श्व गति"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "जबरदस्ती वीडियो शुरू से प्ले करें"
-    },
-    "forcedTheaterMode": {
-        "message": "जबरन थिएटर मोड"
-    },
-    "forcedVolume": {
-        "message": "जबरन ध्वनि"
-    },
-    "foundABug": {
-        "message": "बग मिला?"
-    },
-    "fullWindow": {
-        "message": "पूर्ण स्क्रीन"
-    },
-    "general": {
-        "message": "सामान्य"
-    },
-    "github": {
-        "message": "गिटहब"
-    },
-    "goToSearchBox": {
-        "message": "सर्च बॉक्स पर जाएं"
-    },
-    "gpu": {
-        "message": "जी पी यू"
-    },
-    "green": {
-        "message": "हरा"
-    },
-    "hdThumbnail": {
-        "message": "एच डी थंबनेल"
-    },
-    "header": {
-        "message": "हैडर"
-    },
-    "hidden": {
-        "message": "छिपा हुआ"
-    },
-    "hiddenOnVideoPage": {
-        "message": "वीडियो पेज पर छिपा हुआ"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "वीडियो पेज पर छिपा हुआ"
-    },
-    "hideAnnotations": {
-        "message": "एनोटेशन छुपाएं"
-    },
-    "hideCards": {
-        "message": "पत्ते छिपाओ"
-    },
-    "hideCountryCode": {
-        "message": "देश कोड छुपाएं"
-    },
-    "hideDate": {
-        "message": "तारीख छुपाएं"
-    },
-    "hideDetails": {
-        "message": "जानकारी छिपाएँ"
-    },
-    "hideEndscreen": {
-        "message": "अंत स्क्रीन छिपाएँ"
-    },
-    "hideFeaturedContent": {
-        "message": "विशेषताओं को छिपाएँ"
-    },
-    "hideFooter": {
-        "message": "पाद छिपाएँ"
-    },
-    "hideGradientBottom": {
-        "message": "ग्रेडिएंट बॉटम छुपाएं"
-    },
-    "hideHomePageShorts": {
-        "message": "मुखपृष्ठ के शॉर्ट्स हटाएं"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Hide player controls bar buttons"
-    },
-    "hidePlaylist": {
-        "message": "प्लेलिस्ट छिपाएं"
-    },
-    "hideRightButtons": {
-        "message": "दाएं बटन छुपाएं"
-    },
-    "hideScrollForDetails": {
-        "message": "छिपाएँ «विवरण के लिए स्क्रॉल»"
-    },
-    "hideSkipOverlay": {
-        "message": "स्किप ओवरले छुपाएं"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "व्यू काउंट छिपाएं"
-    },
-    "hideVoiceSearchButton": {
-        "message": "ध्वनि खोज बटन छुपाएं"
-    },
-    "history": {
-        "message": "इतिहास"
-    },
-    "home": {
-        "message": "घर"
-    },
-    "hover": {
-        "message": "होवर"
-    },
-    "hoverOnVideoPage": {
-        "message": "वीडियो पेज पर होवर"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "वीडियो कितनी देर पहले अपलोड किया गया था"
-    },
-    "icons": {
-        "message": "प्रतीक"
-    },
-    "iconsOnly": {
-        "message": "केवल प्रतीक"
-    },
-    "importSettings": {
-        "message": "सेटिंग आयात करना"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "यूट्यूब पर बेहतर आइकन"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube भाषा"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube संस्करण"
-    },
-    "improveLogo": {
-        "message": "लोगो सुधारो"
-    },
-    "increasePlaybackSpeed": {
-        "message": "प्लेबैक स्पीड बढ़ाएं"
-    },
-    "increaseVolume": {
-        "message": "ध्वनि बढ़ाएं"
-    },
-    "indigo": {
-        "message": "नील"
-    },
-    "items": {
-        "message": "आइटम"
-    },
-    "languages": {
-        "message": "बोली"
-    },
-    "legacyYoutube": {
-        "message": "विरासत यूट्यूब"
-    },
-    "light": {
-        "message": "हलका"
-    },
-    "lightBlue": {
-        "message": "हल्का नीला"
-    },
-    "lightGreen": {
-        "message": "हल्का हरा"
-    },
-    "like": {
-        "message": "पसंद"
-    },
-    "lime": {
-        "message": "पीला हरा रंग"
-    },
-    "limitPageWidth": {
-        "message": "पृष्ठ की चौड़ाई सीमित करें"
-    },
-    "list": {
-        "message": "सूची"
-    },
-    "liveChat": {
-        "message": "सीधी बातचीत"
-    },
-    "liveChatType": {
-        "message": "लाइव चैट प्रकार"
-    },
-    "location": {
-        "message": "स्थान"
-    },
-    "loudnessNormalization": {
-        "message": "जोर से सामान्य होना"
-    },
-    "markWatchedVideos": {
-        "message": "चिह्नित वीडियो देखे गए"
-    },
-    "mixer": {
-        "message": "मिक्सर"
-    },
-    "myColors": {
-        "message": "मेरे रंग"
-    },
-    "name": {
-        "message": "नाम"
-    },
-    "nativeMiniPlayer": {
-        "message": "मूल निवासी मिनी प्लेयर"
-    },
-    "new": {
-        "message": "नया"
-    },
-    "nextVideo": {
-        "message": "अगला वीडियो"
-    },
-    "night": {
-        "message": "रात"
-    },
-    "noActiveFeatures": {
-        "message": "कोई सक्रिय सुविधाएँ नहीं"
-    },
-    "none": {
-        "message": "कोई नहीं"
-    },
-    "noOpenVideoTabs": {
-        "message": "कोई खुला वीडियो टैब नहीं"
-    },
-    "normal": {
-        "message": "साधारण"
-    },
-    "old": {
-        "message": "पुराना"
-    },
-    "onAllVideos": {
-        "message": "सभी वीडियो पर"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "केवल यूट्यूब पर सक्रिय है"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "केवल एक प्लेयर का चल रहा है"
-    },
-    "onSubscribedChannels": {
-        "message": "सदस्यता प्राप्त चैनलों पर"
-    },
-    "orange": {
-        "message": "नारंगी रंग"
-    },
-    "os": {
-        "message": "ओ एस"
-    },
-    "other": {
-        "message": "अन्य"
-    },
-    "permissions": {
-        "message": "अनुमतियां"
-    },
-    "pictureInPicture": {
-        "message": "चित्र में चित्र"
-    },
-    "pink": {
-        "message": "गुलाबी"
-    },
-    "plain": {
-        "message": "सादा"
-    },
-    "platform": {
-        "message": "मंच"
-    },
-    "playbackSpeed": {
-        "message": "प्लेबैक स्पीड"
-    },
-    "player": {
-        "message": "प्लेयर"
-    },
-    "playerColor": {
-        "message": "प्लेयर रंग"
-    },
-    "playerSize": {
-        "message": "प्लेयर आकार"
-    },
-    "playlist": {
-        "message": "प्लेलिस्ट"
-    },
-    "playlists": {
-        "message": "प्लेलिस्ट"
-    },
-    "playPause": {
-        "message": "प्ले / ठहराव"
-    },
-    "popupPlayer": {
-        "message": "पॉप अप प्लेयर"
-    },
-    "position": {
-        "message": "स्थान"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "किसी भी कुंजी को दबाएं या माउस व्हील का उपयोग करें।"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "किसी भी कुंजी को दबाएं या माउस व्हील का उपयोग करें।"
-    },
-    "previousVideo": {
-        "message": "पिछला वीडियो"
-    },
-    "primaryColor": {
-        "message": "प्राथमिक रंग"
-    },
-    "purple": {
-        "message": "बैंगनी"
-    },
-    "quality": {
-        "message": "गुणवत्ता"
-    },
-    "rateUs": {
-        "message": "हमें रेटिंग दें"
-    },
-    "red": {
-        "message": "लाल"
-    },
-    "redDislikeButton": {
-        "message": "नापसंद बटन लाल रंग दिखाएं"
-    },
-    "relatedVideos": {
-        "message": "संबंधित वीडियो"
-    },
-    "removeRelatedSearchResults": {
-        "message": "संबंधित खोज परिणाम निकालें"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "खोज परिणामों से शॉर्ट्स रील को हटाएं"
-    },
-    "repeat": {
-        "message": "दोहराना"
-    },
-    "reset": {
-        "message": "रीसेट"
-    },
-    "resetAllSettings": {
-        "message": "सभी सेटिंग्स को रीसेट"
-    },
-    "resetAllShortcuts": {
-        "message": "सभी शॉर्टकट रीसेट करें"
-    },
-    "reverse": {
-        "message": "उलटना"
-    },
-    "rotate": {
-        "message": "घुमाएँ"
-    },
-    "save": {
-        "message": "सहेजें"
-    },
-    "saveAs": {
-        "message": "के रूप रक्षित करें"
-    },
-    "schedule": {
-        "message": "अनुसूची"
-    },
-    "screen": {
-        "message": "स्क्रीन"
-    },
-    "screenshot": {
-        "message": "स्क्रीनशॉट"
-    },
-    "search": {
-        "message": "खोज"
-    },
-    "searchBarOnly": {
-        "message": "केवल बार खोजें"
-    },
-    "seekBackward10Seconds": {
-        "message": "पिछड़े 10 सेकंड की तलाश करें"
-    },
-    "seekForward10Seconds": {
-        "message": "पिछड़े 10 सेकंड की तलाश करें"
-    },
-    "seekNextChapter": {
-        "message": "अगले अध्याय पर चलें"
-    },
-    "seekPreviousChapter": {
-        "message": "पिछले अध्याय पर चलें"
-    },
-    "settings": {
-        "message": "समायोजन"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "सेटिंग्स सफलतापूर्वक आयात की गईं"
-    },
-    "shortcuts": {
-        "message": "शॉर्टकट"
-    },
-    "showCardsOnMouseHover": {
-        "message": "माउस होवर पर कार्ड दिखाएं"
-    },
-    "showChannelVideosCount": {
-        "message": "चैनल वीडियो काउंट दिखाएं"
-    },
-    "showLess": {
-        "message": "कम दिखाएं"
-    },
-    "showMore": {
-        "message": "और दिखाएं"
-    },
-    "showRemainingDuration": {
-        "message": "वीडियो की बची हुई अवधि दिखाएं"
-    },
-    "shuffle": {
-        "message": "मिश्रण"
-    },
-    "sidebar": {
-        "message": "साइडबार"
-    },
-    "spacebar": {
-        "message": "स्पेस बार"
-    },
-    "squaredUserImages": {
-        "message": "चुकता उपयोगकर्ता चित्र"
-    },
-    "static": {
-        "message": "स्थिर"
-    },
-    "statsForNerds": {
-        "message": "डेवलपर के लिए आँकड़े दिखाएँ"
-    },
-    "step": {
-        "message": "चरण"
-    },
-    "stop": {
-        "message": "रुकें"
-    },
-    "style": {
-        "message": "अंदाज"
-    },
-    "styles": {
-        "message": "शैलियाँ"
-    },
-    "subscriptions": {
-        "message": "सदस्यता"
-    },
-    "subtitles": {
-        "message": "उपशीर्षक"
-    },
-    "sunset": {
-        "message": "सूर्यास्त"
-    },
-    "sunsetToSunrise": {
-        "message": "सूर्योदय से सूर्यास्त"
-    },
-    "systemPeferenceDark": {
-        "message": "सिस्टम प्राथमिकताएं: अंधेरा"
-    },
-    "systemPeferenceLight": {
-        "message": "सिस्टम वरीयताएँ: प्रकाश"
-    },
-    "teal": {
-        "message": "टील रंग"
-    },
-    "textColor": {
-        "message": "लिखावट का रंग"
-    },
-    "themes": {
-        "message": "विषय-वस्तु"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "यह सभी कुकीज़ को हटा देगा।"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "यह सभी यूट्यूब कुकीज़ को हटा देगा।"
-    },
-    "thisWillResetAllSettings": {
-        "message": "यह सभी सेटिंग्स को रीसेट कर देगा।"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "यह सभी शॉर्टकट रीसेट कर देगा।"
-    },
-    "thumbnails": {
-        "message": "थंबनेल"
-    },
-    "timeFrom": {
-        "message": "से समय"
-    },
-    "timeTo": {
-        "message": "समय पर"
-    },
-    "todayAt": {
-        "message": "आज इस समय"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "शीर्ष चैट"
-    },
-    "trailerAutoplay": {
-        "message": "ट्रेलर ऑटोप्ले"
-    },
-    "translations": {
-        "message": "अनुवाद"
-    },
-    "transparentBackground": {
-        "message": "पारदर्शी पृष्ठभूमि"
-    },
-    "trending": {
-        "message": "रुझान"
-    },
-    "tryToReloadThePage": {
-        "message": "पृष्ठ को पुनः लोड करने का प्रयास करें"
-    },
-    "type": {
-        "message": "टाइप"
-    },
-    "upNextAutoplay": {
-        "message": "अगले ऑटोप्ले पर"
-    },
-    "use24HourFormat": {
-        "message": "24-घंटे के प्रारूप का उपयोग करें"
-    },
-    "version": {
-        "message": "संस्करण"
-    },
-    "video": {
-        "message": "वीडियो"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "श्रेणी का नाम प्राप्त करने के लिए वीडियो विवरण का विस्तार किया जाएगा।"
-    },
-    "videoFormats": {
-        "message": "वीडियो प्रारूप"
-    },
-    "videos": {
-        "message": "वीडियो"
-    },
-    "volume": {
-        "message": "ध्वनि"
-    },
-    "watchLater": {
-        "message": "बाद में देखना"
-    },
-    "watchTime": {
-        "message": "समय देखें"
-    },
-    "whenTabIsChanged": {
-        "message": "जब टैब बदला जाता है"
-    },
-    "white": {
-        "message": "सफेद"
-    },
-    "windowColor": {
-        "message": "विंडो का रंग"
-    },
-    "windowOpacity": {
-        "message": "विंडो की अस्पष्टता"
-    },
-    "yellow": {
-        "message": "पीला"
-    },
-    "youtubeHeaderLeft": {
-        "message": "यूट्यूब हैडर (बाएं)"
-    },
-    "youtubeHeaderRight": {
-        "message": "यूट्यूब हैडर (दाएं)"
-    },
-    "youtubeHomePage": {
-        "message": "यूट्यूब होम पेज"
-    },
-    "youtubeLanguage": {
-        "message": "यूट्यूब भाषा"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "यूट्यूब h.264 कोडेक के लिए वीडियो की गुणवत्ता 1080 पी तक सीमित है"
-    }
+	"about": {
+		"message": "के बारे में"
+	},
+	"accept": {
+		"message": "स्वीकार"
+	},
+	"activate": {
+		"message": "सक्रिय"
+	},
+	"activateCaptions": {
+		"message": "कैप्शन सक्रिय करें"
+	},
+	"activated": {
+		"message": "सक्रिय"
+	},
+	"activatedFeatures": {
+		"message": "सक्रिय विशेषताएं"
+	},
+	"activateFullscreen": {
+		"message": "पूर्णस्क्रीन सक्रिय करें"
+	},
+	"activeFeatures": {
+		"message": "सक्रिय विशेषताएं"
+	},
+	"addScrollToTop": {
+		"message": "«शीर्ष पर स्क्रॉल करें» जोड़ें"
+	},
+	"ads": {
+		"message": "विज्ञापsन"
+	},
+	"all": {
+		"message": "सब"
+	},
+	"allow": {
+		"message": "अनुमति"
+	},
+	"alwaysActive": {
+		"message": "हमेशा सक्रिय"
+	},
+	"alwaysShowProgressBar": {
+		"message": "हमेशा प्रगति बार दिखाएं"
+	},
+	"amber": {
+		"message": "अंबर"
+	},
+	"analyzer": {
+		"message": "विश्लेषक"
+	},
+	"appearance": {
+		"message": "दिखावट"
+	},
+	"audio": {
+		"message": "ऑडियो"
+	},
+	"audioFormats": {
+		"message": "ऑडियो प्रारूप"
+	},
+	"auto": {
+		"message": "खुद ब खुद"
+	},
+	"autoFullscreen": {
+		"message": "स्वत: पूर्ण स्क्रीन"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "टैब स्विच करते समय ऑटोपॉज"
+	},
+	"autoplay": {
+		"message": "स्वत: प्ले"
+	},
+	"backgroundColor": {
+		"message": "पीछे का रंग"
+	},
+	"backgroundOpacity": {
+		"message": "पृष्ठभूमि अस्पष्टता"
+	},
+	"backupAndReset": {
+		"message": "बैकअप पुनर्स्थापित करना"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "सिस्टम रंग योजना के आधार पर"
+	},
+	"belowPlayer": {
+		"message": "प्लेयर के नीचे"
+	},
+	"black": {
+		"message": "काला"
+	},
+	"blockAll": {
+		"message": "सभी को अवरोधित करें"
+	},
+	"blocklist": {
+		"message": "काला सूची में डालना"
+	},
+	"blue": {
+		"message": "नीला"
+	},
+	"blueGray": {
+		"message": "नीला स्लेटी"
+	},
+	"bluelight": {
+		"message": "नीली बत्ती"
+	},
+	"brown": {
+		"message": "भूरा"
+	},
+	"browser": {
+		"message": "ब्राउज़र"
+	},
+	"browserVersion": {
+		"message": "ब्राउज़र संस्करण"
+	},
+	"bubbles": {
+		"message": "बुलबुले"
+	},
+	"bug": {
+		"message": "बग"
+	},
+	"cancel": {
+		"message": "रद्द"
+	},
+	"categories": {
+		"message": "श्रेणियाँ"
+	},
+	"channel": {
+		"message": "चैनल"
+	},
+	"channels": {
+		"message": "चैनल"
+	},
+	"characterEdgeStyle": {
+		"message": "कैरेक्टर एज स्टाइल"
+	},
+	"clipboard": {
+		"message": "क्लिपबोर्ड"
+	},
+	"codecH264": {
+		"message": "कोडक H264"
+	},
+	"collapsed": {
+		"message": "संक्षिप्त"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "सदस्यता वर्गों का पतन"
+	},
+	"comments": {
+		"message": "टिप्पणियाँ"
+	},
+	"confirmationBeforeClosing": {
+		"message": "बंद करने से पहले पुष्टि"
+	},
+	"cookies": {
+		"message": "कुकीज़"
+	},
+	"cores": {
+		"message": "कोर"
+	},
+	"cropChapterTitles": {
+		"message": "फसल अध्याय के शीर्षक"
+	},
+	"customCss": {
+		"message": "कस्टम सीएसएस"
+	},
+	"customJs": {
+		"message": "कस्टम जेएस"
+	},
+	"customMiniPlayer": {
+		"message": "कस्टम मिनी प्लेयर"
+	},
+	"cyan": {
+		"message": "सियान"
+	},
+	"dark": {
+		"message": "अंधेरा"
+	},
+	"darkTheme": {
+		"message": "डार्क थीम"
+	},
+	"dateAndTime": {
+		"message": "दिनांक और समय"
+	},
+	"dawn": {
+		"message": "भोर"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "पार्श्व गति में कमी"
+	},
+	"decreaseVolume": {
+		"message": "ध्वनि कम"
+	},
+	"deepOrange": {
+		"message": "गहरा नारंगी"
+	},
+	"deepPurple": {
+		"message": "गहरा बैंगनी"
+	},
+	"default": {
+		"message": "डिफ़ॉल्ट"
+	},
+	"defaultChannelTab": {
+		"message": "डिफ़ॉल्ट चैनल टैब"
+	},
+	"defaultContentCountry": {
+		"message": "डिफॉल्ट विषय देश"
+	},
+	"deleteYoutubeCookies": {
+		"message": "यूट्यूब कुकीज़ हटाएं"
+	},
+	"depressed": {
+		"message": "उदास"
+	},
+	"description_ext": {
+		"message": "YouTube को व्यवस्थित एवं स्मार्ट बनाएं! यूट्यूब वीडियो कलर एड स्किप वॉल्यूम स्पीड चैनल टूल स्टाइल एचडी विज्ञापन एडब्लॉकर टैग कीवर्ड प्लेलिस्ट"
+	},
+	"desert": {
+		"message": "रेगिस्तान"
+	},
+	"details": {
+		"message": "विवरण"
+	},
+	"developerOptions": {
+		"message": "डेवलपर विकल्प"
+	},
+	"device": {
+		"message": "युक्ति"
+	},
+	"dim": {
+		"message": "मंद"
+	},
+	"disabled": {
+		"message": "विकलांग"
+	},
+	"dislike": {
+		"message": "नापसन्द"
+	},
+	"donate": {
+		"message": "दान"
+	},
+	"doNotChange": {
+		"message": "मत बदलो"
+	},
+	"draggable": {
+		"message": "खींचने योग्य"
+	},
+	"dropShadow": {
+		"message": "परछाई डालना"
+	},
+	"email": {
+		"message": "ईमेल"
+	},
+	"empty": {
+		"message": "खाली"
+	},
+	"enabled": {
+		"message": "सक्रिय"
+	},
+	"enabledForced": {
+		"message": "सक्रिय(मजबूर)"
+	},
+	"expanded": {
+		"message": "विस्तारित"
+	},
+	"exportSettings": {
+		"message": "निर्यात सेटिंग्स"
+	},
+	"extension": {
+		"message": "एक्सटेंशन"
+	},
+	"file": {
+		"message": "फ़ाइल"
+	},
+	"filters": {
+		"message": "फिल्टर"
+	},
+	"fitToWindow": {
+		"message": "स्क्रीन फिट"
+	},
+	"flash": {
+		"message": "चमक"
+	},
+	"font": {
+		"message": "लिपि"
+	},
+	"fontColor": {
+		"message": "लिपि का रंग"
+	},
+	"fontFamily": {
+		"message": "लिपीओ का काि  संग्रह"
+	},
+	"fontOpacity": {
+		"message": "लिपि की अस्पष्टता"
+	},
+	"fontSize": {
+		"message": "लिपीओ का आकार"
+	},
+	"footer": {
+		"message": "पाद लेख"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "जबरन पार्श्व गति"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "जबरदस्ती वीडियो शुरू से प्ले करें"
+	},
+	"forcedTheaterMode": {
+		"message": "जबरन थिएटर मोड"
+	},
+	"forcedVolume": {
+		"message": "जबरन ध्वनि"
+	},
+	"foundABug": {
+		"message": "बग मिला?"
+	},
+	"fullWindow": {
+		"message": "पूर्ण स्क्रीन"
+	},
+	"general": {
+		"message": "सामान्य"
+	},
+	"github": {
+		"message": "गिटहब"
+	},
+	"goToSearchBox": {
+		"message": "सर्च बॉक्स पर जाएं"
+	},
+	"gpu": {
+		"message": "जी पी यू"
+	},
+	"green": {
+		"message": "हरा"
+	},
+	"hdThumbnail": {
+		"message": "एच डी थंबनेल"
+	},
+	"header": {
+		"message": "हैडर"
+	},
+	"hidden": {
+		"message": "छिपा हुआ"
+	},
+	"hiddenOnVideoPage": {
+		"message": "वीडियो पेज पर छिपा हुआ"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "वीडियो पेज पर छिपा हुआ"
+	},
+	"hideAnnotations": {
+		"message": "एनोटेशन छुपाएं"
+	},
+	"hideCards": {
+		"message": "पत्ते छिपाओ"
+	},
+	"hideCountryCode": {
+		"message": "देश कोड छुपाएं"
+	},
+	"hideDate": {
+		"message": "तारीख छुपाएं"
+	},
+	"hideDetails": {
+		"message": "जानकारी छिपाएँ"
+	},
+	"hideEndscreen": {
+		"message": "अंत स्क्रीन छिपाएँ"
+	},
+	"hideFeaturedContent": {
+		"message": "विशेषताओं को छिपाएँ"
+	},
+	"hideFooter": {
+		"message": "पाद छिपाएँ"
+	},
+	"hideGradientBottom": {
+		"message": "ग्रेडिएंट बॉटम छुपाएं"
+	},
+	"hideHomePageShorts": {
+		"message": "मुखपृष्ठ के शॉर्ट्स हटाएं"
+	},
+	"hidePlaylist": {
+		"message": "प्लेलिस्ट छिपाएं"
+	},
+	"hideRightButtons": {
+		"message": "दाएं बटन छुपाएं"
+	},
+	"hideScrollForDetails": {
+		"message": "छिपाएँ «विवरण के लिए स्क्रॉल»"
+	},
+	"hideSkipOverlay": {
+		"message": "स्किप ओवरले छुपाएं"
+	},
+	"hideViewsCount": {
+		"message": "व्यू काउंट छिपाएं"
+	},
+	"hideVoiceSearchButton": {
+		"message": "ध्वनि खोज बटन छुपाएं"
+	},
+	"history": {
+		"message": "इतिहास"
+	},
+	"home": {
+		"message": "घर"
+	},
+	"hover": {
+		"message": "होवर"
+	},
+	"hoverOnVideoPage": {
+		"message": "वीडियो पेज पर होवर"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "वीडियो कितनी देर पहले अपलोड किया गया था"
+	},
+	"icons": {
+		"message": "प्रतीक"
+	},
+	"iconsOnly": {
+		"message": "केवल प्रतीक"
+	},
+	"importSettings": {
+		"message": "सेटिंग आयात करना"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "यूट्यूब पर बेहतर आइकन"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube भाषा"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube संस्करण"
+	},
+	"improveLogo": {
+		"message": "लोगो सुधारो"
+	},
+	"increasePlaybackSpeed": {
+		"message": "प्लेबैक स्पीड बढ़ाएं"
+	},
+	"increaseVolume": {
+		"message": "ध्वनि बढ़ाएं"
+	},
+	"indigo": {
+		"message": "नील"
+	},
+	"items": {
+		"message": "आइटम"
+	},
+	"languages": {
+		"message": "बोली"
+	},
+	"legacyYoutube": {
+		"message": "विरासत यूट्यूब"
+	},
+	"light": {
+		"message": "हलका"
+	},
+	"lightBlue": {
+		"message": "हल्का नीला"
+	},
+	"lightGreen": {
+		"message": "हल्का हरा"
+	},
+	"like": {
+		"message": "पसंद"
+	},
+	"lime": {
+		"message": "पीला हरा रंग"
+	},
+	"limitPageWidth": {
+		"message": "पृष्ठ की चौड़ाई सीमित करें"
+	},
+	"list": {
+		"message": "सूची"
+	},
+	"liveChat": {
+		"message": "सीधी बातचीत"
+	},
+	"liveChatType": {
+		"message": "लाइव चैट प्रकार"
+	},
+	"location": {
+		"message": "स्थान"
+	},
+	"loudnessNormalization": {
+		"message": "जोर से सामान्य होना"
+	},
+	"markWatchedVideos": {
+		"message": "चिह्नित वीडियो देखे गए"
+	},
+	"mixer": {
+		"message": "मिक्सर"
+	},
+	"myColors": {
+		"message": "मेरे रंग"
+	},
+	"name": {
+		"message": "नाम"
+	},
+	"nativeMiniPlayer": {
+		"message": "मूल निवासी मिनी प्लेयर"
+	},
+	"new": {
+		"message": "नया"
+	},
+	"nextVideo": {
+		"message": "अगला वीडियो"
+	},
+	"night": {
+		"message": "रात"
+	},
+	"noActiveFeatures": {
+		"message": "कोई सक्रिय सुविधाएँ नहीं"
+	},
+	"none": {
+		"message": "कोई नहीं"
+	},
+	"noOpenVideoTabs": {
+		"message": "कोई खुला वीडियो टैब नहीं"
+	},
+	"normal": {
+		"message": "साधारण"
+	},
+	"old": {
+		"message": "पुराना"
+	},
+	"onAllVideos": {
+		"message": "सभी वीडियो पर"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "केवल यूट्यूब पर सक्रिय है"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "केवल एक प्लेयर का चल रहा है"
+	},
+	"onSubscribedChannels": {
+		"message": "सदस्यता प्राप्त चैनलों पर"
+	},
+	"orange": {
+		"message": "नारंगी रंग"
+	},
+	"os": {
+		"message": "ओ एस"
+	},
+	"other": {
+		"message": "अन्य"
+	},
+	"permissions": {
+		"message": "अनुमतियां"
+	},
+	"pictureInPicture": {
+		"message": "चित्र में चित्र"
+	},
+	"pink": {
+		"message": "गुलाबी"
+	},
+	"plain": {
+		"message": "सादा"
+	},
+	"platform": {
+		"message": "मंच"
+	},
+	"playbackSpeed": {
+		"message": "प्लेबैक स्पीड"
+	},
+	"player": {
+		"message": "प्लेयर"
+	},
+	"playerColor": {
+		"message": "प्लेयर रंग"
+	},
+	"playerSize": {
+		"message": "प्लेयर आकार"
+	},
+	"playlist": {
+		"message": "प्लेलिस्ट"
+	},
+	"playlists": {
+		"message": "प्लेलिस्ट"
+	},
+	"playPause": {
+		"message": "प्ले / ठहराव"
+	},
+	"popupPlayer": {
+		"message": "पॉप अप प्लेयर"
+	},
+	"position": {
+		"message": "स्थान"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "किसी भी कुंजी को दबाएं या माउस व्हील का उपयोग करें।"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "किसी भी कुंजी को दबाएं या माउस व्हील का उपयोग करें।"
+	},
+	"previousVideo": {
+		"message": "पिछला वीडियो"
+	},
+	"primaryColor": {
+		"message": "प्राथमिक रंग"
+	},
+	"purple": {
+		"message": "बैंगनी"
+	},
+	"quality": {
+		"message": "गुणवत्ता"
+	},
+	"rateUs": {
+		"message": "हमें रेटिंग दें"
+	},
+	"red": {
+		"message": "लाल"
+	},
+	"redDislikeButton": {
+		"message": "नापसंद बटन लाल रंग दिखाएं"
+	},
+	"relatedVideos": {
+		"message": "संबंधित वीडियो"
+	},
+	"removeRelatedSearchResults": {
+		"message": "संबंधित खोज परिणाम निकालें"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "खोज परिणामों से शॉर्ट्स रील को हटाएं"
+	},
+	"repeat": {
+		"message": "दोहराना"
+	},
+	"reset": {
+		"message": "रीसेट"
+	},
+	"resetAllSettings": {
+		"message": "सभी सेटिंग्स को रीसेट"
+	},
+	"resetAllShortcuts": {
+		"message": "सभी शॉर्टकट रीसेट करें"
+	},
+	"reverse": {
+		"message": "उलटना"
+	},
+	"rotate": {
+		"message": "घुमाएँ"
+	},
+	"save": {
+		"message": "सहेजें"
+	},
+	"saveAs": {
+		"message": "के रूप रक्षित करें"
+	},
+	"schedule": {
+		"message": "अनुसूची"
+	},
+	"screen": {
+		"message": "स्क्रीन"
+	},
+	"screenshot": {
+		"message": "स्क्रीनशॉट"
+	},
+	"search": {
+		"message": "खोज"
+	},
+	"searchBarOnly": {
+		"message": "केवल बार खोजें"
+	},
+	"seekBackward10Seconds": {
+		"message": "पिछड़े 10 सेकंड की तलाश करें"
+	},
+	"seekForward10Seconds": {
+		"message": "पिछड़े 10 सेकंड की तलाश करें"
+	},
+	"seekNextChapter": {
+		"message": "अगले अध्याय पर चलें"
+	},
+	"seekPreviousChapter": {
+		"message": "पिछले अध्याय पर चलें"
+	},
+	"settings": {
+		"message": "समायोजन"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "सेटिंग्स सफलतापूर्वक आयात की गईं"
+	},
+	"shortcuts": {
+		"message": "शॉर्टकट"
+	},
+	"showCardsOnMouseHover": {
+		"message": "माउस होवर पर कार्ड दिखाएं"
+	},
+	"showChannelVideosCount": {
+		"message": "चैनल वीडियो काउंट दिखाएं"
+	},
+	"showLess": {
+		"message": "कम दिखाएं"
+	},
+	"showMore": {
+		"message": "और दिखाएं"
+	},
+	"showRemainingDuration": {
+		"message": "वीडियो की बची हुई अवधि दिखाएं"
+	},
+	"shuffle": {
+		"message": "मिश्रण"
+	},
+	"sidebar": {
+		"message": "साइडबार"
+	},
+	"spacebar": {
+		"message": "स्पेस बार"
+	},
+	"squaredUserImages": {
+		"message": "चुकता उपयोगकर्ता चित्र"
+	},
+	"static": {
+		"message": "स्थिर"
+	},
+	"statsForNerds": {
+		"message": "डेवलपर के लिए आँकड़े दिखाएँ"
+	},
+	"step": {
+		"message": "चरण"
+	},
+	"stop": {
+		"message": "रुकें"
+	},
+	"style": {
+		"message": "अंदाज"
+	},
+	"styles": {
+		"message": "शैलियाँ"
+	},
+	"subscriptions": {
+		"message": "सदस्यता"
+	},
+	"subtitles": {
+		"message": "उपशीर्षक"
+	},
+	"sunset": {
+		"message": "सूर्यास्त"
+	},
+	"sunsetToSunrise": {
+		"message": "सूर्योदय से सूर्यास्त"
+	},
+	"systemPeferenceDark": {
+		"message": "सिस्टम प्राथमिकताएं: अंधेरा"
+	},
+	"systemPeferenceLight": {
+		"message": "सिस्टम वरीयताएँ: प्रकाश"
+	},
+	"teal": {
+		"message": "टील रंग"
+	},
+	"textColor": {
+		"message": "लिखावट का रंग"
+	},
+	"themes": {
+		"message": "विषय-वस्तु"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "यह सभी कुकीज़ को हटा देगा।"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "यह सभी यूट्यूब कुकीज़ को हटा देगा।"
+	},
+	"thisWillResetAllSettings": {
+		"message": "यह सभी सेटिंग्स को रीसेट कर देगा।"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "यह सभी शॉर्टकट रीसेट कर देगा।"
+	},
+	"thumbnails": {
+		"message": "थंबनेल"
+	},
+	"timeFrom": {
+		"message": "से समय"
+	},
+	"timeTo": {
+		"message": "समय पर"
+	},
+	"todayAt": {
+		"message": "आज इस समय"
+	},
+	"topChat": {
+		"message": "शीर्ष चैट"
+	},
+	"trailerAutoplay": {
+		"message": "ट्रेलर ऑटोप्ले"
+	},
+	"translations": {
+		"message": "अनुवाद"
+	},
+	"transparentBackground": {
+		"message": "पारदर्शी पृष्ठभूमि"
+	},
+	"trending": {
+		"message": "रुझान"
+	},
+	"tryToReloadThePage": {
+		"message": "पृष्ठ को पुनः लोड करने का प्रयास करें"
+	},
+	"type": {
+		"message": "टाइप"
+	},
+	"upNextAutoplay": {
+		"message": "अगले ऑटोप्ले पर"
+	},
+	"use24HourFormat": {
+		"message": "24-घंटे के प्रारूप का उपयोग करें"
+	},
+	"version": {
+		"message": "संस्करण"
+	},
+	"video": {
+		"message": "वीडियो"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "श्रेणी का नाम प्राप्त करने के लिए वीडियो विवरण का विस्तार किया जाएगा।"
+	},
+	"videoFormats": {
+		"message": "वीडियो प्रारूप"
+	},
+	"videos": {
+		"message": "वीडियो"
+	},
+	"volume": {
+		"message": "ध्वनि"
+	},
+	"watchLater": {
+		"message": "बाद में देखना"
+	},
+	"watchTime": {
+		"message": "समय देखें"
+	},
+	"whenTabIsChanged": {
+		"message": "जब टैब बदला जाता है"
+	},
+	"white": {
+		"message": "सफेद"
+	},
+	"windowColor": {
+		"message": "विंडो का रंग"
+	},
+	"windowOpacity": {
+		"message": "विंडो की अस्पष्टता"
+	},
+	"yellow": {
+		"message": "पीला"
+	},
+	"youtubeHeaderLeft": {
+		"message": "यूट्यूब हैडर (बाएं)"
+	},
+	"youtubeHeaderRight": {
+		"message": "यूट्यूब हैडर (दाएं)"
+	},
+	"youtubeHomePage": {
+		"message": "यूट्यूब होम पेज"
+	},
+	"youtubeLanguage": {
+		"message": "यूट्यूब भाषा"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "यूट्यूब h.264 कोडेक के लिए वीडियो की गुणवत्ता 1080 पी तक सीमित है"
+	}
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -1,782 +1,782 @@
 {
-    "about": {
-        "message": "O"
-    },
-    "accept": {
-        "message": "Prihvati"
-    },
-    "activate": {
-        "message": "Aktiviraj"
-    },
-    "activateCaptions": {
-        "message": "Aktiviraj naslove"
-    },
-    "activated": {
-        "message": "Aktivirano"
-    },
-    "activatedFeatures": {
-        "message": "Aktivirane značajke"
-    },
-    "activateFullscreen": {
-        "message": "Aktiviraj puni zaslon"
-    },
-    "activeFeatures": {
-        "message": "Aktivne značajke"
-    },
-    "addScrollToTop": {
-        "message": "Dodaj «Pomaknite se na vrh»"
-    },
-    "ads": {
-        "message": "Oglasi"
-    },
-    "all": {
-        "message": "Sve"
-    },
-    "allow": {
-        "message": "Dopusti"
-    },
-    "alwaysActive": {
-        "message": "Uvijek aktivan"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Uvijek prikaži traku napretka"
-    },
-    "amber": {
-        "message": "Jantar"
-    },
-    "analyzer": {
-        "message": "Analizator"
-    },
-    "appearance": {
-        "message": "Izgled"
-    },
-    "audioFormats": {
-        "message": "Audio formati"
-    },
-    "autoFullscreen": {
-        "message": "Automatski prikaz preko cijelog zaslona"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Automatska pauza prilikom zamjene kartica"
-    },
-    "autoplay": {
-        "message": "Auto Play"
-    },
-    "backupAndReset": {
-        "message": "Sigurnosna kopija i resetiranje"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Na temelju shema boja sustava"
-    },
-    "belowPlayer": {
-        "message": "Ispod Playera"
-    },
-    "black": {
-        "message": "Crno"
-    },
-    "blockAll": {
-        "message": "Blokiraj sve"
-    },
-    "blocklist": {
-        "message": "Crna lista"
-    },
-    "blue": {
-        "message": "Plava"
-    },
-    "blueGray": {
-        "message": "Plavo siva"
-    },
-    "bluelight": {
-        "message": "Svijetlo plava"
-    },
-    "brown": {
-        "message": "Smeđa"
-    },
-    "browser": {
-        "message": "Preglednik"
-    },
-    "browserVersion": {
-        "message": "Verzija preglednika"
-    },
-    "bubbles": {
-        "message": "Mjehurići"
-    },
-    "bug": {
-        "message": "Greška"
-    },
-    "buttons": {
-        "message": "Gumbi"
-    },
-    "cancel": {
-        "message": "Otkaži"
-    },
-    "categories": {
-        "message": "Kategorije"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanali"
-    },
-    "clipboard": {
-        "message": "Međuspremnik"
-    },
-    "codecH264": {
-        "message": "Kodek h.264"
-    },
-    "collapsed": {
-        "message": "Skupljeno"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Skupljanje pretplatničkih odjeljaka"
-    },
-    "comments": {
-        "message": "Komentari"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Potvrda prije zatvaranja"
-    },
-    "cookies": {
-        "message": "Kolačići"
-    },
-    "cores": {
-        "message": "Jezgre"
-    },
-    "cropChapterTitles": {
-        "message": "Izreži naslove poglavlja"
-    },
-    "customCss": {
-        "message": "Prilagođeni CSS"
-    },
-    "customJs": {
-        "message": "Prilagođeni JS"
-    },
-    "customMiniPlayer": {
-        "message": "Prilagođeni Mini-Player"
-    },
-    "cyan": {
-        "message": "Cijan"
-    },
-    "dark": {
-        "message": "Tamno"
-    },
-    "darkTheme": {
-        "message": "Tamna tema"
-    },
-    "dateAndTime": {
-        "message": "Datum & vrijeme"
-    },
-    "dawn": {
-        "message": "Zora"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Smanji brzinu reprodukcije"
-    },
-    "decreaseVolume": {
-        "message": "Smanji glasnoću"
-    },
-    "deepOrange": {
-        "message": "Duboko narančasta"
-    },
-    "deepPurple": {
-        "message": "Duboko ljubičasta"
-    },
-    "defaultChannelTab": {
-        "message": "Zadana kartica kanala"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Izbrišite YouTube kolačiće"
-    },
-    "desert": {
-        "message": "Zasluga"
-    },
-    "details": {
-        "message": "Pojedinosti"
-    },
-    "developerOptions": {
-        "message": "Opcije za programere"
-    },
-    "device": {
-        "message": "Uređaj"
-    },
-    "dim": {
-        "message": "Priguši"
-    },
-    "disabled": {
-        "message": "Onemogućeno"
-    },
-    "dislike": {
-        "message": "Ne sviđa mi se"
-    },
-    "donate": {
-        "message": "Doniraj"
-    },
-    "doNotChange": {
-        "message": "Nemoj mijenjati"
-    },
-    "draggable": {
-        "message": "Povuci"
-    },
-    "email": {
-        "message": "E-mail"
-    },
-    "empty": {
-        "message": "Prazno"
-    },
-    "enabled": {
-        "message": "Omogućeno"
-    },
-    "enabledForced": {
-        "message": "Omogućeno (prisilno)"
-    },
-    "expanded": {
-        "message": "Prošireno"
-    },
-    "exportSettings": {
-        "message": "Izvoz postavki"
-    },
-    "extension": {
-        "message": "Proširenje"
-    },
-    "file": {
-        "message": "Datoteka"
-    },
-    "filters": {
-        "message": "Filteri"
-    },
-    "fitToWindow": {
-        "message": "Prilagodi prozoru"
-    },
-    "footer": {
-        "message": "Podnožje"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Prisiljena brzina reprodukcije"
-    },
-    "forcedTheaterMode": {
-        "message": "Prisiljen kazališni način"
-    },
-    "forcedVolume": {
-        "message": "Prisiljena glasnoća"
-    },
-    "forceSDR": {
-        "message": "Prisilno SDR"
-    },
-    "foundABug": {
-        "message": "Pronašli ste grešku?"
-    },
-    "fullWindow": {
-        "message": "Puni prozor"
-    },
-    "general": {
-        "message": "Općenito"
-    },
-    "geoPreference": {
-        "message": "Geografske preferencije"
-    },
-    "goToSearchBox": {
-        "message": "Idite na okvir za pretraživanje"
-    },
-    "green": {
-        "message": "Zelena"
-    },
-    "hdThumbnail": {
-        "message": "HD sličica"
-    },
-    "header": {
-        "message": "Zaglavlje"
-    },
-    "hidden": {
-        "message": "Skriven"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Skriveno na stranici videozapisa"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Sakrij animirane sličice"
-    },
-    "hideAnnotations": {
-        "message": "Sakrij napomene"
-    },
-    "hideCards": {
-        "message": "Sakrij kartice"
-    },
-    "hideDetails": {
-        "message": "Sakrij detalje"
-    },
-    "hideEndscreen": {
-        "message": "Sakrij završni zaslon"
-    },
-    "hideFeaturedContent": {
-        "message": "Sakrij istaknuti sadržaj"
-    },
-    "hideFooter": {
-        "message": "Sakrij podnožje"
-    },
-    "hideGradientBottom": {
-        "message": "Sakrij sjenu oko trake playera"
-    },
-    "hideHomePageShorts": {
-        "message": "Uklonite Shorts s početne stranice"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Sakrij kontrole playera"
-    },
-    "hidePlaylist": {
-        "message": "Sakrij popis za reprodukciju"
-    },
-    "hideRightButtons": {
-        "message": "Sakrij desne gumbe"
-    },
-    "hideScrollForDetails": {
-        "message": "Sakrij «Pomakni za detalje»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Sakrij gumbe na sličicama"
-    },
-    "hideViewsCount": {
-        "message": "Sakrij broj pregleda"
-    },
-    "history": {
-        "message": "Povijest"
-    },
-    "home": {
-        "message": "Početna"
-    },
-    "hover": {
-        "message": "Pređite mišem preko"
-    },
-    "hoverOnVideoPage": {
-        "message": "Zadržite pokazivač miša na stranici videozapisa"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Prije koliko je vremena video prenesen"
-    },
-    "icons": {
-        "message": "Ikone"
-    },
-    "iconsOnly": {
-        "message": "Samo ikone"
-    },
-    "importSettings": {
-        "message": "Uvezi postavke"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ikona ImprovedTube na YouTubeu"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube jezik"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube verzija"
-    },
-    "improveLogo": {
-        "message": "Poboljšajte logotip"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Povećajte brzinu reprodukcije"
-    },
-    "increaseVolume": {
-        "message": "Povećajte glasnoću"
-    },
-    "items": {
-        "message": "Predmeti"
-    },
-    "languages": {
-        "message": "Jezici"
-    },
-    "legacyYoutube": {
-        "message": "Naslijeđeni YouTube"
-    },
-    "light": {
-        "message": "Svjetlo"
-    },
-    "lightBlue": {
-        "message": "Svjetlo plava"
-    },
-    "lightGreen": {
-        "message": "Svjetlo zelena"
-    },
-    "like": {
-        "message": "Sviđa mi se"
-    },
-    "lime": {
-        "message": "Limeta"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Chat uživo"
-    },
-    "liveChatType": {
-        "message": "Vrsta chata uživo"
-    },
-    "loudnessNormalization": {
-        "message": "Normalizacija glasnoće"
-    },
-    "markWatchedVideos": {
-        "message": "Označi pogledane videozapise"
-    },
-    "mixer": {
-        "message": "Mikser"
-    },
-    "myColors": {
-        "message": "Moje boje"
-    },
-    "name": {
-        "message": "Naziv"
-    },
-    "nativeMiniPlayer": {
-        "message": "Izvorni mini player"
-    },
-    "new": {
-        "message": "Novo"
-    },
-    "nextVideo": {
-        "message": "Sljedeći video"
-    },
-    "night": {
-        "message": "Noć"
-    },
-    "noActiveFeatures": {
-        "message": "Nema aktivnih značajki"
-    },
-    "none": {
-        "message": "Nijedna"
-    },
-    "noOpenVideoTabs": {
-        "message": "Nema otvorenih video kartica"
-    },
-    "normal": {
-        "message": "Normalno"
-    },
-    "old": {
-        "message": "Staro"
-    },
-    "onAllVideos": {
-        "message": "Na svim video zapisima"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Aktivno samo na YouTubeu"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Svira samo jedna instanca playera"
-    },
-    "onSubscribedChannels": {
-        "message": "Na pretplaćenim kanalima"
-    },
-    "openPopupPlayer": {
-        "message": "Otvorite videozapis / popis za reprodukciju u novom prozoru"
-    },
-    "orange": {
-        "message": "Narančasto"
-    },
-    "other": {
-        "message": "Ostalo"
-    },
-    "permissions": {
-        "message": "Dopuštenja"
-    },
-    "pictureInPicture": {
-        "message": "Slika u slici"
-    },
-    "pink": {
-        "message": "Ružičasto"
-    },
-    "plain": {
-        "message": "Jednostavno"
-    },
-    "platform": {
-        "message": "Platforma"
-    },
-    "playbackSpeed": {
-        "message": "Brzina reprodukcije"
-    },
-    "playerColor": {
-        "message": "Boja playera"
-    },
-    "playerSize": {
-        "message": "Veličina playera"
-    },
-    "playlist": {
-        "message": "Popis za reprodukciju"
-    },
-    "playlists": {
-        "message": "Popisi za reprodukciju"
-    },
-    "playPause": {
-        "message": "Reprodukcija / pauza"
-    },
-    "popupPlayer": {
-        "message": "Player u skočnom prozoru"
-    },
-    "position": {
-        "message": "Položaj"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Pritisnite bilo koju tipku ili upotrijebite kotačić miša."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Pritisnite bilo koju tipku ili upotrijebite kotačić miša"
-    },
-    "previousVideo": {
-        "message": "Prethodni videozapis"
-    },
-    "primaryColor": {
-        "message": "Primarna boja"
-    },
-    "purple": {
-        "message": "Ljubičasta"
-    },
-    "quality": {
-        "message": "Kvaliteta"
-    },
-    "ram": {
-        "message": "Radna memorija"
-    },
-    "rateUs": {
-        "message": "Ocijenite nas"
-    },
-    "red": {
-        "message": "Crvena"
-    },
-    "redDislikeButton": {
-        "message": "Prikaži ne sviđa mi se botun u crvenoj boji"
-    },
-    "relatedVideos": {
-        "message": "Slični videozapisi"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Uklonite slične rezultate pretraživanja"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Uklonite Shorts kolut iz rezultata pretrage"
-    },
-    "repeat": {
-        "message": "Ponovi"
-    },
-    "reset": {
-        "message": "Resetiraj"
-    },
-    "resetAllSettings": {
-        "message": "Resetirajte sve postavke"
-    },
-    "resetAllShortcuts": {
-        "message": "Resetirajte sve prečace"
-    },
-    "reverse": {
-        "message": "Preokreni"
-    },
-    "rotate": {
-        "message": "Rotiraj"
-    },
-    "save": {
-        "message": "Sačuvaj"
-    },
-    "saveAs": {
-        "message": "Sačuvaj kao"
-    },
-    "schedule": {
-        "message": "Stavi na raspored"
-    },
-    "screen": {
-        "message": "Zaslon"
-    },
-    "screenshot": {
-        "message": "Snimka zaslona"
-    },
-    "search": {
-        "message": "Pretraži"
-    },
-    "searchBarOnly": {
-        "message": "Samo traka za pretraživanje"
-    },
-    "seekBackward10Seconds": {
-        "message": "Traži unatrag 10 sekundi"
-    },
-    "seekForward10Seconds": {
-        "message": "Traži 10 sekundi prema naprijed"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Postavke"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Postavke su uspješno uvezene"
-    },
-    "shortcuts": {
-        "message": "Prečaci"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Pokaži kartice prilikom prelaska miša"
-    },
-    "showChannelVideosCount": {
-        "message": "Prikaži broj videozapisa na kanalu"
-    },
-    "shuffle": {
-        "message": "Nasumično"
-    },
-    "sidebar": {
-        "message": "Bočna traka"
-    },
-    "spacebar": {
-        "message": "Tipka razmaka"
-    },
-    "squaredUserImages": {
-        "message": "Korisničke slike u kvadratu"
-    },
-    "static": {
-        "message": "Statički"
-    },
-    "statsForNerds": {
-        "message": "Prikaži statistiku za štrebere"
-    },
-    "step": {
-        "message": "Korak"
-    },
-    "stop": {
-        "message": "Stani"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stilovi"
-    },
-    "subscriptions": {
-        "message": "Pretplate"
-    },
-    "subtitles": {
-        "message": "Titlovi"
-    },
-    "sunset": {
-        "message": "Zalazak sunca"
-    },
-    "sunsetToSunrise": {
-        "message": "Od zalaska do izlaska sunca"
-    },
-    "systemPeferenceDark": {
-        "message": "Postavke sustava: tamno"
-    },
-    "systemPeferenceLight": {
-        "message": "Postavke sustava: svjetlo"
-    },
-    "textColor": {
-        "message": "Boja teksta"
-    },
-    "themes": {
-        "message": "Teme"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Ovo će ukloniti sve kolačiće."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Ovo će ukloniti sve YouTube kolačiće"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Ovo će resetirati sve postavke."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Ovo će resetirati sve prečace"
-    },
-    "thumbnails": {
-        "message": "Sličice"
-    },
-    "timeFrom": {
-        "message": "Vrijeme od"
-    },
-    "timeTo": {
-        "message": "Vrijeme do"
-    },
-    "todayAt": {
-        "message": "Danas u"
-    },
-    "toggleAutoplay": {
-        "message": "Uključi / isključi automatsku reprodukciju"
-    },
-    "toggleCards": {
-        "message": "Uključi / isključi kartice"
-    },
-    "toggleControls": {
-        "message": "Uključi / isključi kontrole playera"
-    },
-    "trailerAutoplay": {
-        "message": "Automatska reprodukcija kratkog filma"
-    },
-    "translations": {
-        "message": "Prijevodi"
-    },
-    "transparentBackground": {
-        "message": "Prozirna pozadina"
-    },
-    "trending": {
-        "message": "U trendu"
-    },
-    "tryToReloadThePage": {
-        "message": "Pokušajte ponovo učitati stranicu"
-    },
-    "type": {
-        "message": "Tip"
-    },
-    "upNextAutoplay": {
-        "message": "Sljedeća automatska reprodukcija"
-    },
-    "use24HourFormat": {
-        "message": "Koristite 24-satni format"
-    },
-    "version": {
-        "message": "Verzija"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Opis videozapisa biti će proširen kako bi se dobio naziv kategorije"
-    },
-    "videoFormats": {
-        "message": "Video formati"
-    },
-    "videos": {
-        "message": "Videozapisi"
-    },
-    "volume": {
-        "message": "Glasnoća"
-    },
-    "watchLater": {
-        "message": "Gledaj kasnije"
-    },
-    "watchTime": {
-        "message": "Vrijeme gledanja"
-    },
-    "whenTabIsChanged": {
-        "message": "Kada se kartica promijeni"
-    },
-    "white": {
-        "message": "Bijela"
-    },
-    "yellow": {
-        "message": "Žuta"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube zaglavlje (lijevo)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube zaglavlje (desno)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube početna stranica"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube jezik"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube ograničava kvalitetu videozapisa na 1080p za h.264 kodek"
-    }
+	"about": {
+		"message": "O"
+	},
+	"accept": {
+		"message": "Prihvati"
+	},
+	"activate": {
+		"message": "Aktiviraj"
+	},
+	"activateCaptions": {
+		"message": "Aktiviraj naslove"
+	},
+	"activated": {
+		"message": "Aktivirano"
+	},
+	"activatedFeatures": {
+		"message": "Aktivirane značajke"
+	},
+	"activateFullscreen": {
+		"message": "Aktiviraj puni zaslon"
+	},
+	"activeFeatures": {
+		"message": "Aktivne značajke"
+	},
+	"addScrollToTop": {
+		"message": "Dodaj «Pomaknite se na vrh»"
+	},
+	"ads": {
+		"message": "Oglasi"
+	},
+	"all": {
+		"message": "Sve"
+	},
+	"allow": {
+		"message": "Dopusti"
+	},
+	"alwaysActive": {
+		"message": "Uvijek aktivan"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Uvijek prikaži traku napretka"
+	},
+	"amber": {
+		"message": "Jantar"
+	},
+	"analyzer": {
+		"message": "Analizator"
+	},
+	"appearance": {
+		"message": "Izgled"
+	},
+	"audioFormats": {
+		"message": "Audio formati"
+	},
+	"autoFullscreen": {
+		"message": "Automatski prikaz preko cijelog zaslona"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Automatska pauza prilikom zamjene kartica"
+	},
+	"autoplay": {
+		"message": "Auto Play"
+	},
+	"backupAndReset": {
+		"message": "Sigurnosna kopija i resetiranje"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Na temelju shema boja sustava"
+	},
+	"belowPlayer": {
+		"message": "Ispod Playera"
+	},
+	"black": {
+		"message": "Crno"
+	},
+	"blockAll": {
+		"message": "Blokiraj sve"
+	},
+	"blocklist": {
+		"message": "Crna lista"
+	},
+	"blue": {
+		"message": "Plava"
+	},
+	"blueGray": {
+		"message": "Plavo siva"
+	},
+	"bluelight": {
+		"message": "Svijetlo plava"
+	},
+	"brown": {
+		"message": "Smeđa"
+	},
+	"browser": {
+		"message": "Preglednik"
+	},
+	"browserVersion": {
+		"message": "Verzija preglednika"
+	},
+	"bubbles": {
+		"message": "Mjehurići"
+	},
+	"bug": {
+		"message": "Greška"
+	},
+	"buttons": {
+		"message": "Gumbi"
+	},
+	"cancel": {
+		"message": "Otkaži"
+	},
+	"categories": {
+		"message": "Kategorije"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanali"
+	},
+	"clipboard": {
+		"message": "Međuspremnik"
+	},
+	"codecH264": {
+		"message": "Kodek h.264"
+	},
+	"collapsed": {
+		"message": "Skupljeno"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Skupljanje pretplatničkih odjeljaka"
+	},
+	"comments": {
+		"message": "Komentari"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Potvrda prije zatvaranja"
+	},
+	"cookies": {
+		"message": "Kolačići"
+	},
+	"cores": {
+		"message": "Jezgre"
+	},
+	"cropChapterTitles": {
+		"message": "Izreži naslove poglavlja"
+	},
+	"customCss": {
+		"message": "Prilagođeni CSS"
+	},
+	"customJs": {
+		"message": "Prilagođeni JS"
+	},
+	"customMiniPlayer": {
+		"message": "Prilagođeni Mini-Player"
+	},
+	"cyan": {
+		"message": "Cijan"
+	},
+	"dark": {
+		"message": "Tamno"
+	},
+	"darkTheme": {
+		"message": "Tamna tema"
+	},
+	"dateAndTime": {
+		"message": "Datum & vrijeme"
+	},
+	"dawn": {
+		"message": "Zora"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Smanji brzinu reprodukcije"
+	},
+	"decreaseVolume": {
+		"message": "Smanji glasnoću"
+	},
+	"deepOrange": {
+		"message": "Duboko narančasta"
+	},
+	"deepPurple": {
+		"message": "Duboko ljubičasta"
+	},
+	"defaultChannelTab": {
+		"message": "Zadana kartica kanala"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Izbrišite YouTube kolačiće"
+	},
+	"desert": {
+		"message": "Zasluga"
+	},
+	"details": {
+		"message": "Pojedinosti"
+	},
+	"developerOptions": {
+		"message": "Opcije za programere"
+	},
+	"device": {
+		"message": "Uređaj"
+	},
+	"dim": {
+		"message": "Priguši"
+	},
+	"disabled": {
+		"message": "Onemogućeno"
+	},
+	"dislike": {
+		"message": "Ne sviđa mi se"
+	},
+	"donate": {
+		"message": "Doniraj"
+	},
+	"doNotChange": {
+		"message": "Nemoj mijenjati"
+	},
+	"draggable": {
+		"message": "Povuci"
+	},
+	"email": {
+		"message": "E-mail"
+	},
+	"empty": {
+		"message": "Prazno"
+	},
+	"enabled": {
+		"message": "Omogućeno"
+	},
+	"enabledForced": {
+		"message": "Omogućeno (prisilno)"
+	},
+	"expanded": {
+		"message": "Prošireno"
+	},
+	"exportSettings": {
+		"message": "Izvoz postavki"
+	},
+	"extension": {
+		"message": "Proširenje"
+	},
+	"file": {
+		"message": "Datoteka"
+	},
+	"filters": {
+		"message": "Filteri"
+	},
+	"fitToWindow": {
+		"message": "Prilagodi prozoru"
+	},
+	"footer": {
+		"message": "Podnožje"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Prisiljena brzina reprodukcije"
+	},
+	"forcedTheaterMode": {
+		"message": "Prisiljen kazališni način"
+	},
+	"forcedVolume": {
+		"message": "Prisiljena glasnoća"
+	},
+	"forceSDR": {
+		"message": "Prisilno SDR"
+	},
+	"foundABug": {
+		"message": "Pronašli ste grešku?"
+	},
+	"fullWindow": {
+		"message": "Puni prozor"
+	},
+	"general": {
+		"message": "Općenito"
+	},
+	"geoPreference": {
+		"message": "Geografske preferencije"
+	},
+	"goToSearchBox": {
+		"message": "Idite na okvir za pretraživanje"
+	},
+	"green": {
+		"message": "Zelena"
+	},
+	"hdThumbnail": {
+		"message": "HD sličica"
+	},
+	"header": {
+		"message": "Zaglavlje"
+	},
+	"hidden": {
+		"message": "Skriven"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Skriveno na stranici videozapisa"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Sakrij animirane sličice"
+	},
+	"hideAnnotations": {
+		"message": "Sakrij napomene"
+	},
+	"hideCards": {
+		"message": "Sakrij kartice"
+	},
+	"hideDetails": {
+		"message": "Sakrij detalje"
+	},
+	"hideEndscreen": {
+		"message": "Sakrij završni zaslon"
+	},
+	"hideFeaturedContent": {
+		"message": "Sakrij istaknuti sadržaj"
+	},
+	"hideFooter": {
+		"message": "Sakrij podnožje"
+	},
+	"hideGradientBottom": {
+		"message": "Sakrij sjenu oko trake playera"
+	},
+	"hideHomePageShorts": {
+		"message": "Uklonite Shorts s početne stranice"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Sakrij kontrole playera"
+	},
+	"hidePlaylist": {
+		"message": "Sakrij popis za reprodukciju"
+	},
+	"hideRightButtons": {
+		"message": "Sakrij desne gumbe"
+	},
+	"hideScrollForDetails": {
+		"message": "Sakrij «Pomakni za detalje»"
+	},
+	"hideSkipOverlay": {
+		"message": "Hide Skip Overlay"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Sakrij gumbe na sličicama"
+	},
+	"hideViewsCount": {
+		"message": "Sakrij broj pregleda"
+	},
+	"history": {
+		"message": "Povijest"
+	},
+	"home": {
+		"message": "Početna"
+	},
+	"hover": {
+		"message": "Pređite mišem preko"
+	},
+	"hoverOnVideoPage": {
+		"message": "Zadržite pokazivač miša na stranici videozapisa"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Prije koliko je vremena video prenesen"
+	},
+	"icons": {
+		"message": "Ikone"
+	},
+	"iconsOnly": {
+		"message": "Samo ikone"
+	},
+	"importSettings": {
+		"message": "Uvezi postavke"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ikona ImprovedTube na YouTubeu"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube jezik"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube verzija"
+	},
+	"improveLogo": {
+		"message": "Poboljšajte logotip"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Povećajte brzinu reprodukcije"
+	},
+	"increaseVolume": {
+		"message": "Povećajte glasnoću"
+	},
+	"items": {
+		"message": "Predmeti"
+	},
+	"languages": {
+		"message": "Jezici"
+	},
+	"legacyYoutube": {
+		"message": "Naslijeđeni YouTube"
+	},
+	"light": {
+		"message": "Svjetlo"
+	},
+	"lightBlue": {
+		"message": "Svjetlo plava"
+	},
+	"lightGreen": {
+		"message": "Svjetlo zelena"
+	},
+	"like": {
+		"message": "Sviđa mi se"
+	},
+	"lime": {
+		"message": "Limeta"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Chat uživo"
+	},
+	"liveChatType": {
+		"message": "Vrsta chata uživo"
+	},
+	"loudnessNormalization": {
+		"message": "Normalizacija glasnoće"
+	},
+	"markWatchedVideos": {
+		"message": "Označi pogledane videozapise"
+	},
+	"mixer": {
+		"message": "Mikser"
+	},
+	"myColors": {
+		"message": "Moje boje"
+	},
+	"name": {
+		"message": "Naziv"
+	},
+	"nativeMiniPlayer": {
+		"message": "Izvorni mini player"
+	},
+	"new": {
+		"message": "Novo"
+	},
+	"nextVideo": {
+		"message": "Sljedeći video"
+	},
+	"night": {
+		"message": "Noć"
+	},
+	"noActiveFeatures": {
+		"message": "Nema aktivnih značajki"
+	},
+	"none": {
+		"message": "Nijedna"
+	},
+	"noOpenVideoTabs": {
+		"message": "Nema otvorenih video kartica"
+	},
+	"normal": {
+		"message": "Normalno"
+	},
+	"old": {
+		"message": "Staro"
+	},
+	"onAllVideos": {
+		"message": "Na svim video zapisima"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Aktivno samo na YouTubeu"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Svira samo jedna instanca playera"
+	},
+	"onSubscribedChannels": {
+		"message": "Na pretplaćenim kanalima"
+	},
+	"openPopupPlayer": {
+		"message": "Otvorite videozapis / popis za reprodukciju u novom prozoru"
+	},
+	"orange": {
+		"message": "Narančasto"
+	},
+	"other": {
+		"message": "Ostalo"
+	},
+	"permissions": {
+		"message": "Dopuštenja"
+	},
+	"pictureInPicture": {
+		"message": "Slika u slici"
+	},
+	"pink": {
+		"message": "Ružičasto"
+	},
+	"plain": {
+		"message": "Jednostavno"
+	},
+	"platform": {
+		"message": "Platforma"
+	},
+	"playbackSpeed": {
+		"message": "Brzina reprodukcije"
+	},
+	"playerColor": {
+		"message": "Boja playera"
+	},
+	"playerSize": {
+		"message": "Veličina playera"
+	},
+	"playlist": {
+		"message": "Popis za reprodukciju"
+	},
+	"playlists": {
+		"message": "Popisi za reprodukciju"
+	},
+	"playPause": {
+		"message": "Reprodukcija / pauza"
+	},
+	"popupPlayer": {
+		"message": "Player u skočnom prozoru"
+	},
+	"position": {
+		"message": "Položaj"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Pritisnite bilo koju tipku ili upotrijebite kotačić miša."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Pritisnite bilo koju tipku ili upotrijebite kotačić miša"
+	},
+	"previousVideo": {
+		"message": "Prethodni videozapis"
+	},
+	"primaryColor": {
+		"message": "Primarna boja"
+	},
+	"purple": {
+		"message": "Ljubičasta"
+	},
+	"quality": {
+		"message": "Kvaliteta"
+	},
+	"ram": {
+		"message": "Radna memorija"
+	},
+	"rateUs": {
+		"message": "Ocijenite nas"
+	},
+	"red": {
+		"message": "Crvena"
+	},
+	"redDislikeButton": {
+		"message": "Prikaži ne sviđa mi se botun u crvenoj boji"
+	},
+	"relatedVideos": {
+		"message": "Slični videozapisi"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Uklonite slične rezultate pretraživanja"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Uklonite Shorts kolut iz rezultata pretrage"
+	},
+	"repeat": {
+		"message": "Ponovi"
+	},
+	"reset": {
+		"message": "Resetiraj"
+	},
+	"resetAllSettings": {
+		"message": "Resetirajte sve postavke"
+	},
+	"resetAllShortcuts": {
+		"message": "Resetirajte sve prečace"
+	},
+	"reverse": {
+		"message": "Preokreni"
+	},
+	"rotate": {
+		"message": "Rotiraj"
+	},
+	"save": {
+		"message": "Sačuvaj"
+	},
+	"saveAs": {
+		"message": "Sačuvaj kao"
+	},
+	"schedule": {
+		"message": "Stavi na raspored"
+	},
+	"screen": {
+		"message": "Zaslon"
+	},
+	"screenshot": {
+		"message": "Snimka zaslona"
+	},
+	"search": {
+		"message": "Pretraži"
+	},
+	"searchBarOnly": {
+		"message": "Samo traka za pretraživanje"
+	},
+	"seekBackward10Seconds": {
+		"message": "Traži unatrag 10 sekundi"
+	},
+	"seekForward10Seconds": {
+		"message": "Traži 10 sekundi prema naprijed"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Postavke"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Postavke su uspješno uvezene"
+	},
+	"shortcuts": {
+		"message": "Prečaci"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Pokaži kartice prilikom prelaska miša"
+	},
+	"showChannelVideosCount": {
+		"message": "Prikaži broj videozapisa na kanalu"
+	},
+	"shuffle": {
+		"message": "Nasumično"
+	},
+	"sidebar": {
+		"message": "Bočna traka"
+	},
+	"spacebar": {
+		"message": "Tipka razmaka"
+	},
+	"squaredUserImages": {
+		"message": "Korisničke slike u kvadratu"
+	},
+	"static": {
+		"message": "Statički"
+	},
+	"statsForNerds": {
+		"message": "Prikaži statistiku za štrebere"
+	},
+	"step": {
+		"message": "Korak"
+	},
+	"stop": {
+		"message": "Stani"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stilovi"
+	},
+	"subscriptions": {
+		"message": "Pretplate"
+	},
+	"subtitles": {
+		"message": "Titlovi"
+	},
+	"sunset": {
+		"message": "Zalazak sunca"
+	},
+	"sunsetToSunrise": {
+		"message": "Od zalaska do izlaska sunca"
+	},
+	"systemPeferenceDark": {
+		"message": "Postavke sustava: tamno"
+	},
+	"systemPeferenceLight": {
+		"message": "Postavke sustava: svjetlo"
+	},
+	"textColor": {
+		"message": "Boja teksta"
+	},
+	"themes": {
+		"message": "Teme"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Ovo će ukloniti sve kolačiće."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Ovo će ukloniti sve YouTube kolačiće"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Ovo će resetirati sve postavke."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Ovo će resetirati sve prečace"
+	},
+	"thumbnails": {
+		"message": "Sličice"
+	},
+	"timeFrom": {
+		"message": "Vrijeme od"
+	},
+	"timeTo": {
+		"message": "Vrijeme do"
+	},
+	"todayAt": {
+		"message": "Danas u"
+	},
+	"toggleAutoplay": {
+		"message": "Uključi / isključi automatsku reprodukciju"
+	},
+	"toggleCards": {
+		"message": "Uključi / isključi kartice"
+	},
+	"toggleControls": {
+		"message": "Uključi / isključi kontrole playera"
+	},
+	"trailerAutoplay": {
+		"message": "Automatska reprodukcija kratkog filma"
+	},
+	"translations": {
+		"message": "Prijevodi"
+	},
+	"transparentBackground": {
+		"message": "Prozirna pozadina"
+	},
+	"trending": {
+		"message": "U trendu"
+	},
+	"tryToReloadThePage": {
+		"message": "Pokušajte ponovo učitati stranicu"
+	},
+	"type": {
+		"message": "Tip"
+	},
+	"upNextAutoplay": {
+		"message": "Sljedeća automatska reprodukcija"
+	},
+	"use24HourFormat": {
+		"message": "Koristite 24-satni format"
+	},
+	"version": {
+		"message": "Verzija"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Opis videozapisa biti će proširen kako bi se dobio naziv kategorije"
+	},
+	"videoFormats": {
+		"message": "Video formati"
+	},
+	"videos": {
+		"message": "Videozapisi"
+	},
+	"volume": {
+		"message": "Glasnoća"
+	},
+	"watchLater": {
+		"message": "Gledaj kasnije"
+	},
+	"watchTime": {
+		"message": "Vrijeme gledanja"
+	},
+	"whenTabIsChanged": {
+		"message": "Kada se kartica promijeni"
+	},
+	"white": {
+		"message": "Bijela"
+	},
+	"yellow": {
+		"message": "Žuta"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube zaglavlje (lijevo)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube zaglavlje (desno)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube početna stranica"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube jezik"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube ograničava kvalitetu videozapisa na 1080p za h.264 kodek"
+	}
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Shorts eltávolítása a főoldalról"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Távolítsa el a Shorts karusellt a keresési találatokból"
-    }
+	"hideHomePageShorts": {
+		"message": "Shorts eltávolítása a főoldalról"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Távolítsa el a Shorts karusellt a keresési találatokból"
+	}
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1,758 +1,755 @@
 {
-    "about": {
-        "message": "Tentang"
-    },
-    "accept": {
-        "message": "Terima"
-    },
-    "activate": {
-        "message": "Aktifkan"
-    },
-    "activateCaptions": {
-        "message": "Aktifkan keterangan"
-    },
-    "activated": {
-        "message": "Diaktifkan"
-    },
-    "activatedFeatures": {
-        "message": "Fitur diaktifkan"
-    },
-    "activateFullscreen": {
-        "message": "Aktifkan layar penuh"
-    },
-    "activeFeatures": {
-        "message": "Fitur yang aktif"
-    },
-    "addScrollToTop": {
-        "message": "Tambah «Gulir ke atas»"
-    },
-    "ads": {
-        "message": "Tampilkan iklan"
-    },
-    "all": {
-        "message": "Semua"
-    },
-    "allow": {
-        "message": "Izinkan"
-    },
-    "alwaysActive": {
-        "message": "Selalu aktif"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Selalu tampilkan progress bar"
-    },
-    "analyzer": {
-        "message": "Pengnalisa"
-    },
-    "appearance": {
-        "message": "Tampilan"
-    },
-    "audio": {
-        "message": "Suara"
-    },
-    "audioFormats": {
-        "message": "Format suara"
-    },
-    "auto": {
-        "message": "Otomatis"
-    },
-    "autoFullscreen": {
-        "message": "Layar penuh otomatis"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Jeda saat mengganti tab"
-    },
-    "autoplay": {
-        "message": "Putar secara otomatis"
-    },
-    "backupAndReset": {
-        "message": "Cadangkan & setel ulang"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Berdasarkan skema warna sistem"
-    },
-    "belowPlayer": {
-        "message": "Dibawah pemutar"
-    },
-    "black": {
-        "message": "Hitam"
-    },
-    "blockAll": {
-        "message": "Blokir semua"
-    },
-    "blocklist": {
-        "message": "Blokir"
-    },
-    "blue": {
-        "message": "Biru"
-    },
-    "blueGray": {
-        "message": "Abu-abu biru"
-    },
-    "bluelight": {
-        "message": "Cahaya biru"
-    },
-    "brown": {
-        "message": "Coklat"
-    },
-    "browser": {
-        "message": "Peramban"
-    },
-    "browserVersion": {
-        "message": "Versi peramban"
-    },
-    "bubbles": {
-        "message": "Gelembung"
-    },
-    "bug": {
-        "message": "Masalah"
-    },
-    "buttons": {
-        "message": "Tombol"
-    },
-    "cancel": {
-        "message": "Batalkan"
-    },
-    "categories": {
-        "message": "Kategori"
-    },
-    "channel": {
-        "message": "Saluran"
-    },
-    "channels": {
-        "message": "Saluran"
-    },
-    "collapsed": {
-        "message": "Tutup"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Tutup bagian berlangganan"
-    },
-    "comments": {
-        "message": "Komentar"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Konfirmasi sebelum ditutup"
-    },
-    "cookies": {
-        "message": "Kuki"
-    },
-    "cores": {
-        "message": "Inti"
-    },
-    "cropChapterTitles": {
-        "message": "Potong bagian judul "
-    },
-    "customCss": {
-        "message": "Kostum CSS"
-    },
-    "customJs": {
-        "message": "Kostum JS"
-    },
-    "dark": {
-        "message": "Gelap"
-    },
-    "darkTheme": {
-        "message": "Tema gelap"
-    },
-    "dateAndTime": {
-        "message": "Tanggal dan waktu"
-    },
-    "dawn": {
-        "message": "Fajar"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Kurangi kecepatan pemutaran"
-    },
-    "decreaseVolume": {
-        "message": "Kurangi suara"
-    },
-    "deepOrange": {
-        "message": "Oranye tua"
-    },
-    "deepPurple": {
-        "message": "Ungu tua"
-    },
-    "defaultChannelTab": {
-        "message": "Tab saluran standar"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Hapus kuki youtube"
-    },
-    "desert": {
-        "message": "Gurun"
-    },
-    "details": {
-        "message": "Detail"
-    },
-    "developerOptions": {
-        "message": "Opsi pengembang"
-    },
-    "device": {
-        "message": "Perangkat"
-    },
-    "dim": {
-        "message": "Redupkan"
-    },
-    "disabled": {
-        "message": "Dinonaktifkan"
-    },
-    "dislike": {
-        "message": "Tidak Suka"
-    },
-    "donate": {
-        "message": "Donasi"
-    },
-    "doNotChange": {
-        "message": "Jangan ubah"
-    },
-    "draggable": {
-        "message": "Dapat diseret"
-    },
-    "email": {
-        "message": "Surel"
-    },
-    "empty": {
-        "message": "Kosong"
-    },
-    "enabled": {
-        "message": "Aktifkan"
-    },
-    "enabledForced": {
-        "message": "Aktifkan (paksa)"
-    },
-    "expanded": {
-        "message": "Perluas"
-    },
-    "exportSettings": {
-        "message": "Ekspor pengaturan"
-    },
-    "extension": {
-        "message": "Ekstensi"
-    },
-    "file": {
-        "message": "Berkas"
-    },
-    "filters": {
-        "message": "Saringan"
-    },
-    "fitToWindow": {
-        "message": "Sesuaikan dengan layar"
-    },
-    "flash": {
-        "message": "Cahaya"
-    },
-    "footer": {
-        "message": "Catatan kaki"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Paksa kecepatan pemutaran"
-    },
-    "forcedTheaterMode": {
-        "message": "Paksa mode teater"
-    },
-    "forcedVolume": {
-        "message": "Paksa suara"
-    },
-    "foundABug": {
-        "message": "Menemukan masalah?"
-    },
-    "fullWindow": {
-        "message": "Layar penuh"
-    },
-    "general": {
-        "message": "Umum"
-    },
-    "goToSearchBox": {
-        "message": "Ke kotak pencarian"
-    },
-    "green": {
-        "message": "Hijau"
-    },
-    "hdThumbnail": {
-        "message": "Gambar kecil HD"
-    },
-    "header": {
-        "message": "Kepala"
-    },
-    "hidden": {
-        "message": "Sembunyikan"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Tersembunyi di halaman video"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Sembunyikan animasi gambar kecil"
-    },
-    "hideAnnotations": {
-        "message": "Sembunyikan penjelasan"
-    },
-    "hideCards": {
-        "message": "Sembunyikan kartu"
-    },
-    "hideDetails": {
-        "message": "Sembunyikan detail"
-    },
-    "hideEndscreen": {
-        "message": "Sembunyikan layar akhir"
-    },
-    "hideFeaturedContent": {
-        "message": "Sembunyikan konten unggulan"
-    },
-    "hideFooter": {
-        "message": "Sembunyikan catatan kaki"
-    },
-    "hideGradientBottom": {
-        "message": "Sembunyikan Gradient Bagian Bawah"
-    },
-    "hideHomePageShorts": {
-        "message": "Hapus Shorts dari halaman beranda"
-    },
-    "hidePlaylist": {
-        "message": "Sembunyikan daftar putar"
-    },
-    "hideRightButtons": {
-        "message": "Sembunyikan tombol kanan"
-    },
-    "hideScrollForDetails": {
-        "message": "Sembunyikan «gulir untuk detail»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "Sembunyikan jumlah penayangan"
-    },
-    "history": {
-        "message": "Sejarah"
-    },
-    "home": {
-        "message": "Beranda"
-    },
-    "hover": {
-        "message": "Arahkan"
-    },
-    "hoverOnVideoPage": {
-        "message": "Arahkan pada halaman video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Berapa lama video itu diunggah"
-    },
-    "icons": {
-        "message": "Ikon"
-    },
-    "iconsOnly": {
-        "message": "Ikon saja"
-    },
-    "importSettings": {
-        "message": "Impor pengaturan"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ikon ImprovedTube di YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Bahasa ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Versi ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Tingkatkan kualitas logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Tingkatkan kecepatan pemutaran"
-    },
-    "increaseVolume": {
-        "message": "Tingkatkan suara"
-    },
-    "indigo": {
-        "message": "Nila"
-    },
-    "items": {
-        "message": "Item"
-    },
-    "languages": {
-        "message": "Bahasa"
-    },
-    "legacyYoutube": {
-        "message": "YouTube lama"
-    },
-    "light": {
-        "message": "Terang"
-    },
-    "lightBlue": {
-        "message": "Biru terang"
-    },
-    "lightGreen": {
-        "message": "Hijau terang"
-    },
-    "like": {
-        "message": "Suka"
-    },
-    "lime": {
-        "message": "Limau"
-    },
-    "list": {
-        "message": "Daftar"
-    },
-    "liveChat": {
-        "message": "Obrolan langsung"
-    },
-    "liveChatType": {
-        "message": "Jenis obrolan langsung"
-    },
-    "loudnessNormalization": {
-        "message": "Normalkan suara"
-    },
-    "markWatchedVideos": {
-        "message": "Tandai video yang ditonton"
-    },
-    "myColors": {
-        "message": "Warna saya"
-    },
-    "name": {
-        "message": "Nama"
-    },
-    "nativeMiniPlayer": {
-        "message": "Pemutar kecil bawaan"
-    },
-    "new": {
-        "message": "Baru"
-    },
-    "nextVideo": {
-        "message": "Video selanjutnya"
-    },
-    "night": {
-        "message": "Malam"
-    },
-    "noActiveFeatures": {
-        "message": "Tidak ada fitur aktif"
-    },
-    "none": {
-        "message": "Tidak ada"
-    },
-    "noOpenVideoTabs": {
-        "message": "Tidak ada tab video terbuka"
-    },
-    "old": {
-        "message": "Lama"
-    },
-    "onAllVideos": {
-        "message": "Disetiap video"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Hanya aktif di YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Hanya mainkan satu pemutar"
-    },
-    "onSubscribedChannels": {
-        "message": "Di saluran berlangganan"
-    },
-    "orange": {
-        "message": "Oranye"
-    },
-    "other": {
-        "message": "Lainnya"
-    },
-    "permissions": {
-        "message": "Perizinan"
-    },
-    "pictureInPicture": {
-        "message": "Gambar di dalam gambar"
-    },
-    "pink": {
-        "message": "Merah jambu"
-    },
-    "plain": {
-        "message": "Dataran"
-    },
-    "playbackSpeed": {
-        "message": "Kecepatan pemutar"
-    },
-    "player": {
-        "message": "Pemutar"
-    },
-    "playerColor": {
-        "message": "Warna pemutar"
-    },
-    "playerSize": {
-        "message": "Ukuran pemutar"
-    },
-    "playlist": {
-        "message": "Daftar putar"
-    },
-    "playlists": {
-        "message": "Daftar putar"
-    },
-    "playPause": {
-        "message": "Mulai / Jeda"
-    },
-    "popupPlayer": {
-        "message": "Pemutar sembulan"
-    },
-    "position": {
-        "message": "Posisi"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Tekan tombol apa saja atau gunakan roda mouse."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Tekan tombol apa saja atau gunakan roda mouse"
-    },
-    "previousVideo": {
-        "message": "Video sebelumnya"
-    },
-    "primaryColor": {
-        "message": "Warna utama"
-    },
-    "purple": {
-        "message": "Ungu"
-    },
-    "quality": {
-        "message": "Kualitas video"
-    },
-    "rateUs": {
-        "message": "Nilai Kami"
-    },
-    "red": {
-        "message": "Merah"
-    },
-    "relatedVideos": {
-        "message": "Video terkait"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Hapus hasil pencarian terkait"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Hapus gulungan Shorts dari hasil pencarian"
-    },
-    "repeat": {
-        "message": "Putar ulang"
-    },
-    "reset": {
-        "message": "Setel ulang"
-    },
-    "resetAllSettings": {
-        "message": "Setel ulang semua pengaturan"
-    },
-    "resetAllShortcuts": {
-        "message": "Setel ulang semua pintasan"
-    },
-    "reverse": {
-        "message": "Putar secara terbalik"
-    },
-    "rotate": {
-        "message": "Putar"
-    },
-    "save": {
-        "message": "Simpan"
-    },
-    "saveAs": {
-        "message": "Simpan dengan"
-    },
-    "schedule": {
-        "message": "Jadwal"
-    },
-    "screen": {
-        "message": "Layar"
-    },
-    "screenshot": {
-        "message": "Tangkapan layar"
-    },
-    "search": {
-        "message": "Cari"
-    },
-    "searchBarOnly": {
-        "message": "Hanya bilah pencarian"
-    },
-    "seekBackward10Seconds": {
-        "message": "Mundur 10 detik"
-    },
-    "seekForward10Seconds": {
-        "message": "Maju 10 detik"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Pengaturan"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Berhasil mengimpor pengaturan"
-    },
-    "shortcuts": {
-        "message": "Pintasan"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Tunjukkan kartu pada arah mouse"
-    },
-    "showChannelVideosCount": {
-        "message": "Tampilkan jumlah video saluran"
-    },
-    "shuffle": {
-        "message": "Putar secara acak"
-    },
-    "sidebar": {
-        "message": "Bilah samping"
-    },
-    "spacebar": {
-        "message": "Bilah spasi"
-    },
-    "squaredUserImages": {
-        "message": "Gambar pengguna kotak"
-    },
-    "static": {
-        "message": "Statis"
-    },
-    "statsForNerds": {
-        "message": "Tampilkan statistik bagi para 'kutu buku'"
-    },
-    "step": {
-        "message": "Langkah"
-    },
-    "stop": {
-        "message": "Berhenti"
-    },
-    "style": {
-        "message": "Mode"
-    },
-    "styles": {
-        "message": "Mode"
-    },
-    "subscriptions": {
-        "message": "Berlangganan"
-    },
-    "subtitles": {
-        "message": "Teks"
-    },
-    "sunset": {
-        "message": "Senja"
-    },
-    "sunsetToSunrise": {
-        "message": "Matahari terbenam hingga matahari terbit"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferensi sistem: gelap"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferensi sistem: terang"
-    },
-    "teal": {
-        "message": "Hijau kebiruan"
-    },
-    "textColor": {
-        "message": "Warna teks"
-    },
-    "themes": {
-        "message": "Tema"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Ini akan menghapus semua kuki."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Ini akan menghapus semua kuki YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Ini akan mengatur ulang semua pengaturan."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Ini akan mengatur ulang semua pintasan"
-    },
-    "thumbnails": {
-        "message": "Gambar kecil"
-    },
-    "timeFrom": {
-        "message": "Waktu dari"
-    },
-    "timeTo": {
-        "message": "Waktu ke"
-    },
-    "todayAt": {
-        "message": "Hari ini di"
-    },
-    "toggleCards": {
-        "message": "Alihkan kartu"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "Obrolan teratas"
-    },
-    "trailerAutoplay": {
-        "message": "Putar otomatis cuplikan"
-    },
-    "translations": {
-        "message": "Terjemahan"
-    },
-    "transparentBackground": {
-        "message": "Latar belakang transparan"
-    },
-    "trending": {
-        "message": "Populer"
-    },
-    "tryToReloadThePage": {
-        "message": "Coba muat ulang halaman"
-    },
-    "type": {
-        "message": "Tipe"
-    },
-    "upNextAutoplay": {
-        "message": "Putar otomatis berikutnya"
-    },
-    "use24HourFormat": {
-        "message": "Gunakan format 24 jam"
-    },
-    "version": {
-        "message": "Versi"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Deskripsi video akan diperluas untuk mendapatkan nama kategori"
-    },
-    "videoFormats": {
-        "message": "Format video"
-    },
-    "videos": {
-        "message": "Video"
-    },
-    "volume": {
-        "message": "Suara"
-    },
-    "watchLater": {
-        "message": "Tonton nanti"
-    },
-    "watchTime": {
-        "message": "Waktu tayang"
-    },
-    "whenTabIsChanged": {
-        "message": "Saat tab berubah"
-    },
-    "white": {
-        "message": "Putih"
-    },
-    "yellow": {
-        "message": "Kuning"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Header YouTube (kiri)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Header YouTube (kanan)"
-    },
-    "youtubeHomePage": {
-        "message": "Beranda YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Bahasa YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube membatasi kualitas video hingga 1080p untuk codec h.264"
-    }
+	"about": {
+		"message": "Tentang"
+	},
+	"accept": {
+		"message": "Terima"
+	},
+	"activate": {
+		"message": "Aktifkan"
+	},
+	"activateCaptions": {
+		"message": "Aktifkan keterangan"
+	},
+	"activated": {
+		"message": "Diaktifkan"
+	},
+	"activatedFeatures": {
+		"message": "Fitur diaktifkan"
+	},
+	"activateFullscreen": {
+		"message": "Aktifkan layar penuh"
+	},
+	"activeFeatures": {
+		"message": "Fitur yang aktif"
+	},
+	"addScrollToTop": {
+		"message": "Tambah «Gulir ke atas»"
+	},
+	"ads": {
+		"message": "Tampilkan iklan"
+	},
+	"all": {
+		"message": "Semua"
+	},
+	"allow": {
+		"message": "Izinkan"
+	},
+	"alwaysActive": {
+		"message": "Selalu aktif"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Selalu tampilkan progress bar"
+	},
+	"analyzer": {
+		"message": "Pengnalisa"
+	},
+	"appearance": {
+		"message": "Tampilan"
+	},
+	"audio": {
+		"message": "Suara"
+	},
+	"audioFormats": {
+		"message": "Format suara"
+	},
+	"auto": {
+		"message": "Otomatis"
+	},
+	"autoFullscreen": {
+		"message": "Layar penuh otomatis"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Jeda saat mengganti tab"
+	},
+	"autoplay": {
+		"message": "Putar secara otomatis"
+	},
+	"backupAndReset": {
+		"message": "Cadangkan & setel ulang"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Berdasarkan skema warna sistem"
+	},
+	"belowPlayer": {
+		"message": "Dibawah pemutar"
+	},
+	"black": {
+		"message": "Hitam"
+	},
+	"blockAll": {
+		"message": "Blokir semua"
+	},
+	"blocklist": {
+		"message": "Blokir"
+	},
+	"blue": {
+		"message": "Biru"
+	},
+	"blueGray": {
+		"message": "Abu-abu biru"
+	},
+	"bluelight": {
+		"message": "Cahaya biru"
+	},
+	"brown": {
+		"message": "Coklat"
+	},
+	"browser": {
+		"message": "Peramban"
+	},
+	"browserVersion": {
+		"message": "Versi peramban"
+	},
+	"bubbles": {
+		"message": "Gelembung"
+	},
+	"bug": {
+		"message": "Masalah"
+	},
+	"buttons": {
+		"message": "Tombol"
+	},
+	"cancel": {
+		"message": "Batalkan"
+	},
+	"categories": {
+		"message": "Kategori"
+	},
+	"channel": {
+		"message": "Saluran"
+	},
+	"channels": {
+		"message": "Saluran"
+	},
+	"collapsed": {
+		"message": "Tutup"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Tutup bagian berlangganan"
+	},
+	"comments": {
+		"message": "Komentar"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Konfirmasi sebelum ditutup"
+	},
+	"cookies": {
+		"message": "Kuki"
+	},
+	"cores": {
+		"message": "Inti"
+	},
+	"cropChapterTitles": {
+		"message": "Potong bagian judul "
+	},
+	"customCss": {
+		"message": "Kostum CSS"
+	},
+	"customJs": {
+		"message": "Kostum JS"
+	},
+	"dark": {
+		"message": "Gelap"
+	},
+	"darkTheme": {
+		"message": "Tema gelap"
+	},
+	"dateAndTime": {
+		"message": "Tanggal dan waktu"
+	},
+	"dawn": {
+		"message": "Fajar"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Kurangi kecepatan pemutaran"
+	},
+	"decreaseVolume": {
+		"message": "Kurangi suara"
+	},
+	"deepOrange": {
+		"message": "Oranye tua"
+	},
+	"deepPurple": {
+		"message": "Ungu tua"
+	},
+	"defaultChannelTab": {
+		"message": "Tab saluran standar"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Hapus kuki youtube"
+	},
+	"desert": {
+		"message": "Gurun"
+	},
+	"details": {
+		"message": "Detail"
+	},
+	"developerOptions": {
+		"message": "Opsi pengembang"
+	},
+	"device": {
+		"message": "Perangkat"
+	},
+	"dim": {
+		"message": "Redupkan"
+	},
+	"disabled": {
+		"message": "Dinonaktifkan"
+	},
+	"dislike": {
+		"message": "Tidak Suka"
+	},
+	"donate": {
+		"message": "Donasi"
+	},
+	"doNotChange": {
+		"message": "Jangan ubah"
+	},
+	"draggable": {
+		"message": "Dapat diseret"
+	},
+	"email": {
+		"message": "Surel"
+	},
+	"empty": {
+		"message": "Kosong"
+	},
+	"enabled": {
+		"message": "Aktifkan"
+	},
+	"enabledForced": {
+		"message": "Aktifkan (paksa)"
+	},
+	"expanded": {
+		"message": "Perluas"
+	},
+	"exportSettings": {
+		"message": "Ekspor pengaturan"
+	},
+	"extension": {
+		"message": "Ekstensi"
+	},
+	"file": {
+		"message": "Berkas"
+	},
+	"filters": {
+		"message": "Saringan"
+	},
+	"fitToWindow": {
+		"message": "Sesuaikan dengan layar"
+	},
+	"flash": {
+		"message": "Cahaya"
+	},
+	"footer": {
+		"message": "Catatan kaki"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Paksa kecepatan pemutaran"
+	},
+	"forcedTheaterMode": {
+		"message": "Paksa mode teater"
+	},
+	"forcedVolume": {
+		"message": "Paksa suara"
+	},
+	"foundABug": {
+		"message": "Menemukan masalah?"
+	},
+	"fullWindow": {
+		"message": "Layar penuh"
+	},
+	"general": {
+		"message": "Umum"
+	},
+	"goToSearchBox": {
+		"message": "Ke kotak pencarian"
+	},
+	"green": {
+		"message": "Hijau"
+	},
+	"hdThumbnail": {
+		"message": "Gambar kecil HD"
+	},
+	"header": {
+		"message": "Kepala"
+	},
+	"hidden": {
+		"message": "Sembunyikan"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Tersembunyi di halaman video"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Sembunyikan animasi gambar kecil"
+	},
+	"hideAnnotations": {
+		"message": "Sembunyikan penjelasan"
+	},
+	"hideCards": {
+		"message": "Sembunyikan kartu"
+	},
+	"hideDetails": {
+		"message": "Sembunyikan detail"
+	},
+	"hideEndscreen": {
+		"message": "Sembunyikan layar akhir"
+	},
+	"hideFeaturedContent": {
+		"message": "Sembunyikan konten unggulan"
+	},
+	"hideFooter": {
+		"message": "Sembunyikan catatan kaki"
+	},
+	"hideGradientBottom": {
+		"message": "Sembunyikan Gradient Bagian Bawah"
+	},
+	"hideHomePageShorts": {
+		"message": "Hapus Shorts dari halaman beranda"
+	},
+	"hidePlaylist": {
+		"message": "Sembunyikan daftar putar"
+	},
+	"hideRightButtons": {
+		"message": "Sembunyikan tombol kanan"
+	},
+	"hideScrollForDetails": {
+		"message": "Sembunyikan «gulir untuk detail»"
+	},
+	"hideSkipOverlay": {
+		"message": "Hide Skip Overlay"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Hide thumbnail overlay"
+	},
+	"hideViewsCount": {
+		"message": "Sembunyikan jumlah penayangan"
+	},
+	"history": {
+		"message": "Sejarah"
+	},
+	"home": {
+		"message": "Beranda"
+	},
+	"hover": {
+		"message": "Arahkan"
+	},
+	"hoverOnVideoPage": {
+		"message": "Arahkan pada halaman video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Berapa lama video itu diunggah"
+	},
+	"icons": {
+		"message": "Ikon"
+	},
+	"iconsOnly": {
+		"message": "Ikon saja"
+	},
+	"importSettings": {
+		"message": "Impor pengaturan"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ikon ImprovedTube di YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Bahasa ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Versi ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Tingkatkan kualitas logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Tingkatkan kecepatan pemutaran"
+	},
+	"increaseVolume": {
+		"message": "Tingkatkan suara"
+	},
+	"indigo": {
+		"message": "Nila"
+	},
+	"items": {
+		"message": "Item"
+	},
+	"languages": {
+		"message": "Bahasa"
+	},
+	"legacyYoutube": {
+		"message": "YouTube lama"
+	},
+	"light": {
+		"message": "Terang"
+	},
+	"lightBlue": {
+		"message": "Biru terang"
+	},
+	"lightGreen": {
+		"message": "Hijau terang"
+	},
+	"like": {
+		"message": "Suka"
+	},
+	"lime": {
+		"message": "Limau"
+	},
+	"list": {
+		"message": "Daftar"
+	},
+	"liveChat": {
+		"message": "Obrolan langsung"
+	},
+	"liveChatType": {
+		"message": "Jenis obrolan langsung"
+	},
+	"loudnessNormalization": {
+		"message": "Normalkan suara"
+	},
+	"markWatchedVideos": {
+		"message": "Tandai video yang ditonton"
+	},
+	"myColors": {
+		"message": "Warna saya"
+	},
+	"name": {
+		"message": "Nama"
+	},
+	"nativeMiniPlayer": {
+		"message": "Pemutar kecil bawaan"
+	},
+	"new": {
+		"message": "Baru"
+	},
+	"nextVideo": {
+		"message": "Video selanjutnya"
+	},
+	"night": {
+		"message": "Malam"
+	},
+	"noActiveFeatures": {
+		"message": "Tidak ada fitur aktif"
+	},
+	"none": {
+		"message": "Tidak ada"
+	},
+	"noOpenVideoTabs": {
+		"message": "Tidak ada tab video terbuka"
+	},
+	"old": {
+		"message": "Lama"
+	},
+	"onAllVideos": {
+		"message": "Disetiap video"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Hanya aktif di YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Hanya mainkan satu pemutar"
+	},
+	"onSubscribedChannels": {
+		"message": "Di saluran berlangganan"
+	},
+	"orange": {
+		"message": "Oranye"
+	},
+	"other": {
+		"message": "Lainnya"
+	},
+	"permissions": {
+		"message": "Perizinan"
+	},
+	"pictureInPicture": {
+		"message": "Gambar di dalam gambar"
+	},
+	"pink": {
+		"message": "Merah jambu"
+	},
+	"plain": {
+		"message": "Dataran"
+	},
+	"playbackSpeed": {
+		"message": "Kecepatan pemutar"
+	},
+	"player": {
+		"message": "Pemutar"
+	},
+	"playerColor": {
+		"message": "Warna pemutar"
+	},
+	"playerSize": {
+		"message": "Ukuran pemutar"
+	},
+	"playlist": {
+		"message": "Daftar putar"
+	},
+	"playlists": {
+		"message": "Daftar putar"
+	},
+	"playPause": {
+		"message": "Mulai / Jeda"
+	},
+	"popupPlayer": {
+		"message": "Pemutar sembulan"
+	},
+	"position": {
+		"message": "Posisi"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Tekan tombol apa saja atau gunakan roda mouse."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Tekan tombol apa saja atau gunakan roda mouse"
+	},
+	"previousVideo": {
+		"message": "Video sebelumnya"
+	},
+	"primaryColor": {
+		"message": "Warna utama"
+	},
+	"purple": {
+		"message": "Ungu"
+	},
+	"quality": {
+		"message": "Kualitas video"
+	},
+	"rateUs": {
+		"message": "Nilai Kami"
+	},
+	"red": {
+		"message": "Merah"
+	},
+	"relatedVideos": {
+		"message": "Video terkait"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Hapus hasil pencarian terkait"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Hapus gulungan Shorts dari hasil pencarian"
+	},
+	"repeat": {
+		"message": "Putar ulang"
+	},
+	"reset": {
+		"message": "Setel ulang"
+	},
+	"resetAllSettings": {
+		"message": "Setel ulang semua pengaturan"
+	},
+	"resetAllShortcuts": {
+		"message": "Setel ulang semua pintasan"
+	},
+	"reverse": {
+		"message": "Putar secara terbalik"
+	},
+	"rotate": {
+		"message": "Putar"
+	},
+	"save": {
+		"message": "Simpan"
+	},
+	"saveAs": {
+		"message": "Simpan dengan"
+	},
+	"schedule": {
+		"message": "Jadwal"
+	},
+	"screen": {
+		"message": "Layar"
+	},
+	"screenshot": {
+		"message": "Tangkapan layar"
+	},
+	"search": {
+		"message": "Cari"
+	},
+	"searchBarOnly": {
+		"message": "Hanya bilah pencarian"
+	},
+	"seekBackward10Seconds": {
+		"message": "Mundur 10 detik"
+	},
+	"seekForward10Seconds": {
+		"message": "Maju 10 detik"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Pengaturan"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Berhasil mengimpor pengaturan"
+	},
+	"shortcuts": {
+		"message": "Pintasan"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Tunjukkan kartu pada arah mouse"
+	},
+	"showChannelVideosCount": {
+		"message": "Tampilkan jumlah video saluran"
+	},
+	"shuffle": {
+		"message": "Putar secara acak"
+	},
+	"sidebar": {
+		"message": "Bilah samping"
+	},
+	"spacebar": {
+		"message": "Bilah spasi"
+	},
+	"squaredUserImages": {
+		"message": "Gambar pengguna kotak"
+	},
+	"static": {
+		"message": "Statis"
+	},
+	"statsForNerds": {
+		"message": "Tampilkan statistik bagi para 'kutu buku'"
+	},
+	"step": {
+		"message": "Langkah"
+	},
+	"stop": {
+		"message": "Berhenti"
+	},
+	"style": {
+		"message": "Mode"
+	},
+	"styles": {
+		"message": "Mode"
+	},
+	"subscriptions": {
+		"message": "Berlangganan"
+	},
+	"subtitles": {
+		"message": "Teks"
+	},
+	"sunset": {
+		"message": "Senja"
+	},
+	"sunsetToSunrise": {
+		"message": "Matahari terbenam hingga matahari terbit"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferensi sistem: gelap"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferensi sistem: terang"
+	},
+	"teal": {
+		"message": "Hijau kebiruan"
+	},
+	"textColor": {
+		"message": "Warna teks"
+	},
+	"themes": {
+		"message": "Tema"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Ini akan menghapus semua kuki."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Ini akan menghapus semua kuki YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Ini akan mengatur ulang semua pengaturan."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Ini akan mengatur ulang semua pintasan"
+	},
+	"thumbnails": {
+		"message": "Gambar kecil"
+	},
+	"timeFrom": {
+		"message": "Waktu dari"
+	},
+	"timeTo": {
+		"message": "Waktu ke"
+	},
+	"todayAt": {
+		"message": "Hari ini di"
+	},
+	"toggleCards": {
+		"message": "Alihkan kartu"
+	},
+	"topChat": {
+		"message": "Obrolan teratas"
+	},
+	"trailerAutoplay": {
+		"message": "Putar otomatis cuplikan"
+	},
+	"translations": {
+		"message": "Terjemahan"
+	},
+	"transparentBackground": {
+		"message": "Latar belakang transparan"
+	},
+	"trending": {
+		"message": "Populer"
+	},
+	"tryToReloadThePage": {
+		"message": "Coba muat ulang halaman"
+	},
+	"type": {
+		"message": "Tipe"
+	},
+	"upNextAutoplay": {
+		"message": "Putar otomatis berikutnya"
+	},
+	"use24HourFormat": {
+		"message": "Gunakan format 24 jam"
+	},
+	"version": {
+		"message": "Versi"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Deskripsi video akan diperluas untuk mendapatkan nama kategori"
+	},
+	"videoFormats": {
+		"message": "Format video"
+	},
+	"videos": {
+		"message": "Video"
+	},
+	"volume": {
+		"message": "Suara"
+	},
+	"watchLater": {
+		"message": "Tonton nanti"
+	},
+	"watchTime": {
+		"message": "Waktu tayang"
+	},
+	"whenTabIsChanged": {
+		"message": "Saat tab berubah"
+	},
+	"white": {
+		"message": "Putih"
+	},
+	"yellow": {
+		"message": "Kuning"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Header YouTube (kiri)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Header YouTube (kanan)"
+	},
+	"youtubeHomePage": {
+		"message": "Beranda YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Bahasa YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube membatasi kualitas video hingga 1080p untuk codec h.264"
+	}
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1,962 +1,959 @@
 {
-    "about": {
-        "message": "Al riguardo"
-    },
-    "accept": {
-        "message": "Accetta"
-    },
-    "activate": {
-        "message": "Attivo/a"
-    },
-    "activateCaptions": {
-        "message": "Attiva didascalie"
-    },
-    "activated": {
-        "message": "Attivato/a"
-    },
-    "activatedFeatures": {
-        "message": "Funzionalità attivate"
-    },
-    "activateFullscreen": {
-        "message": "Attiva schermo intero"
-    },
-    "activeFeatures": {
-        "message": "Funzioni disponibili"
-    },
-    "addScrollToTop": {
-        "message": "Aggiungi «Scorri in cima»"
-    },
-    "ads": {
-        "message": "Pubblicità"
-    },
-    "all": {
-        "message": "Tutte"
-    },
-    "allow": {
-        "message": "Permetti"
-    },
-    "always": {
-        "message": "Sempre"
-    },
-    "alwaysActive": {
-        "message": "Sempre attivo"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Mostra sempre barra di avanzamento"
-    },
-    "amber": {
-        "message": "Ambra"
-    },
-    "analyzer": {
-        "message": "Analizzatore"
-    },
-    "appearance": {
-        "message": "Aspetto"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Sicuri di voler esportare i dati?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Sicuri di voler importare i dati?"
-    },
-    "audioFormats": {
-        "message": "Formati audio"
-    },
-    "auto": {
-        "message": "Automatico"
-    },
-    "autoFullscreen": {
-        "message": "Schermo intero automatico"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausa automatica al cambio di scheda"
-    },
-    "autoplay": {
-        "message": "Avvio automatico"
-    },
-    "avoidAv1": {
-        "message": "Evita AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Evita AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Evita AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Evita rendering tramite CPU quando possibile"
-    },
-    "backgroundColor": {
-        "message": "Colore di sfondo"
-    },
-    "backgroundOpacity": {
-        "message": "Opacità di sfondo"
-    },
-    "backupAndReset": {
-        "message": "Backup e reimpostazione"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Basato sullo schema di colore del sistema"
-    },
-    "belowPlayer": {
-        "message": "Sotto il lettore"
-    },
-    "black": {
-        "message": "Nero"
-    },
-    "blockAll": {
-        "message": "Blocca tutte"
-    },
-    "blockAv1": {
-        "message": "Blocca AV1"
-    },
-    "blockH264": {
-        "message": "Blocca H.264"
-    },
-    "blocklist": {
-        "message": "Lista nera"
-    },
-    "blockMusic": {
-        "message": "Blocca musica"
-    },
-    "blockVp8": {
-        "message": "Blocca VP8"
-    },
-    "blockVp9": {
-        "message": "Blocca VP9"
-    },
-    "blue": {
-        "message": "Blu"
-    },
-    "blueGray": {
-        "message": "Grigio blu"
-    },
-    "bluelight": {
-        "message": "Luce blu"
-    },
-    "brown": {
-        "message": "Marrone"
-    },
-    "browserVersion": {
-        "message": "Versione browser"
-    },
-    "bubbles": {
-        "message": "Bolle"
-    },
-    "cancel": {
-        "message": "Annulla"
-    },
-    "categories": {
-        "message": "Categorie"
-    },
-    "channel": {
-        "message": "Canale"
-    },
-    "channels": {
-        "message": "Canali"
-    },
-    "characterEdgeStyle": {
-        "message": "Stile del bordo carattere"
-    },
-    "clipboard": {
-        "message": "Appunti"
-    },
-    "codecH264": {
-        "message": "Codec H.264"
-    },
-    "collapsed": {
-        "message": "Compressa/i"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Comprimi sezioni di sottoscrizione"
-    },
-    "comments": {
-        "message": "Commenti"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Conferma prima della chiusura"
-    },
-    "cores": {
-        "message": "Core"
-    },
-    "cropChapterTitles": {
-        "message": "Ritaglia titoli dei capitoli"
-    },
-    "customCss": {
-        "message": "CSS personalizzato"
-    },
-    "customJs": {
-        "message": "JS personalizzato"
-    },
-    "customMiniPlayer": {
-        "message": "Mini lettore personalizzato"
-    },
-    "cyan": {
-        "message": "Ciano"
-    },
-    "dark": {
-        "message": "Scuro"
-    },
-    "darkTheme": {
-        "message": "Tema scuro"
-    },
-    "dateAndTime": {
-        "message": "Data e ora"
-    },
-    "dawn": {
-        "message": "Albeggio"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Riduci velocità di riproduzione"
-    },
-    "decreaseVolume": {
-        "message": "Diminuisci volume"
-    },
-    "deepOrange": {
-        "message": "Arancione intenso"
-    },
-    "deepPurple": {
-        "message": "Viola intenso"
-    },
-    "default": {
-        "message": "Predefinito"
-    },
-    "defaultChannelTab": {
-        "message": "Scheda predefinita"
-    },
-    "defaultContentCountry": {
-        "message": "Paese del contenuto predefinito"
-    },
-    "deleteWatchedVideos": {
-        "message": "Elimina video guardati"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Cancella cookie YouTube"
-    },
-    "depressed": {
-        "message": "Depresso"
-    },
-    "description": {
-        "message": "Descrizione"
-    },
-    "description_ext": {
-        "message": "Rendi YouTube ordinato & intelligente! YouTube colore video salta annuncio volume velocità canale utensile stile HD annunci blocca-annunci etichette tags keyword playlist"
-    },
-    "desert": {
-        "message": "Deserto"
-    },
-    "details": {
-        "message": "Dettagli"
-    },
-    "developerOptions": {
-        "message": "Opzioni per sviluppatori"
-    },
-    "device": {
-        "message": "Dispositivo"
-    },
-    "dim": {
-        "message": "Smorzamento"
-    },
-    "disabled": {
-        "message": "Disabilitata"
-    },
-    "dislike": {
-        "message": "Non mi piace"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Mostra il giorno della settimana"
-    },
-    "donate": {
-        "message": "Donazione"
-    },
-    "doNotChange": {
-        "message": "Non cambiare"
-    },
-    "draggable": {
-        "message": "Trascinabile"
-    },
-    "durationWithSpeed": {
-        "message": "Mostra il tempo rimanente con riferimento alla velocità di riproduzione"
-    },
-    "email": {
-        "message": "E-mail"
-    },
-    "empty": {
-        "message": "Vuota"
-    },
-    "enabled": {
-        "message": "Abilitato"
-    },
-    "enabledForced": {
-        "message": "Abilitato (forzato)"
-    },
-    "expanded": {
-        "message": "Estesa"
-    },
-    "exportSettings": {
-        "message": "Esporta impostazioni"
-    },
-    "extension": {
-        "message": "Estensione"
-    },
-    "filters": {
-        "message": "Filtri"
-    },
-    "fitToWindow": {
-        "message": "Adatta alla finestra"
-    },
-    "fontColor": {
-        "message": "Colore font"
-    },
-    "fontFamily": {
-        "message": "Famiglia font"
-    },
-    "fontOpacity": {
-        "message": "Opacità font"
-    },
-    "fontSize": {
-        "message": "Dimensione font"
-    },
-    "footer": {
-        "message": "Piè di pagina"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Velocità di riproduzione forzata"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Riproduzione forzata di video dall'inizio"
-    },
-    "forcedTheaterMode": {
-        "message": "Modalità cinema forzata"
-    },
-    "forcedVolume": {
-        "message": "Volume forzato"
-    },
-    "forceSDR": {
-        "message": "Forza SDR"
-    },
-    "foundABug": {
-        "message": "Trovato un bug?"
-    },
-    "fullWindow": {
-        "message": "Finestra intera"
-    },
-    "general": {
-        "message": "Generale"
-    },
-    "geoPreference": {
-        "message": "Preferenza Geo"
-    },
-    "googleApiKey": {
-        "message": "Chiave API di Google"
-    },
-    "goToSearchBox": {
-        "message": "Vai alla casella di ricerca"
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "hardwareInformation": {
-        "message": "Informazioni hardware"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura in altà qualità"
-    },
-    "header": {
-        "message": "Intestazione"
-    },
-    "hidden": {
-        "message": "Nascosta/i"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Nascosta nella pagina video"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Nascondi miniature animate"
-    },
-    "hideAnnotations": {
-        "message": "Nascondi annotazioni"
-    },
-    "hideCards": {
-        "message": "Nascondi tessere di fine video"
-    },
-    "hideCategories": {
-        "message": "Nascondi categorie"
-    },
-    "hideCommentsCount": {
-        "message": "Nascondi il numero dei commenti"
-    },
-    "hideCountryCode": {
-        "message": "Nascondi codice paese"
-    },
-    "hideDate": {
-        "message": "Nascondi data"
-    },
-    "hideDetails": {
-        "message": "Nascondi dettagli"
-    },
-    "hideEndscreen": {
-        "message": "Nascondi finale video"
-    },
-    "hideFeaturedContent": {
-        "message": "Nascondi contenuti in primo piano"
-    },
-    "hideFooter": {
-        "message": "Nascondi piè di pagina"
-    },
-    "hideGradientBottom": {
-        "message": "Nascondi fondo gradiente"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Nascondi barra dei controlli del lettore"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Nascondi pulsanti della barra dei controlli del lettore"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Nascondi opzioni di controllo del lettore"
-    },
-    "hidePlaylist": {
-        "message": "Nascondi scaletta"
-    },
-    "hideRightButtons": {
-        "message": "Nascondi pulsanti sulla destra"
-    },
-    "hideScrollForDetails": {
-        "message": "Nascondi «Scorri per dettagli»"
-    },
-    "hideSkipOverlay": {
-        "message": "Nascondi \"Salta overlay\""
-    },
-    "hideThumbnailOverlay": {
-        "message": "Nascondi overlay miniature"
-    },
-    "hideThumbnails": {
-        "message": "Nascondi miniature"
-    },
-    "hideViewsCount": {
-        "message": "Nascondi contatore visualizzazioni"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Nascondi buttone di ricerca vocale"
-    },
-    "high": {
-        "message": "Alto"
-    },
-    "history": {
-        "message": "Cronologia"
-    },
-    "home": {
-        "message": "Pagina iniziale"
-    },
-    "hover": {
-        "message": "In sospensione"
-    },
-    "hoverOnVideoPage": {
-        "message": "In sospensione sulla pagine del video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Quanto tempo fa il video è stato caricato"
-    },
-    "icons": {
-        "message": "Icone"
-    },
-    "iconsOnly": {
-        "message": "Solo icone"
-    },
-    "importSettings": {
-        "message": "Importa impostazioni"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Icona su YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Lingua"
-    },
-    "improvedtubeVersion": {
-        "message": "Versione"
-    },
-    "improveLogo": {
-        "message": "Migliora logo YouTube"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Incrementa velocità di riproduzione"
-    },
-    "increaseVolume": {
-        "message": "Aumenta volume"
-    },
-    "indigo": {
-        "message": "Indaco"
-    },
-    "items": {
-        "message": "Oggetti"
-    },
-    "language": {
-        "message": "Lingua"
-    },
-    "languages": {
-        "message": "Lingue"
-    },
-    "legacyYoutube": {
-        "message": "YouTube versione legacy"
-    },
-    "library": {
-        "message": "Librerie"
-    },
-    "light": {
-        "message": "Chiaro"
-    },
-    "lightBlue": {
-        "message": "Blu chiaro"
-    },
-    "lightGreen": {
-        "message": "Verde chiaro"
-    },
-    "like": {
-        "message": "Mi piace"
-    },
-    "liked": {
-        "message": "Piaciuto"
-    },
-    "likes": {
-        "message": "Mi piace"
-    },
-    "limitPageWidth": {
-        "message": "Limita larghezza pagina"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Chat dal vivo"
-    },
-    "liveChatType": {
-        "message": "Tipologia chat dal vivo"
-    },
-    "location": {
-        "message": "Luogo"
-    },
-    "loudnessNormalization": {
-        "message": "Normalizzazione rumorosità"
-    },
-    "low": {
-        "message": "Basso"
-    },
-    "markWatchedVideos": {
-        "message": "Contrassegna video visti"
-    },
-    "medium": {
-        "message": "Medio"
-    },
-    "more": {
-        "message": "Di piú"
-    },
-    "moveSidebarLeft": {
-        "message": "Sposta barra laterale a sinistra"
-    },
-    "moveThumbnailsRight": {
-        "message": "Sposta miniature a destra"
-    },
-    "myColors": {
-        "message": "Miei colori"
-    },
-    "name": {
-        "message": "Nome"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini lettore nativo"
-    },
-    "new": {
-        "message": "Nuovo"
-    },
-    "nextVideo": {
-        "message": "Prossimo video"
-    },
-    "night": {
-        "message": "Notte"
-    },
-    "nightMode": {
-        "message": "Molta notturna"
-    },
-    "noActiveFeatures": {
-        "message": "Nessuna funzione attivata"
-    },
-    "none": {
-        "message": "Nessuno"
-    },
-    "noOpenVideoTabs": {
-        "message": "Nessuna scheda video aperta"
-    },
-    "normal": {
-        "message": "Standard"
-    },
-    "old": {
-        "message": "Vecchio"
-    },
-    "onAllVideos": {
-        "message": "Su tutti i video"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Attivo solo su YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Istanza unica di riproduzione attiva"
-    },
-    "onSubscribedChannels": {
-        "message": "In canali sottoscritti"
-    },
-    "openPopupPlayer": {
-        "message": "Apri video/playlist in una nuova finestra"
-    },
-    "orange": {
-        "message": "Arancione"
-    },
-    "os": {
-        "message": "Sistema Operativo"
-    },
-    "other": {
-        "message": "Altro"
-    },
-    "outline": {
-        "message": "Contorno"
-    },
-    "permissions": {
-        "message": "Autorizzazioni"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Pianura"
-    },
-    "platform": {
-        "message": "Piattaforma"
-    },
-    "playbackSpeed": {
-        "message": "Velocità di riproduzione"
-    },
-    "player": {
-        "message": "Lettore"
-    },
-    "playerColor": {
-        "message": "Colore lettore"
-    },
-    "playerSize": {
-        "message": "Dimensione lettore"
-    },
-    "playlist": {
-        "message": "Scaletta"
-    },
-    "playlists": {
-        "message": "Scalette"
-    },
-    "playPause": {
-        "message": "Avvio/Pausa"
-    },
-    "popupPlayer": {
-        "message": "Lettore pop-up"
-    },
-    "position": {
-        "message": "Posizione"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Premere un qualunque tasto o scorrere"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Premere un qualunque tasto o usare rotella del mouse"
-    },
-    "previousVideo": {
-        "message": "Video precedente"
-    },
-    "primaryColor": {
-        "message": "Colore primario"
-    },
-    "purple": {
-        "message": "Viola"
-    },
-    "quality": {
-        "message": "Qualità"
-    },
-    "qualityWithoutFocus": {
-        "message": "Kualitas Tanpa Fokus"
-    },
-    "raised": {
-        "message": "Rialzato"
-    },
-    "rateMe": {
-        "message": "Valutami"
-    },
-    "rateUs": {
-        "message": "Valutaci"
-    },
-    "red": {
-        "message": "Rosso"
-    },
-    "redDislikeButton": {
-        "message": "Mostra pulsante Non mi piace in rosso"
-    },
-    "relatedVideos": {
-        "message": "Video correlati"
-    },
-    "remote": {
-        "message": "Riproduci su tv"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Rimuovi risultati di ricerca correlati"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Rimuovi il carosello di Shorts dai risultati di ricerca"
-    },
-    "repeat": {
-        "message": "Ripeti"
-    },
-    "reset": {
-        "message": "Reimposta"
-    },
-    "resetAllSettings": {
-        "message": "Reimposta tutte le impostazioni"
-    },
-    "resetAllShortcuts": {
-        "message": "Reimposta tutte le scorciatoie"
-    },
-    "reverse": {
-        "message": "Inverti"
-    },
-    "rotate": {
-        "message": "Ruota"
-    },
-    "save": {
-        "message": "Salva"
-    },
-    "saveAs": {
-        "message": "Salva come"
-    },
-    "schedule": {
-        "message": "Programmazione"
-    },
-    "screen": {
-        "message": "Schermo"
-    },
-    "scrollBar": {
-        "message": "Barra di scorrimento"
-    },
-    "search": {
-        "message": "Ricerca"
-    },
-    "searchBarOnly": {
-        "message": "Cerca solamente nella barra"
-    },
-    "seekBackward10Seconds": {
-        "message": "Muovi indietro 10 secondi"
-    },
-    "seekForward10Seconds": {
-        "message": "Muovi avanti 10 secondi"
-    },
-    "seekNextChapter": {
-        "message": "Cerca prossimo capitolo"
-    },
-    "seekPreviousChapter": {
-        "message": "Cerca precedente capitolo"
-    },
-    "settings": {
-        "message": "Impostazioni"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Impostazioni importate con successo"
-    },
-    "shortcuts": {
-        "message": "Scorciatoie"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Mostra tessere di fine video al passaggio del puntatore"
-    },
-    "showChannelVideosCount": {
-        "message": "Mostra contatore visualizzazioni canale"
-    },
-    "showLess": {
-        "message": "Mostra meno"
-    },
-    "showMore": {
-        "message": "Mostra altro"
-    },
-    "showRemainingDuration": {
-        "message": "Mostra durata residua del video"
-    },
-    "shuffle": {
-        "message": "Riproduzione casuale"
-    },
-    "sidebar": {
-        "message": "Barra laterale"
-    },
-    "spacebar": {
-        "message": "Barra spaziatrice"
-    },
-    "squaredUserImages": {
-        "message": "Immagini utente squadrate"
-    },
-    "static": {
-        "message": "Statica"
-    },
-    "statsForNerds": {
-        "message": "Visualizza statistiche per nerd"
-    },
-    "stop": {
-        "message": "Arresto"
-    },
-    "style": {
-        "message": "Stile"
-    },
-    "styles": {
-        "message": "Stili"
-    },
-    "subscribe": {
-        "message": "Sottoscrivi"
-    },
-    "subscriptions": {
-        "message": "Sottoscrizioni"
-    },
-    "subtitles": {
-        "message": "Sottotitoli"
-    },
-    "sunset": {
-        "message": "Tramonto"
-    },
-    "sunsetToSunrise": {
-        "message": "Dal tramonto all'alba"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferenza di sistema: scuro"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferenza di sistema: chiaro"
-    },
-    "teal": {
-        "message": "Verde acqua"
-    },
-    "textColor": {
-        "message": "Colore testo"
-    },
-    "themes": {
-        "message": "Temi"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Questo rimuoverà tutti i cookies"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Questo rimuoverà tutti i cookies di YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Questo reimposterà l'intera configurazione"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Questo reimposterà tutte le scorciatoie"
-    },
-    "thumbnails": {
-        "message": "Miniature"
-    },
-    "thumbnailsQuality": {
-        "message": "Qualità miniature"
-    },
-    "timeFrom": {
-        "message": "Dalle ore"
-    },
-    "timeTo": {
-        "message": "Alle ore"
-    },
-    "todayAt": {
-        "message": "Oggi alle"
-    },
-    "toggleAutoplay": {
-        "message": "Dis/attiva riproduzione automatica"
-    },
-    "toggleCards": {
-        "message": "Dis/attiva tessere di fine video"
-    },
-    "toggleControls": {
-        "message": "Attiva/disattiva i controlli"
-    },
-    "topChat": {
-        "message": "Chat superiore"
-    },
-    "trackWatchedVideos": {
-        "message": "Traccia video guardati"
-    },
-    "trailerAutoplay": {
-        "message": "Avvio automatico trailer"
-    },
-    "Transcript": {
-        "message": "Trascrizione"
-    },
-    "translations": {
-        "message": "Traduzioni"
-    },
-    "transparentBackground": {
-        "message": "Sfondo trasparente"
-    },
-    "trending": {
-        "message": "In tendenza"
-    },
-    "tryToReloadThePage": {
-        "message": "Provare a ricaricare la pagina"
-    },
-    "type": {
-        "message": "Tipologia"
-    },
-    "upNextAutoplay": {
-        "message": "Riproduzione automatica video successivo"
-    },
-    "use24HourFormat": {
-        "message": "Usa formato a 24 ore"
-    },
-    "version": {
-        "message": "Numero versione"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "La descrizione del video verrà espansa per ottenere il nome della categoria"
-    },
-    "videoFormats": {
-        "message": "Formati video"
-    },
-    "videos": {
-        "message": "Video"
-    },
-    "viewMode": {
-        "message": "Modalità cinema"
-    },
-    "watchLater": {
-        "message": "Guarda più tardi"
-    },
-    "watchTime": {
-        "message": "Tempo di visione"
-    },
-    "whenTabIsChanged": {
-        "message": "Quando si cambia scheda"
-    },
-    "white": {
-        "message": "Bianco"
-    },
-    "windowColor": {
-        "message": "Colore finestra"
-    },
-    "windowOpacity": {
-        "message": "Opacità finestra"
-    },
-    "yellow": {
-        "message": "Giallo"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Intestazione YouTube (sinistra)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Intestazione YouTube (destra)"
-    },
-    "youtubeHomePage": {
-        "message": "Pagina iniziale YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Lingua YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limita la qualità video a 1080p per il codec h.264"
-    }
+	"about": {
+		"message": "Al riguardo"
+	},
+	"accept": {
+		"message": "Accetta"
+	},
+	"activate": {
+		"message": "Attivo/a"
+	},
+	"activateCaptions": {
+		"message": "Attiva didascalie"
+	},
+	"activated": {
+		"message": "Attivato/a"
+	},
+	"activatedFeatures": {
+		"message": "Funzionalità attivate"
+	},
+	"activateFullscreen": {
+		"message": "Attiva schermo intero"
+	},
+	"activeFeatures": {
+		"message": "Funzioni disponibili"
+	},
+	"addScrollToTop": {
+		"message": "Aggiungi «Scorri in cima»"
+	},
+	"ads": {
+		"message": "Pubblicità"
+	},
+	"all": {
+		"message": "Tutte"
+	},
+	"allow": {
+		"message": "Permetti"
+	},
+	"always": {
+		"message": "Sempre"
+	},
+	"alwaysActive": {
+		"message": "Sempre attivo"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Mostra sempre barra di avanzamento"
+	},
+	"amber": {
+		"message": "Ambra"
+	},
+	"analyzer": {
+		"message": "Analizzatore"
+	},
+	"appearance": {
+		"message": "Aspetto"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Sicuri di voler esportare i dati?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Sicuri di voler importare i dati?"
+	},
+	"audioFormats": {
+		"message": "Formati audio"
+	},
+	"auto": {
+		"message": "Automatico"
+	},
+	"autoFullscreen": {
+		"message": "Schermo intero automatico"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausa automatica al cambio di scheda"
+	},
+	"autoplay": {
+		"message": "Avvio automatico"
+	},
+	"avoidAv1": {
+		"message": "Evita AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Evita AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Evita AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Evita rendering tramite CPU quando possibile"
+	},
+	"backgroundColor": {
+		"message": "Colore di sfondo"
+	},
+	"backgroundOpacity": {
+		"message": "Opacità di sfondo"
+	},
+	"backupAndReset": {
+		"message": "Backup e reimpostazione"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Basato sullo schema di colore del sistema"
+	},
+	"belowPlayer": {
+		"message": "Sotto il lettore"
+	},
+	"black": {
+		"message": "Nero"
+	},
+	"blockAll": {
+		"message": "Blocca tutte"
+	},
+	"blockAv1": {
+		"message": "Blocca AV1"
+	},
+	"blockH264": {
+		"message": "Blocca H.264"
+	},
+	"blocklist": {
+		"message": "Lista nera"
+	},
+	"blockMusic": {
+		"message": "Blocca musica"
+	},
+	"blockVp8": {
+		"message": "Blocca VP8"
+	},
+	"blockVp9": {
+		"message": "Blocca VP9"
+	},
+	"blue": {
+		"message": "Blu"
+	},
+	"blueGray": {
+		"message": "Grigio blu"
+	},
+	"bluelight": {
+		"message": "Luce blu"
+	},
+	"brown": {
+		"message": "Marrone"
+	},
+	"browserVersion": {
+		"message": "Versione browser"
+	},
+	"bubbles": {
+		"message": "Bolle"
+	},
+	"cancel": {
+		"message": "Annulla"
+	},
+	"categories": {
+		"message": "Categorie"
+	},
+	"channel": {
+		"message": "Canale"
+	},
+	"channels": {
+		"message": "Canali"
+	},
+	"characterEdgeStyle": {
+		"message": "Stile del bordo carattere"
+	},
+	"clipboard": {
+		"message": "Appunti"
+	},
+	"collapsed": {
+		"message": "Compressa/i"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Comprimi sezioni di sottoscrizione"
+	},
+	"comments": {
+		"message": "Commenti"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Conferma prima della chiusura"
+	},
+	"cores": {
+		"message": "Core"
+	},
+	"cropChapterTitles": {
+		"message": "Ritaglia titoli dei capitoli"
+	},
+	"customCss": {
+		"message": "CSS personalizzato"
+	},
+	"customJs": {
+		"message": "JS personalizzato"
+	},
+	"customMiniPlayer": {
+		"message": "Mini lettore personalizzato"
+	},
+	"cyan": {
+		"message": "Ciano"
+	},
+	"dark": {
+		"message": "Scuro"
+	},
+	"darkTheme": {
+		"message": "Tema scuro"
+	},
+	"dateAndTime": {
+		"message": "Data e ora"
+	},
+	"dawn": {
+		"message": "Albeggio"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Riduci velocità di riproduzione"
+	},
+	"decreaseVolume": {
+		"message": "Diminuisci volume"
+	},
+	"deepOrange": {
+		"message": "Arancione intenso"
+	},
+	"deepPurple": {
+		"message": "Viola intenso"
+	},
+	"default": {
+		"message": "Predefinito"
+	},
+	"defaultChannelTab": {
+		"message": "Scheda predefinita"
+	},
+	"defaultContentCountry": {
+		"message": "Paese del contenuto predefinito"
+	},
+	"deleteWatchedVideos": {
+		"message": "Elimina video guardati"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Cancella cookie YouTube"
+	},
+	"depressed": {
+		"message": "Depresso"
+	},
+	"description": {
+		"message": "Descrizione"
+	},
+	"description_ext": {
+		"message": "Rendi YouTube ordinato & intelligente! YouTube colore video salta annuncio volume velocità canale utensile stile HD annunci blocca-annunci etichette tags keyword playlist"
+	},
+	"desert": {
+		"message": "Deserto"
+	},
+	"details": {
+		"message": "Dettagli"
+	},
+	"developerOptions": {
+		"message": "Opzioni per sviluppatori"
+	},
+	"device": {
+		"message": "Dispositivo"
+	},
+	"dim": {
+		"message": "Smorzamento"
+	},
+	"disabled": {
+		"message": "Disabilitata"
+	},
+	"dislike": {
+		"message": "Non mi piace"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Mostra il giorno della settimana"
+	},
+	"donate": {
+		"message": "Donazione"
+	},
+	"doNotChange": {
+		"message": "Non cambiare"
+	},
+	"draggable": {
+		"message": "Trascinabile"
+	},
+	"durationWithSpeed": {
+		"message": "Mostra il tempo rimanente con riferimento alla velocità di riproduzione"
+	},
+	"email": {
+		"message": "E-mail"
+	},
+	"empty": {
+		"message": "Vuota"
+	},
+	"enabled": {
+		"message": "Abilitato"
+	},
+	"enabledForced": {
+		"message": "Abilitato (forzato)"
+	},
+	"expanded": {
+		"message": "Estesa"
+	},
+	"exportSettings": {
+		"message": "Esporta impostazioni"
+	},
+	"extension": {
+		"message": "Estensione"
+	},
+	"filters": {
+		"message": "Filtri"
+	},
+	"fitToWindow": {
+		"message": "Adatta alla finestra"
+	},
+	"fontColor": {
+		"message": "Colore font"
+	},
+	"fontFamily": {
+		"message": "Famiglia font"
+	},
+	"fontOpacity": {
+		"message": "Opacità font"
+	},
+	"fontSize": {
+		"message": "Dimensione font"
+	},
+	"footer": {
+		"message": "Piè di pagina"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Velocità di riproduzione forzata"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Riproduzione forzata di video dall'inizio"
+	},
+	"forcedTheaterMode": {
+		"message": "Modalità cinema forzata"
+	},
+	"forcedVolume": {
+		"message": "Volume forzato"
+	},
+	"forceSDR": {
+		"message": "Forza SDR"
+	},
+	"foundABug": {
+		"message": "Trovato un bug?"
+	},
+	"fullWindow": {
+		"message": "Finestra intera"
+	},
+	"general": {
+		"message": "Generale"
+	},
+	"geoPreference": {
+		"message": "Preferenza Geo"
+	},
+	"googleApiKey": {
+		"message": "Chiave API di Google"
+	},
+	"goToSearchBox": {
+		"message": "Vai alla casella di ricerca"
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"hardwareInformation": {
+		"message": "Informazioni hardware"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura in altà qualità"
+	},
+	"header": {
+		"message": "Intestazione"
+	},
+	"hidden": {
+		"message": "Nascosta/i"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Nascosta nella pagina video"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Nascondi miniature animate"
+	},
+	"hideAnnotations": {
+		"message": "Nascondi annotazioni"
+	},
+	"hideCards": {
+		"message": "Nascondi tessere di fine video"
+	},
+	"hideCategories": {
+		"message": "Nascondi categorie"
+	},
+	"hideCommentsCount": {
+		"message": "Nascondi il numero dei commenti"
+	},
+	"hideCountryCode": {
+		"message": "Nascondi codice paese"
+	},
+	"hideDate": {
+		"message": "Nascondi data"
+	},
+	"hideDetails": {
+		"message": "Nascondi dettagli"
+	},
+	"hideEndscreen": {
+		"message": "Nascondi finale video"
+	},
+	"hideFeaturedContent": {
+		"message": "Nascondi contenuti in primo piano"
+	},
+	"hideFooter": {
+		"message": "Nascondi piè di pagina"
+	},
+	"hideGradientBottom": {
+		"message": "Nascondi fondo gradiente"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Nascondi barra dei controlli del lettore"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Nascondi pulsanti della barra dei controlli del lettore"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Nascondi opzioni di controllo del lettore"
+	},
+	"hidePlaylist": {
+		"message": "Nascondi scaletta"
+	},
+	"hideRightButtons": {
+		"message": "Nascondi pulsanti sulla destra"
+	},
+	"hideScrollForDetails": {
+		"message": "Nascondi «Scorri per dettagli»"
+	},
+	"hideSkipOverlay": {
+		"message": "Nascondi \"Salta overlay\""
+	},
+	"hideThumbnailOverlay": {
+		"message": "Nascondi overlay miniature"
+	},
+	"hideThumbnails": {
+		"message": "Nascondi miniature"
+	},
+	"hideViewsCount": {
+		"message": "Nascondi contatore visualizzazioni"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Nascondi buttone di ricerca vocale"
+	},
+	"high": {
+		"message": "Alto"
+	},
+	"history": {
+		"message": "Cronologia"
+	},
+	"home": {
+		"message": "Pagina iniziale"
+	},
+	"hover": {
+		"message": "In sospensione"
+	},
+	"hoverOnVideoPage": {
+		"message": "In sospensione sulla pagine del video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Quanto tempo fa il video è stato caricato"
+	},
+	"icons": {
+		"message": "Icone"
+	},
+	"iconsOnly": {
+		"message": "Solo icone"
+	},
+	"importSettings": {
+		"message": "Importa impostazioni"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Icona su YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Lingua"
+	},
+	"improvedtubeVersion": {
+		"message": "Versione"
+	},
+	"improveLogo": {
+		"message": "Migliora logo YouTube"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Incrementa velocità di riproduzione"
+	},
+	"increaseVolume": {
+		"message": "Aumenta volume"
+	},
+	"indigo": {
+		"message": "Indaco"
+	},
+	"items": {
+		"message": "Oggetti"
+	},
+	"language": {
+		"message": "Lingua"
+	},
+	"languages": {
+		"message": "Lingue"
+	},
+	"legacyYoutube": {
+		"message": "YouTube versione legacy"
+	},
+	"library": {
+		"message": "Librerie"
+	},
+	"light": {
+		"message": "Chiaro"
+	},
+	"lightBlue": {
+		"message": "Blu chiaro"
+	},
+	"lightGreen": {
+		"message": "Verde chiaro"
+	},
+	"like": {
+		"message": "Mi piace"
+	},
+	"liked": {
+		"message": "Piaciuto"
+	},
+	"likes": {
+		"message": "Mi piace"
+	},
+	"limitPageWidth": {
+		"message": "Limita larghezza pagina"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Chat dal vivo"
+	},
+	"liveChatType": {
+		"message": "Tipologia chat dal vivo"
+	},
+	"location": {
+		"message": "Luogo"
+	},
+	"loudnessNormalization": {
+		"message": "Normalizzazione rumorosità"
+	},
+	"low": {
+		"message": "Basso"
+	},
+	"markWatchedVideos": {
+		"message": "Contrassegna video visti"
+	},
+	"medium": {
+		"message": "Medio"
+	},
+	"more": {
+		"message": "Di piú"
+	},
+	"moveSidebarLeft": {
+		"message": "Sposta barra laterale a sinistra"
+	},
+	"moveThumbnailsRight": {
+		"message": "Sposta miniature a destra"
+	},
+	"myColors": {
+		"message": "Miei colori"
+	},
+	"name": {
+		"message": "Nome"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini lettore nativo"
+	},
+	"new": {
+		"message": "Nuovo"
+	},
+	"nextVideo": {
+		"message": "Prossimo video"
+	},
+	"night": {
+		"message": "Notte"
+	},
+	"nightMode": {
+		"message": "Molta notturna"
+	},
+	"noActiveFeatures": {
+		"message": "Nessuna funzione attivata"
+	},
+	"none": {
+		"message": "Nessuno"
+	},
+	"noOpenVideoTabs": {
+		"message": "Nessuna scheda video aperta"
+	},
+	"normal": {
+		"message": "Standard"
+	},
+	"old": {
+		"message": "Vecchio"
+	},
+	"onAllVideos": {
+		"message": "Su tutti i video"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Attivo solo su YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Istanza unica di riproduzione attiva"
+	},
+	"onSubscribedChannels": {
+		"message": "In canali sottoscritti"
+	},
+	"openPopupPlayer": {
+		"message": "Apri video/playlist in una nuova finestra"
+	},
+	"orange": {
+		"message": "Arancione"
+	},
+	"os": {
+		"message": "Sistema Operativo"
+	},
+	"other": {
+		"message": "Altro"
+	},
+	"outline": {
+		"message": "Contorno"
+	},
+	"permissions": {
+		"message": "Autorizzazioni"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Pianura"
+	},
+	"platform": {
+		"message": "Piattaforma"
+	},
+	"playbackSpeed": {
+		"message": "Velocità di riproduzione"
+	},
+	"player": {
+		"message": "Lettore"
+	},
+	"playerColor": {
+		"message": "Colore lettore"
+	},
+	"playerSize": {
+		"message": "Dimensione lettore"
+	},
+	"playlist": {
+		"message": "Scaletta"
+	},
+	"playlists": {
+		"message": "Scalette"
+	},
+	"playPause": {
+		"message": "Avvio/Pausa"
+	},
+	"popupPlayer": {
+		"message": "Lettore pop-up"
+	},
+	"position": {
+		"message": "Posizione"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Premere un qualunque tasto o scorrere"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Premere un qualunque tasto o usare rotella del mouse"
+	},
+	"previousVideo": {
+		"message": "Video precedente"
+	},
+	"primaryColor": {
+		"message": "Colore primario"
+	},
+	"purple": {
+		"message": "Viola"
+	},
+	"quality": {
+		"message": "Qualità"
+	},
+	"qualityWithoutFocus": {
+		"message": "Kualitas Tanpa Fokus"
+	},
+	"raised": {
+		"message": "Rialzato"
+	},
+	"rateMe": {
+		"message": "Valutami"
+	},
+	"rateUs": {
+		"message": "Valutaci"
+	},
+	"red": {
+		"message": "Rosso"
+	},
+	"redDislikeButton": {
+		"message": "Mostra pulsante Non mi piace in rosso"
+	},
+	"relatedVideos": {
+		"message": "Video correlati"
+	},
+	"remote": {
+		"message": "Riproduci su tv"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Rimuovi risultati di ricerca correlati"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Rimuovi il carosello di Shorts dai risultati di ricerca"
+	},
+	"repeat": {
+		"message": "Ripeti"
+	},
+	"reset": {
+		"message": "Reimposta"
+	},
+	"resetAllSettings": {
+		"message": "Reimposta tutte le impostazioni"
+	},
+	"resetAllShortcuts": {
+		"message": "Reimposta tutte le scorciatoie"
+	},
+	"reverse": {
+		"message": "Inverti"
+	},
+	"rotate": {
+		"message": "Ruota"
+	},
+	"save": {
+		"message": "Salva"
+	},
+	"saveAs": {
+		"message": "Salva come"
+	},
+	"schedule": {
+		"message": "Programmazione"
+	},
+	"screen": {
+		"message": "Schermo"
+	},
+	"scrollBar": {
+		"message": "Barra di scorrimento"
+	},
+	"search": {
+		"message": "Ricerca"
+	},
+	"searchBarOnly": {
+		"message": "Cerca solamente nella barra"
+	},
+	"seekBackward10Seconds": {
+		"message": "Muovi indietro 10 secondi"
+	},
+	"seekForward10Seconds": {
+		"message": "Muovi avanti 10 secondi"
+	},
+	"seekNextChapter": {
+		"message": "Cerca prossimo capitolo"
+	},
+	"seekPreviousChapter": {
+		"message": "Cerca precedente capitolo"
+	},
+	"settings": {
+		"message": "Impostazioni"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Impostazioni importate con successo"
+	},
+	"shortcuts": {
+		"message": "Scorciatoie"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Mostra tessere di fine video al passaggio del puntatore"
+	},
+	"showChannelVideosCount": {
+		"message": "Mostra contatore visualizzazioni canale"
+	},
+	"showLess": {
+		"message": "Mostra meno"
+	},
+	"showMore": {
+		"message": "Mostra altro"
+	},
+	"showRemainingDuration": {
+		"message": "Mostra durata residua del video"
+	},
+	"shuffle": {
+		"message": "Riproduzione casuale"
+	},
+	"sidebar": {
+		"message": "Barra laterale"
+	},
+	"spacebar": {
+		"message": "Barra spaziatrice"
+	},
+	"squaredUserImages": {
+		"message": "Immagini utente squadrate"
+	},
+	"static": {
+		"message": "Statica"
+	},
+	"statsForNerds": {
+		"message": "Visualizza statistiche per nerd"
+	},
+	"stop": {
+		"message": "Arresto"
+	},
+	"style": {
+		"message": "Stile"
+	},
+	"styles": {
+		"message": "Stili"
+	},
+	"subscribe": {
+		"message": "Sottoscrivi"
+	},
+	"subscriptions": {
+		"message": "Sottoscrizioni"
+	},
+	"subtitles": {
+		"message": "Sottotitoli"
+	},
+	"sunset": {
+		"message": "Tramonto"
+	},
+	"sunsetToSunrise": {
+		"message": "Dal tramonto all'alba"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferenza di sistema: scuro"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferenza di sistema: chiaro"
+	},
+	"teal": {
+		"message": "Verde acqua"
+	},
+	"textColor": {
+		"message": "Colore testo"
+	},
+	"themes": {
+		"message": "Temi"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Questo rimuoverà tutti i cookies"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Questo rimuoverà tutti i cookies di YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Questo reimposterà l'intera configurazione"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Questo reimposterà tutte le scorciatoie"
+	},
+	"thumbnails": {
+		"message": "Miniature"
+	},
+	"thumbnailsQuality": {
+		"message": "Qualità miniature"
+	},
+	"timeFrom": {
+		"message": "Dalle ore"
+	},
+	"timeTo": {
+		"message": "Alle ore"
+	},
+	"todayAt": {
+		"message": "Oggi alle"
+	},
+	"toggleAutoplay": {
+		"message": "Dis/attiva riproduzione automatica"
+	},
+	"toggleCards": {
+		"message": "Dis/attiva tessere di fine video"
+	},
+	"toggleControls": {
+		"message": "Attiva/disattiva i controlli"
+	},
+	"topChat": {
+		"message": "Chat superiore"
+	},
+	"trackWatchedVideos": {
+		"message": "Traccia video guardati"
+	},
+	"trailerAutoplay": {
+		"message": "Avvio automatico trailer"
+	},
+	"Transcript": {
+		"message": "Trascrizione"
+	},
+	"translations": {
+		"message": "Traduzioni"
+	},
+	"transparentBackground": {
+		"message": "Sfondo trasparente"
+	},
+	"trending": {
+		"message": "In tendenza"
+	},
+	"tryToReloadThePage": {
+		"message": "Provare a ricaricare la pagina"
+	},
+	"type": {
+		"message": "Tipologia"
+	},
+	"upNextAutoplay": {
+		"message": "Riproduzione automatica video successivo"
+	},
+	"use24HourFormat": {
+		"message": "Usa formato a 24 ore"
+	},
+	"version": {
+		"message": "Numero versione"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "La descrizione del video verrà espansa per ottenere il nome della categoria"
+	},
+	"videoFormats": {
+		"message": "Formati video"
+	},
+	"videos": {
+		"message": "Video"
+	},
+	"viewMode": {
+		"message": "Modalità cinema"
+	},
+	"watchLater": {
+		"message": "Guarda più tardi"
+	},
+	"watchTime": {
+		"message": "Tempo di visione"
+	},
+	"whenTabIsChanged": {
+		"message": "Quando si cambia scheda"
+	},
+	"white": {
+		"message": "Bianco"
+	},
+	"windowColor": {
+		"message": "Colore finestra"
+	},
+	"windowOpacity": {
+		"message": "Opacità finestra"
+	},
+	"yellow": {
+		"message": "Giallo"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Intestazione YouTube (sinistra)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Intestazione YouTube (destra)"
+	},
+	"youtubeHomePage": {
+		"message": "Pagina iniziale YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Lingua YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube limita la qualità video a 1080p per il codec h.264"
+	}
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,1046 +1,1031 @@
 {
-    "about": {
-        "message": "このソフトについて"
-    },
-    "accept": {
-        "message": "了解"
-    },
-    "activate": {
-        "message": "有効にする"
-    },
-    "activateCaptions": {
-        "message": "キャプションを有効にする"
-    },
-    "activated": {
-        "message": "有効化"
-    },
-    "activatedFeatures": {
-        "message": "有効化された機能"
-    },
-    "activateFullscreen": {
-        "message": "全画面にする"
-    },
-    "activeFeatures": {
-        "message": "有効な機能"
-    },
-    "addScrollToTop": {
-        "message": "\"一番上にスクロール\"ボタンを追加"
-    },
-    "ads": {
-        "message": "広告"
-    },
-    "all": {
-        "message": "すべて"
-    },
-    "allow": {
-        "message": "許可"
-    },
-    "Allow_auto_generate": {
-        "message": "自動生成を許可"
-    },
-    "alwaysActive": {
-        "message": "常に有効"
-    },
-    "alwaysShowProgressBar": {
-        "message": "常にプログレスバーを表示"
-    },
-    "amber": {
-        "message": "アンバー"
-    },
-    "analyzer": {
-        "message": "分析"
-    },
-    "animations": {
-        "message": "アニメーション"
-    },
-    "appearance": {
-        "message": "外観"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "本当にエクスポートしますか？"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "本当にインポートしますか？"
-    },
-    "audio": {
-        "message": "音声"
-    },
-    "audioFormats": {
-        "message": "音声形式"
-    },
-    "auto": {
-        "message": "自動"
-    },
-    "autoFullscreen": {
-        "message": "自動的に全画面にする"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "タブ切り替えで自動的に一時停止"
-    },
-    "autoplay": {
-        "message": "自動再生"
-    },
-    "backgroundColor": {
-        "message": "背景色"
-    },
-    "backgroundOpacity": {
-        "message": "背景の不透明度"
-    },
-    "backupAndReset": {
-        "message": "バックアップとリセット"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "システムの色に合わせる"
-    },
-    "belowPlayer": {
-        "message": "プレーヤーの下"
-    },
-    "bitness": {
-        "message": "ビット数"
-    },
-    "black": {
-        "message": "黒"
-    },
-    "blockAll": {
-        "message": "すべてブロック"
-    },
-    "blockAv1": {
-        "message": "AV1をブロック"
-    },
-    "blockH264": {
-        "message": "H.264をブロック"
-    },
-    "blocklist": {
-        "message": "ブラックリスト"
-    },
-    "blockMusic": {
-        "message": "音楽の再生中はブロック"
-    },
-    "blockVp8": {
-        "message": "VP8をブロック"
-    },
-    "blockVp9": {
-        "message": "VP9をブロック"
-    },
-    "blue": {
-        "message": "青"
-    },
-    "blueGray": {
-        "message": "青みがかった灰"
-    },
-    "bluelight": {
-        "message": "ブルーライト"
-    },
-    "brown": {
-        "message": "茶"
-    },
-    "browser": {
-        "message": "ブラウザー"
-    },
-    "browserVersion": {
-        "message": "ブラウザーのバージョン"
-    },
-    "bubbles": {
-        "message": "バブル"
-    },
-    "bug": {
-        "message": "バグ"
-    },
-    "cancel": {
-        "message": "キャンセル"
-    },
-    "categories": {
-        "message": "カテゴリー"
-    },
-    "channel": {
-        "message": "チャンネル"
-    },
-    "channels": {
-        "message": "チャンネル"
-    },
-    "characterEdgeStyle": {
-        "message": "文字の縁のスタイル"
-    },
-    "clipboard": {
-        "message": "クリップボード"
-    },
-    "codecH264": {
-        "message": "H.264コーデック"
-    },
-    "codecs": {
-        "message": "コーデック"
-    },
-    "collapsed": {
-        "message": "畳む"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "サブスクリプション部分を畳む"
-    },
-    "comments": {
-        "message": "コメント"
-    },
-    "confirmationBeforeClosing": {
-        "message": "閉じる前に確認"
-    },
-    "cookies": {
-        "message": "Cookie"
-    },
-    "cores": {
-        "message": "コア数"
-    },
-    "cropChapterTitles": {
-        "message": "チャプターのタイトルをトリミング"
-    },
-    "custom": {
-        "message": "カスタム"
-    },
-    "customCss": {
-        "message": "カスタムCSS"
-    },
-    "customJs": {
-        "message": "カスタムJS"
-    },
-    "customMiniPlayer": {
-        "message": "カスタムミニプレーヤー"
-    },
-    "cyan": {
-        "message": "シアン"
-    },
-    "dark": {
-        "message": "ダーク"
-    },
-    "darkTheme": {
-        "message": "ダークテーマ"
-    },
-    "dateAndTime": {
-        "message": "日付と時刻"
-    },
-    "dawn": {
-        "message": "夜明け"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "再生速度を下げる"
-    },
-    "decreaseVolume": {
-        "message": "音量を下げる"
-    },
-    "deepOrange": {
-        "message": "深いオレンジ"
-    },
-    "deepPurple": {
-        "message": "深い紫"
-    },
-    "default": {
-        "message": "デフォルト"
-    },
-    "default_theme": {
-        "message": "デフォルト"
-    },
-    "defaultChannelTab": {
-        "message": "デフォルトのチャンネルタブ"
-    },
-    "defaultContentCountry": {
-        "message": "デフォルトのコンテンツの地域"
-    },
-    "defaultPlaybackSpeed": {
-        "message": "デフォルトの再生速度"
-    },
-    "deleteWatchedVideos": {
-        "message": "視聴した動画を削除"
-    },
-    "deleteYoutubeCookies": {
-        "message": "YouTubeのCookieを削除"
-    },
-    "description": {
-        "message": "動画の説明"
-    },
-    "description_ext": {
-        "message": "YouTube をスマートに整理しましょう！ YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
-    },
-    "desert": {
-        "message": "砂漠"
-    },
-    "details": {
-        "message": "詳細"
-    },
-    "developerOptions": {
-        "message": "開発者向けオプション"
-    },
-    "device": {
-        "message": "デバイス"
-    },
-    "dim": {
-        "message": "暗さ"
-    },
-    "disabled": {
-        "message": "無効"
-    },
-    "dislike": {
-        "message": "低評価"
-    },
-    "displayDayOfTheWeak": {
-        "message": "曜日を表示"
-    },
-    "donate": {
-        "message": "寄付する"
-    },
-    "doNotChange": {
-        "message": "変更しない"
-    },
-    "download": {
-        "message": "ダウンロード"
-    },
-    "draggable": {
-        "message": "ドラッグ可能にする"
-    },
-    "durationWithSpeed": {
-        "message": "再生速度に応じた残り時間を表示"
-    },
-    "embedded_Hide_Share": {
-        "message": "共有ボタンを非表示"
-    },
-    "Embedded_YouTube": {
-        "message": "埋め込み動画"
-    },
-    "empty": {
-        "message": "なし"
-    },
-    "enabled": {
-        "message": "有効"
-    },
-    "enabledForced": {
-        "message": "有効 (強制)"
-    },
-    "expanded": {
-        "message": "広げる"
-    },
-    "exportSettings": {
-        "message": "設定をエクスポート"
-    },
-    "extension": {
-        "message": "拡張"
-    },
-    "Feature_not_yet_available": {
-        "message": "利用できない機能"
-    },
-    "file": {
-        "message": "ファイル"
-    },
-    "filters": {
-        "message": "フィルター"
-    },
-    "fitToWindow": {
-        "message": "ウィンドウに合わせる"
-    },
-    "font": {
-        "message": "フォント"
-    },
-    "fontColor": {
-        "message": "フォントの色"
-    },
-    "fontFamily": {
-        "message": "フォントファミリー"
-    },
-    "fontOpacity": {
-        "message": "フォントの不透明度"
-    },
-    "fontSize": {
-        "message": "フォントサイズ"
-    },
-    "footer": {
-        "message": "フッター"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "再生速度を指定"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(音楽でも再生速度を指定する？)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "強制的に動画を最初から再生"
-    },
-    "forcedTheaterMode": {
-        "message": "シアターモードにする"
-    },
-    "forcedVolume": {
-        "message": "音量を指定する"
-    },
-    "forceSDR": {
-        "message": "SDRを強制"
-    },
-    "foundABug": {
-        "message": "バグ報告"
-    },
-    "fullWindow": {
-        "message": "フルウィンドウ"
-    },
-    "general": {
-        "message": "一般"
-    },
-    "github": {
-        "message": "GitHub"
-    },
-    "goToSearchBox": {
-        "message": "検索ボックスに移動"
-    },
-    "gpu": {
-        "message": "GPU"
-    },
-    "green": {
-        "message": "緑"
-    },
-    "Hamburger_Menu": {
-        "message": "ハンバーガーメニュー"
-    },
-    "hardwareInformation": {
-        "message": "ハードウェア情報"
-    },
-    "hdThumbnail": {
-        "message": "HDサムネイル"
-    },
-    "header": {
-        "message": "ヘッダー"
-    },
-    "hidden": {
-        "message": "非表示"
-    },
-    "hiddenOnVideoPage": {
-        "message": "動画ページでは隠す"
-    },
-    "hide_author_avatars": {
-        "message": "投稿者のアバターを非表示"
-    },
-    "hide_labels": {
-        "message": "名前を非表示"
-    },
-    "Hide_Pause_Overlay": {
-        "message": "一時停止中のオーバーレイを非表示"
-    },
-    "Hide_sidebar": {
-        "message": "サイドバーを非表示 "
-    },
-    "Hide_YouTube_Logo": {
-        "message": "YouTubeロゴを非表示"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "サムネイルのアニメーションを行わない"
-    },
-    "hideAnnotations": {
-        "message": "アノテーションを非表示"
-    },
-    "hideCards": {
-        "message": "カードを非表示"
-    },
-    "hideCategories": {
-        "message": "カテゴリーを非表示にする"
-    },
-    "hideCommentsCount": {
-        "message": "コメント数を非表示"
-    },
-    "hideCountryCode": {
-        "message": "国名コードを非表示"
-    },
-    "hideDate": {
-        "message": "日付を非表示"
-    },
-    "hideDetails": {
-        "message": "詳細を非表示"
-    },
-    "hideEndscreen": {
-        "message": "再生終了時の画面を非表示"
-    },
-    "hideFeaturedContent": {
-        "message": "注目コンテンツを非表示"
-    },
-    "hideFooter": {
-        "message": "フッターを非表示"
-    },
-    "hideGradientBottom": {
-        "message": "グラデーションの下部を非表示"
-    },
-    "hidePlayerControlsBar": {
-        "message": "プレーヤーのコントロールバーを非表示"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "プレーヤーのコントロールボタンを非表示"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "プレーヤーのコントロールオプションを非表示"
-    },
-    "hidePlaylist": {
-        "message": "再生リストを非表示"
-    },
-    "hideRightButtons": {
-        "message": "右のボタンを非表示"
-    },
-    "hideScrollForDetails": {
-        "message": "\"スクロールして詳細を表示\"を非表示"
-    },
-    "hideSkipOverlay": {
-        "message": "スキップオーバーレイを非表示"
-    },
-    "hideThumbnailOverlay": {
-        "message": "サムネイルオーバーレイを非表示"
-    },
-    "hideThumbnails": {
-        "message": "サムネイルを非表示"
-    },
-    "hideViewsCount": {
-        "message": "再生回数を非表示"
-    },
-    "hideVoiceSearchButton": {
-        "message": "音声検索ボタンを非表示"
-    },
-    "high": {
-        "message": "高"
-    },
-    "history": {
-        "message": "履歴"
-    },
-    "home": {
-        "message": "ホーム"
-    },
-    "homeScreen": {
-        "message": "ホーム画面"
-    },
-    "hover": {
-        "message": "ホバー"
-    },
-    "hoverOnVideoPage": {
-        "message": "動画ページではホバー"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "動画がアップロードされてからの時間"
-    },
-    "icons": {
-        "message": "アイコン"
-    },
-    "iconsOnly": {
-        "message": "アイコンのみ"
-    },
-    "importSettings": {
-        "message": "設定をインポート"
-    },
-    "ImprovedTube": {
-        "message": "ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTubeのアイコンをYouTubeに表示"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTubeの言語"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTubeのバージョン"
-    },
-    "improveLogo": {
-        "message": "ロゴを改善"
-    },
-    "increasePlaybackSpeed": {
-        "message": "再生速度を上げる"
-    },
-    "increaseVolume": {
-        "message": "音量を上げる"
-    },
-    "indigo": {
-        "message": "インディゴ"
-    },
-    "items": {
-        "message": "アイテム"
-    },
-    "language": {
-        "message": "言語"
-    },
-    "languages": {
-        "message": "言語"
-    },
-    "layerAnimationScale": {
-        "message": "遷移アニメーションの速さ"
-    },
-    "layout": {
-        "message": "レイアウト"
-    },
-    "legacyYoutube": {
-        "message": "古いYouTube"
-    },
-    "library": {
-        "message": "ライブラリ"
-    },
-    "light": {
-        "message": "ライト"
-    },
-    "lightBlue": {
-        "message": "薄い青"
-    },
-    "lightGreen": {
-        "message": "薄い緑"
-    },
-    "like": {
-        "message": "高評価"
-    },
-    "lime": {
-        "message": "ライム"
-    },
-    "limitPageWidth": {
-        "message": "ページ幅を制限"
-    },
-    "list": {
-        "message": "リスト"
-    },
-    "liveChat": {
-        "message": "ライブチャット"
-    },
-    "liveChatType": {
-        "message": "ライブチャットの種類"
-    },
-    "location": {
-        "message": "地域"
-    },
-    "loop": {
-        "message": "ループ"
-    },
-    "loudnessNormalization": {
-        "message": "ラウドネスノーマライゼーション"
-    },
-    "low": {
-        "message": "低"
-    },
-    "markWatchedVideos": {
-        "message": "視聴した動画にマークを付ける"
-    },
-    "medium": {
-        "message": "中"
-    },
-    "mixer": {
-        "message": "ミキサー"
-    },
-    "more": {
-        "message": "その他"
-    },
-    "moveSidebarLeft": {
-        "message": "サイドバーを左に移動"
-    },
-    "moveThumbnailsRight": {
-        "message": "サムネイルを右に表示"
-    },
-    "myColors": {
-        "message": "色設定"
-    },
-    "name": {
-        "message": "名前"
-    },
-    "nativeMiniPlayer": {
-        "message": "ネイティブミニプレーヤー"
-    },
-    "new": {
-        "message": "新規"
-    },
-    "nextVideo": {
-        "message": "次の動画"
-    },
-    "night": {
-        "message": "夜"
-    },
-    "nightMode": {
-        "message": "夜間モード"
-    },
-    "noActiveFeatures": {
-        "message": "有効な機能はありません"
-    },
-    "none": {
-        "message": "なし"
-    },
-    "noOpenVideoTabs": {
-        "message": "開いている動画タブがありません"
-    },
-    "normal": {
-        "message": "標準"
-    },
-    "ok": {
-        "message": "OK"
-    },
-    "onAllVideos": {
-        "message": "すべて許可"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "YouTubeでのみ有効"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "他の動画の再生時に一時停止"
-    },
-    "onSubscribedChannels": {
-        "message": "登録チャンネル以外ではブロック"
-    },
-    "optimizeCodecForHardwareAcceleration": {
-        "message": "ハードウェアアクセラレーション用にコーデックを最適化"
-    },
-    "orange": {
-        "message": "オレンジ"
-    },
-    "other": {
-        "message": "その他"
-    },
-    "overlay": {
-        "message": "オーバーレイ"
-    },
-    "permissions": {
-        "message": "権限"
-    },
-    "pictureInPicture": {
-        "message": "ピクチャーインピクチャー"
-    },
-    "pink": {
-        "message": "ピンク"
-    },
-    "plain": {
-        "message": "プレーン"
-    },
-    "platform": {
-        "message": "プラットフォーム"
-    },
-    "playbackSpeed": {
-        "message": "再生速度"
-    },
-    "player": {
-        "message": "プレーヤー"
-    },
-    "playerColor": {
-        "message": "プレーヤーの色"
-    },
-    "playerSize": {
-        "message": "プレーヤーのサイズ"
-    },
-    "playlist": {
-        "message": "再生リスト"
-    },
-    "playlists": {
-        "message": "再生リスト"
-    },
-    "playPause": {
-        "message": "再生/一時停止"
-    },
-    "popupPlayer": {
-        "message": "ポップアッププレーヤー"
-    },
-    "position": {
-        "message": "位置"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "任意のキーを押すか、マウスホイールを使用してください"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "任意のキーを押すか、マウスホイールを使用してください"
-    },
-    "previousVideo": {
-        "message": "前の動画"
-    },
-    "primaryColor": {
-        "message": "全体の色"
-    },
-    "purple": {
-        "message": "紫"
-    },
-    "quality": {
-        "message": "画質"
-    },
-    "ram": {
-        "message": "RAM"
-    },
-    "rateUs": {
-        "message": "評価する"
-    },
-    "red": {
-        "message": "赤"
-    },
-    "redDislikeButton": {
-        "message": "低評価ボタンを赤色で表示する"
-    },
-    "relatedVideos": {
-        "message": "関連動画"
-    },
-    "removeIcons": {
-        "message": "アイコンを削除"
-    },
-    "removeRelatedSearchResults": {
-        "message": "関連動画を検索結果から削除"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "検索結果からショート動画を削除"
-    },
-    "repeat": {
-        "message": "リピート"
-    },
-    "reset": {
-        "message": "リセット"
-    },
-    "resetAllSettings": {
-        "message": "すべての設定をリセット"
-    },
-    "resetAllShortcuts": {
-        "message": "すべてのショートカットをリセット"
-    },
-    "reverse": {
-        "message": "逆順にする"
-    },
-    "rotate": {
-        "message": "回転"
-    },
-    "save": {
-        "message": "保存"
-    },
-    "saveAs": {
-        "message": "別名で保存"
-    },
-    "schedule": {
-        "message": "スケジュール"
-    },
-    "screen": {
-        "message": "画面解像度"
-    },
-    "screenshot": {
-        "message": "スクリーンショット"
-    },
-    "scrollBar": {
-        "message": "スクロールバー"
-    },
-    "search": {
-        "message": "検索"
-    },
-    "searchBarOnly": {
-        "message": "検索バーのみ"
-    },
-    "seekBackward10Seconds": {
-        "message": "10秒戻る"
-    },
-    "seekForward10Seconds": {
-        "message": "10秒進む"
-    },
-    "seekNextChapter": {
-        "message": "次のチャプターへ進む"
-    },
-    "seekPreviousChapter": {
-        "message": "前のチャプターへ戻る"
-    },
-    "settings": {
-        "message": "設定"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "設定を正常にインポートしました"
-    },
-    "share": {
-        "message": "共有"
-    },
-    "shortcut_screenshot": {
-        "message": "スクリーンショット"
-    },
-    "shortcuts": {
-        "message": "ショートカット"
-    },
-    "showCardsOnMouseHover": {
-        "message": "マウスオーバーでカードを表示"
-    },
-    "showChannelVideosCount": {
-        "message": "チャンネルの動画数を表示"
-    },
-    "showLess": {
-        "message": "一部を表示"
-    },
-    "showMore": {
-        "message": "もっと見る"
-    },
-    "showRemainingDuration": {
-        "message": "動画の残り時間を表示"
-    },
-    "showVersion": {
-        "message": "バージョンを表示"
-    },
-    "shuffle": {
-        "message": "シャッフル"
-    },
-    "sidebar": {
-        "message": "サイドバー"
-    },
-    "softwareInformation": {
-        "message": "ソフトウェア情報"
-    },
-    "spacebar": {
-        "message": "スペースキー"
-    },
-    "squaredUserImages": {
-        "message": "ユーザー画像を四角にする"
-    },
-    "static": {
-        "message": "スタティック"
-    },
-    "statsForNerds": {
-        "message": "マニア向けの統計を表示"
-    },
-    "step": {
-        "message": "ステップ"
-    },
-    "stop": {
-        "message": "停止"
-    },
-    "style": {
-        "message": "スタイル"
-    },
-    "styles": {
-        "message": "スタイル"
-    },
-    "subscribe": {
-        "message": "登録"
-    },
-    "subscriptions": {
-        "message": "登録チャンネル"
-    },
-    "subtitles": {
-        "message": "字幕"
-    },
-    "sunset": {
-        "message": "夕焼け"
-    },
-    "sunsetToSunrise": {
-        "message": "時刻指定"
-    },
-    "systemPeferenceDark": {
-        "message": "システム設定: ダーク"
-    },
-    "systemPeferenceLight": {
-        "message": "システム設定: ライト"
-    },
-    "teal": {
-        "message": "ティール"
-    },
-    "textColor": {
-        "message": "文字の色"
-    },
-    "thanks": {
-        "message": "Thanks"
-    },
-    "themes": {
-        "message": "テーマ"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "これはすべての Cookie を削除します。"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "YouTubeのすべてのCookieを削除します"
-    },
-    "thisWillResetAllSettings": {
-        "message": "すべての設定をリセットします。"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "すべてのショートカットをリセットします"
-    },
-    "thumbnails": {
-        "message": "サムネイル"
-    },
-    "thumbnailsQuality": {
-        "message": "サムネイルの品質"
-    },
-    "timeFrom": {
-        "message": "開始時刻"
-    },
-    "timeTo": {
-        "message": "終了時刻"
-    },
-    "todayAt": {
-        "message": "測定時刻"
-    },
-    "toggleAutoplay": {
-        "message": "自動再生を切り替え"
-    },
-    "toggleCards": {
-        "message": "カードを切り替え"
-    },
-    "toggleControls": {
-        "message": "コントロールを切り替え"
-    },
-    "topChat": {
-        "message": "上位チャット"
-    },
-    "trackWatchedVideos": {
-        "message": "視聴した動画を記録"
-    },
-    "trailerAutoplay": {
-        "message": "トレーラーを自動再生"
-    },
-    "translations": {
-        "message": "翻訳"
-    },
-    "transparentBackground": {
-        "message": "透明な背景"
-    },
-    "trending": {
-        "message": "急上昇"
-    },
-    "tryToReloadThePage": {
-        "message": "ページをリロードしてみてください"
-    },
-    "type": {
-        "message": "種類"
-    },
-    "upNextAutoplay": {
-        "message": "次の動画を自動再生"
-    },
-    "use24HourFormat": {
-        "message": "24時間表示にする"
-    },
-    "version": {
-        "message": "バージョン"
-    },
-    "video": {
-        "message": "動画"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "動画の説明はカテゴリ名を取得するために展開されます"
-    },
-    "videoFormats": {
-        "message": "動画形式"
-    },
-    "videos": {
-        "message": "動画"
-    },
-    "volume": {
-        "message": "音量"
-    },
-    "watchedVideos": {
-        "message": "視聴した動画"
-    },
-    "watchLater": {
-        "message": "後で見る"
-    },
-    "watchTime": {
-        "message": "視聴時間"
-    },
-    "whenTabIsChanged": {
-        "message": "タブを変更したとき"
-    },
-    "white": {
-        "message": "白"
-    },
-    "windowColor": {
-        "message": "ウィンドウの色"
-    },
-    "windowOpacity": {
-        "message": "ウィンドウの不透明度"
-    },
-    "yellow": {
-        "message": "黄"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTubeのヘッダー(左)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTubeのヘッダー(右)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTubeのホームページ"
-    },
-    "youtubeLanguage": {
-        "message": "YouTubeの言語"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTubeはH.264コーデックの画質を1080pに制限しています"
-    }
+	"about": {
+		"message": "このソフトについて"
+	},
+	"accept": {
+		"message": "了解"
+	},
+	"activate": {
+		"message": "有効にする"
+	},
+	"activateCaptions": {
+		"message": "キャプションを有効にする"
+	},
+	"activated": {
+		"message": "有効化"
+	},
+	"activatedFeatures": {
+		"message": "有効化された機能"
+	},
+	"activateFullscreen": {
+		"message": "全画面にする"
+	},
+	"activeFeatures": {
+		"message": "有効な機能"
+	},
+	"addScrollToTop": {
+		"message": "\"一番上にスクロール\"ボタンを追加"
+	},
+	"ads": {
+		"message": "広告"
+	},
+	"all": {
+		"message": "すべて"
+	},
+	"allow": {
+		"message": "許可"
+	},
+	"Allow_auto_generate": {
+		"message": "自動生成を許可"
+	},
+	"alwaysActive": {
+		"message": "常に有効"
+	},
+	"alwaysShowProgressBar": {
+		"message": "常にプログレスバーを表示"
+	},
+	"amber": {
+		"message": "アンバー"
+	},
+	"analyzer": {
+		"message": "分析"
+	},
+	"animations": {
+		"message": "アニメーション"
+	},
+	"appearance": {
+		"message": "外観"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "本当にエクスポートしますか？"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "本当にインポートしますか？"
+	},
+	"audio": {
+		"message": "音声"
+	},
+	"audioFormats": {
+		"message": "音声形式"
+	},
+	"auto": {
+		"message": "自動"
+	},
+	"autoFullscreen": {
+		"message": "自動的に全画面にする"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "タブ切り替えで自動的に一時停止"
+	},
+	"autoplay": {
+		"message": "自動再生"
+	},
+	"backgroundColor": {
+		"message": "背景色"
+	},
+	"backgroundOpacity": {
+		"message": "背景の不透明度"
+	},
+	"backupAndReset": {
+		"message": "バックアップとリセット"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "システムの色に合わせる"
+	},
+	"belowPlayer": {
+		"message": "プレーヤーの下"
+	},
+	"bitness": {
+		"message": "ビット数"
+	},
+	"black": {
+		"message": "黒"
+	},
+	"blockAll": {
+		"message": "すべてブロック"
+	},
+	"blockAv1": {
+		"message": "AV1をブロック"
+	},
+	"blockH264": {
+		"message": "H.264をブロック"
+	},
+	"blocklist": {
+		"message": "ブラックリスト"
+	},
+	"blockMusic": {
+		"message": "音楽の再生中はブロック"
+	},
+	"blockVp8": {
+		"message": "VP8をブロック"
+	},
+	"blockVp9": {
+		"message": "VP9をブロック"
+	},
+	"blue": {
+		"message": "青"
+	},
+	"blueGray": {
+		"message": "青みがかった灰"
+	},
+	"bluelight": {
+		"message": "ブルーライト"
+	},
+	"brown": {
+		"message": "茶"
+	},
+	"browser": {
+		"message": "ブラウザー"
+	},
+	"browserVersion": {
+		"message": "ブラウザーのバージョン"
+	},
+	"bubbles": {
+		"message": "バブル"
+	},
+	"bug": {
+		"message": "バグ"
+	},
+	"cancel": {
+		"message": "キャンセル"
+	},
+	"categories": {
+		"message": "カテゴリー"
+	},
+	"channel": {
+		"message": "チャンネル"
+	},
+	"channels": {
+		"message": "チャンネル"
+	},
+	"characterEdgeStyle": {
+		"message": "文字の縁のスタイル"
+	},
+	"clipboard": {
+		"message": "クリップボード"
+	},
+	"codecH264": {
+		"message": "H.264コーデック"
+	},
+	"codecs": {
+		"message": "コーデック"
+	},
+	"collapsed": {
+		"message": "畳む"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "サブスクリプション部分を畳む"
+	},
+	"comments": {
+		"message": "コメント"
+	},
+	"confirmationBeforeClosing": {
+		"message": "閉じる前に確認"
+	},
+	"cookies": {
+		"message": "Cookie"
+	},
+	"cores": {
+		"message": "コア数"
+	},
+	"cropChapterTitles": {
+		"message": "チャプターのタイトルをトリミング"
+	},
+	"custom": {
+		"message": "カスタム"
+	},
+	"customCss": {
+		"message": "カスタムCSS"
+	},
+	"customJs": {
+		"message": "カスタムJS"
+	},
+	"customMiniPlayer": {
+		"message": "カスタムミニプレーヤー"
+	},
+	"cyan": {
+		"message": "シアン"
+	},
+	"dark": {
+		"message": "ダーク"
+	},
+	"darkTheme": {
+		"message": "ダークテーマ"
+	},
+	"dateAndTime": {
+		"message": "日付と時刻"
+	},
+	"dawn": {
+		"message": "夜明け"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "再生速度を下げる"
+	},
+	"decreaseVolume": {
+		"message": "音量を下げる"
+	},
+	"deepOrange": {
+		"message": "深いオレンジ"
+	},
+	"deepPurple": {
+		"message": "深い紫"
+	},
+	"default": {
+		"message": "デフォルト"
+	},
+	"default_theme": {
+		"message": "デフォルト"
+	},
+	"defaultChannelTab": {
+		"message": "デフォルトのチャンネルタブ"
+	},
+	"defaultContentCountry": {
+		"message": "デフォルトのコンテンツの地域"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "デフォルトの再生速度"
+	},
+	"deleteWatchedVideos": {
+		"message": "視聴した動画を削除"
+	},
+	"deleteYoutubeCookies": {
+		"message": "YouTubeのCookieを削除"
+	},
+	"description": {
+		"message": "動画の説明"
+	},
+	"description_ext": {
+		"message": "YouTube をスマートに整理しましょう！ YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+	},
+	"desert": {
+		"message": "砂漠"
+	},
+	"details": {
+		"message": "詳細"
+	},
+	"developerOptions": {
+		"message": "開発者向けオプション"
+	},
+	"device": {
+		"message": "デバイス"
+	},
+	"dim": {
+		"message": "暗さ"
+	},
+	"disabled": {
+		"message": "無効"
+	},
+	"dislike": {
+		"message": "低評価"
+	},
+	"displayDayOfTheWeak": {
+		"message": "曜日を表示"
+	},
+	"donate": {
+		"message": "寄付する"
+	},
+	"doNotChange": {
+		"message": "変更しない"
+	},
+	"download": {
+		"message": "ダウンロード"
+	},
+	"draggable": {
+		"message": "ドラッグ可能にする"
+	},
+	"durationWithSpeed": {
+		"message": "再生速度に応じた残り時間を表示"
+	},
+	"embedded_Hide_Share": {
+		"message": "共有ボタンを非表示"
+	},
+	"Embedded_YouTube": {
+		"message": "埋め込み動画"
+	},
+	"empty": {
+		"message": "なし"
+	},
+	"enabled": {
+		"message": "有効"
+	},
+	"enabledForced": {
+		"message": "有効 (強制)"
+	},
+	"expanded": {
+		"message": "広げる"
+	},
+	"exportSettings": {
+		"message": "設定をエクスポート"
+	},
+	"extension": {
+		"message": "拡張"
+	},
+	"Feature_not_yet_available": {
+		"message": "利用できない機能"
+	},
+	"file": {
+		"message": "ファイル"
+	},
+	"filters": {
+		"message": "フィルター"
+	},
+	"fitToWindow": {
+		"message": "ウィンドウに合わせる"
+	},
+	"font": {
+		"message": "フォント"
+	},
+	"fontColor": {
+		"message": "フォントの色"
+	},
+	"fontFamily": {
+		"message": "フォントファミリー"
+	},
+	"fontOpacity": {
+		"message": "フォントの不透明度"
+	},
+	"fontSize": {
+		"message": "フォントサイズ"
+	},
+	"footer": {
+		"message": "フッター"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "再生速度を指定"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(音楽でも再生速度を指定する？)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "強制的に動画を最初から再生"
+	},
+	"forcedTheaterMode": {
+		"message": "シアターモードにする"
+	},
+	"forcedVolume": {
+		"message": "音量を指定する"
+	},
+	"forceSDR": {
+		"message": "SDRを強制"
+	},
+	"foundABug": {
+		"message": "バグ報告"
+	},
+	"fullWindow": {
+		"message": "フルウィンドウ"
+	},
+	"general": {
+		"message": "一般"
+	},
+	"goToSearchBox": {
+		"message": "検索ボックスに移動"
+	},
+	"green": {
+		"message": "緑"
+	},
+	"Hamburger_Menu": {
+		"message": "ハンバーガーメニュー"
+	},
+	"hardwareInformation": {
+		"message": "ハードウェア情報"
+	},
+	"hdThumbnail": {
+		"message": "HDサムネイル"
+	},
+	"header": {
+		"message": "ヘッダー"
+	},
+	"hidden": {
+		"message": "非表示"
+	},
+	"hiddenOnVideoPage": {
+		"message": "動画ページでは隠す"
+	},
+	"hide_author_avatars": {
+		"message": "投稿者のアバターを非表示"
+	},
+	"hide_labels": {
+		"message": "名前を非表示"
+	},
+	"Hide_Pause_Overlay": {
+		"message": "一時停止中のオーバーレイを非表示"
+	},
+	"Hide_sidebar": {
+		"message": "サイドバーを非表示"
+	},
+	"Hide_YouTube_Logo": {
+		"message": "YouTubeロゴを非表示"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "サムネイルのアニメーションを行わない"
+	},
+	"hideAnnotations": {
+		"message": "アノテーションを非表示"
+	},
+	"hideCards": {
+		"message": "カードを非表示"
+	},
+	"hideCategories": {
+		"message": "カテゴリーを非表示にする"
+	},
+	"hideCommentsCount": {
+		"message": "コメント数を非表示"
+	},
+	"hideCountryCode": {
+		"message": "国名コードを非表示"
+	},
+	"hideDate": {
+		"message": "日付を非表示"
+	},
+	"hideDetails": {
+		"message": "詳細を非表示"
+	},
+	"hideEndscreen": {
+		"message": "再生終了時の画面を非表示"
+	},
+	"hideFeaturedContent": {
+		"message": "注目コンテンツを非表示"
+	},
+	"hideFooter": {
+		"message": "フッターを非表示"
+	},
+	"hideGradientBottom": {
+		"message": "グラデーションの下部を非表示"
+	},
+	"hidePlayerControlsBar": {
+		"message": "プレーヤーのコントロールバーを非表示"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "プレーヤーのコントロールボタンを非表示"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "プレーヤーのコントロールオプションを非表示"
+	},
+	"hidePlaylist": {
+		"message": "再生リストを非表示"
+	},
+	"hideRightButtons": {
+		"message": "右のボタンを非表示"
+	},
+	"hideScrollForDetails": {
+		"message": "\"スクロールして詳細を表示\"を非表示"
+	},
+	"hideSkipOverlay": {
+		"message": "スキップオーバーレイを非表示"
+	},
+	"hideThumbnailOverlay": {
+		"message": "サムネイルオーバーレイを非表示"
+	},
+	"hideThumbnails": {
+		"message": "サムネイルを非表示"
+	},
+	"hideViewsCount": {
+		"message": "再生回数を非表示"
+	},
+	"hideVoiceSearchButton": {
+		"message": "音声検索ボタンを非表示"
+	},
+	"high": {
+		"message": "高"
+	},
+	"history": {
+		"message": "履歴"
+	},
+	"home": {
+		"message": "ホーム"
+	},
+	"homeScreen": {
+		"message": "ホーム画面"
+	},
+	"hover": {
+		"message": "ホバー"
+	},
+	"hoverOnVideoPage": {
+		"message": "動画ページではホバー"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "動画がアップロードされてからの時間"
+	},
+	"icons": {
+		"message": "アイコン"
+	},
+	"iconsOnly": {
+		"message": "アイコンのみ"
+	},
+	"importSettings": {
+		"message": "設定をインポート"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTubeのアイコンをYouTubeに表示"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTubeの言語"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTubeのバージョン"
+	},
+	"improveLogo": {
+		"message": "ロゴを改善"
+	},
+	"increasePlaybackSpeed": {
+		"message": "再生速度を上げる"
+	},
+	"increaseVolume": {
+		"message": "音量を上げる"
+	},
+	"indigo": {
+		"message": "インディゴ"
+	},
+	"items": {
+		"message": "アイテム"
+	},
+	"language": {
+		"message": "言語"
+	},
+	"languages": {
+		"message": "言語"
+	},
+	"layerAnimationScale": {
+		"message": "遷移アニメーションの速さ"
+	},
+	"layout": {
+		"message": "レイアウト"
+	},
+	"legacyYoutube": {
+		"message": "古いYouTube"
+	},
+	"library": {
+		"message": "ライブラリ"
+	},
+	"light": {
+		"message": "ライト"
+	},
+	"lightBlue": {
+		"message": "薄い青"
+	},
+	"lightGreen": {
+		"message": "薄い緑"
+	},
+	"like": {
+		"message": "高評価"
+	},
+	"lime": {
+		"message": "ライム"
+	},
+	"limitPageWidth": {
+		"message": "ページ幅を制限"
+	},
+	"list": {
+		"message": "リスト"
+	},
+	"liveChat": {
+		"message": "ライブチャット"
+	},
+	"liveChatType": {
+		"message": "ライブチャットの種類"
+	},
+	"location": {
+		"message": "地域"
+	},
+	"loop": {
+		"message": "ループ"
+	},
+	"loudnessNormalization": {
+		"message": "ラウドネスノーマライゼーション"
+	},
+	"low": {
+		"message": "低"
+	},
+	"markWatchedVideos": {
+		"message": "視聴した動画にマークを付ける"
+	},
+	"medium": {
+		"message": "中"
+	},
+	"mixer": {
+		"message": "ミキサー"
+	},
+	"more": {
+		"message": "その他"
+	},
+	"moveSidebarLeft": {
+		"message": "サイドバーを左に移動"
+	},
+	"moveThumbnailsRight": {
+		"message": "サムネイルを右に表示"
+	},
+	"myColors": {
+		"message": "色設定"
+	},
+	"name": {
+		"message": "名前"
+	},
+	"nativeMiniPlayer": {
+		"message": "ネイティブミニプレーヤー"
+	},
+	"new": {
+		"message": "新規"
+	},
+	"nextVideo": {
+		"message": "次の動画"
+	},
+	"night": {
+		"message": "夜"
+	},
+	"nightMode": {
+		"message": "夜間モード"
+	},
+	"noActiveFeatures": {
+		"message": "有効な機能はありません"
+	},
+	"none": {
+		"message": "なし"
+	},
+	"noOpenVideoTabs": {
+		"message": "開いている動画タブがありません"
+	},
+	"normal": {
+		"message": "標準"
+	},
+	"ok": {
+		"message": "OK"
+	},
+	"onAllVideos": {
+		"message": "すべて許可"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "YouTubeでのみ有効"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "他の動画の再生時に一時停止"
+	},
+	"onSubscribedChannels": {
+		"message": "登録チャンネル以外ではブロック"
+	},
+	"optimizeCodecForHardwareAcceleration": {
+		"message": "ハードウェアアクセラレーション用にコーデックを最適化"
+	},
+	"orange": {
+		"message": "オレンジ"
+	},
+	"other": {
+		"message": "その他"
+	},
+	"overlay": {
+		"message": "オーバーレイ"
+	},
+	"permissions": {
+		"message": "権限"
+	},
+	"pictureInPicture": {
+		"message": "ピクチャーインピクチャー"
+	},
+	"pink": {
+		"message": "ピンク"
+	},
+	"plain": {
+		"message": "プレーン"
+	},
+	"platform": {
+		"message": "プラットフォーム"
+	},
+	"playbackSpeed": {
+		"message": "再生速度"
+	},
+	"player": {
+		"message": "プレーヤー"
+	},
+	"playerColor": {
+		"message": "プレーヤーの色"
+	},
+	"playerSize": {
+		"message": "プレーヤーのサイズ"
+	},
+	"playlist": {
+		"message": "再生リスト"
+	},
+	"playlists": {
+		"message": "再生リスト"
+	},
+	"playPause": {
+		"message": "再生/一時停止"
+	},
+	"popupPlayer": {
+		"message": "ポップアッププレーヤー"
+	},
+	"position": {
+		"message": "位置"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "任意のキーを押すか、マウスホイールを使用してください"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "任意のキーを押すか、マウスホイールを使用してください"
+	},
+	"previousVideo": {
+		"message": "前の動画"
+	},
+	"primaryColor": {
+		"message": "全体の色"
+	},
+	"purple": {
+		"message": "紫"
+	},
+	"quality": {
+		"message": "画質"
+	},
+	"rateUs": {
+		"message": "評価する"
+	},
+	"red": {
+		"message": "赤"
+	},
+	"redDislikeButton": {
+		"message": "低評価ボタンを赤色で表示する"
+	},
+	"relatedVideos": {
+		"message": "関連動画"
+	},
+	"removeIcons": {
+		"message": "アイコンを削除"
+	},
+	"removeRelatedSearchResults": {
+		"message": "関連動画を検索結果から削除"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "検索結果からショート動画を削除"
+	},
+	"repeat": {
+		"message": "リピート"
+	},
+	"reset": {
+		"message": "リセット"
+	},
+	"resetAllSettings": {
+		"message": "すべての設定をリセット"
+	},
+	"resetAllShortcuts": {
+		"message": "すべてのショートカットをリセット"
+	},
+	"reverse": {
+		"message": "逆順にする"
+	},
+	"rotate": {
+		"message": "回転"
+	},
+	"save": {
+		"message": "保存"
+	},
+	"saveAs": {
+		"message": "別名で保存"
+	},
+	"schedule": {
+		"message": "スケジュール"
+	},
+	"screen": {
+		"message": "画面解像度"
+	},
+	"screenshot": {
+		"message": "スクリーンショット"
+	},
+	"scrollBar": {
+		"message": "スクロールバー"
+	},
+	"search": {
+		"message": "検索"
+	},
+	"searchBarOnly": {
+		"message": "検索バーのみ"
+	},
+	"seekBackward10Seconds": {
+		"message": "10秒戻る"
+	},
+	"seekForward10Seconds": {
+		"message": "10秒進む"
+	},
+	"seekNextChapter": {
+		"message": "次のチャプターへ進む"
+	},
+	"seekPreviousChapter": {
+		"message": "前のチャプターへ戻る"
+	},
+	"settings": {
+		"message": "設定"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "設定を正常にインポートしました"
+	},
+	"share": {
+		"message": "共有"
+	},
+	"shortcut_screenshot": {
+		"message": "スクリーンショット"
+	},
+	"shortcuts": {
+		"message": "ショートカット"
+	},
+	"showCardsOnMouseHover": {
+		"message": "マウスオーバーでカードを表示"
+	},
+	"showChannelVideosCount": {
+		"message": "チャンネルの動画数を表示"
+	},
+	"showLess": {
+		"message": "一部を表示"
+	},
+	"showMore": {
+		"message": "もっと見る"
+	},
+	"showRemainingDuration": {
+		"message": "動画の残り時間を表示"
+	},
+	"showVersion": {
+		"message": "バージョンを表示"
+	},
+	"shuffle": {
+		"message": "シャッフル"
+	},
+	"sidebar": {
+		"message": "サイドバー"
+	},
+	"softwareInformation": {
+		"message": "ソフトウェア情報"
+	},
+	"spacebar": {
+		"message": "スペースキー"
+	},
+	"squaredUserImages": {
+		"message": "ユーザー画像を四角にする"
+	},
+	"static": {
+		"message": "スタティック"
+	},
+	"statsForNerds": {
+		"message": "マニア向けの統計を表示"
+	},
+	"step": {
+		"message": "ステップ"
+	},
+	"stop": {
+		"message": "停止"
+	},
+	"style": {
+		"message": "スタイル"
+	},
+	"styles": {
+		"message": "スタイル"
+	},
+	"subscribe": {
+		"message": "登録"
+	},
+	"subscriptions": {
+		"message": "登録チャンネル"
+	},
+	"subtitles": {
+		"message": "字幕"
+	},
+	"sunset": {
+		"message": "夕焼け"
+	},
+	"sunsetToSunrise": {
+		"message": "時刻指定"
+	},
+	"systemPeferenceDark": {
+		"message": "システム設定: ダーク"
+	},
+	"systemPeferenceLight": {
+		"message": "システム設定: ライト"
+	},
+	"teal": {
+		"message": "ティール"
+	},
+	"textColor": {
+		"message": "文字の色"
+	},
+	"themes": {
+		"message": "テーマ"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "これはすべての Cookie を削除します。"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "YouTubeのすべてのCookieを削除します"
+	},
+	"thisWillResetAllSettings": {
+		"message": "すべての設定をリセットします。"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "すべてのショートカットをリセットします"
+	},
+	"thumbnails": {
+		"message": "サムネイル"
+	},
+	"thumbnailsQuality": {
+		"message": "サムネイルの品質"
+	},
+	"timeFrom": {
+		"message": "開始時刻"
+	},
+	"timeTo": {
+		"message": "終了時刻"
+	},
+	"todayAt": {
+		"message": "測定時刻"
+	},
+	"toggleAutoplay": {
+		"message": "自動再生を切り替え"
+	},
+	"toggleCards": {
+		"message": "カードを切り替え"
+	},
+	"toggleControls": {
+		"message": "コントロールを切り替え"
+	},
+	"topChat": {
+		"message": "上位チャット"
+	},
+	"trackWatchedVideos": {
+		"message": "視聴した動画を記録"
+	},
+	"trailerAutoplay": {
+		"message": "トレーラーを自動再生"
+	},
+	"translations": {
+		"message": "翻訳"
+	},
+	"transparentBackground": {
+		"message": "透明な背景"
+	},
+	"trending": {
+		"message": "急上昇"
+	},
+	"tryToReloadThePage": {
+		"message": "ページをリロードしてみてください"
+	},
+	"type": {
+		"message": "種類"
+	},
+	"upNextAutoplay": {
+		"message": "次の動画を自動再生"
+	},
+	"use24HourFormat": {
+		"message": "24時間表示にする"
+	},
+	"version": {
+		"message": "バージョン"
+	},
+	"video": {
+		"message": "動画"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "動画の説明はカテゴリ名を取得するために展開されます"
+	},
+	"videoFormats": {
+		"message": "動画形式"
+	},
+	"videos": {
+		"message": "動画"
+	},
+	"volume": {
+		"message": "音量"
+	},
+	"watchedVideos": {
+		"message": "視聴した動画"
+	},
+	"watchLater": {
+		"message": "後で見る"
+	},
+	"watchTime": {
+		"message": "視聴時間"
+	},
+	"whenTabIsChanged": {
+		"message": "タブを変更したとき"
+	},
+	"white": {
+		"message": "白"
+	},
+	"windowColor": {
+		"message": "ウィンドウの色"
+	},
+	"windowOpacity": {
+		"message": "ウィンドウの不透明度"
+	},
+	"yellow": {
+		"message": "黄"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTubeのヘッダー(左)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTubeのヘッダー(右)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTubeのホームページ"
+	},
+	"youtubeLanguage": {
+		"message": "YouTubeの言語"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTubeはH.264コーデックの画質を1080pに制限しています"
+	}
 }

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "ಮುಖ್ಯ ಪೇಜಿನ ಶಾರ್ಟ್ಸ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "ಹುಡುಕಾಟದ ಫಲಿತಾಂಶಗಳಿಂದ ಷಾರ್ಟ್ಸ್ ರೀಲ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ"
-    }
+	"hideHomePageShorts": {
+		"message": "ಮುಖ್ಯ ಪೇಜಿನ ಶಾರ್ಟ್ಸ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "ಹುಡುಕಾಟದ ಫಲಿತಾಂಶಗಳಿಂದ ಷಾರ್ಟ್ಸ್ ರೀಲ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ"
+	}
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,1052 +1,1052 @@
 {
-    "about": {
-        "message": "정보"
-    },
-    "accept": {
-        "message": "동의"
-    },
-    "activate": {
-        "message": "활성화"
-    },
-    "activateCaptions": {
-        "message": "자막 활성화"
-    },
-    "activated": {
-        "message": "활성화됨"
-    },
-    "activatedFeatures": {
-        "message": "활성화된 기능"
-    },
-    "activateFullscreen": {
-        "message": "전체화면 활성화"
-    },
-    "activeFeatures": {
-        "message": "활성 기능"
-    },
-    "addScrollToTop": {
-        "message": "<<맨 위로>> 버튼 추가"
-    },
-    "ads": {
-        "message": "광고"
-    },
-    "all": {
-        "message": "모두"
-    },
-    "allow": {
-        "message": "허용"
-    },
-    "always": {
-        "message": "항상"
-    },
-    "alwaysActive": {
-        "message": "항상 활성화"
-    },
-    "alwaysShowProgressBar": {
-        "message": "재생 진행상태(Progress Bar) 항상 표시"
-    },
-    "amber": {
-        "message": "호박색"
-    },
-    "analyzer": {
-        "message": "분석"
-    },
-    "appearance": {
-        "message": "외관"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "데이터를 내보낼까요?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "데이터를 불러올까요?"
-    },
-    "audio": {
-        "message": "오디오"
-    },
-    "audioFormats": {
-        "message": "오디오 형식"
-    },
-    "auto": {
-        "message": "자동"
-    },
-    "autoFullscreen": {
-        "message": "자동 전체화면"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "탭 전환 시 자동 일시중지"
-    },
-    "autoplay": {
-        "message": "자동재생"
-    },
-    "avoidAv1": {
-        "message": "AV1 막기"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "AV1, VP8, VP9 막기"
-    },
-    "avoidAv1Vp9": {
-        "message": "AV1, VP9 막기"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "가능한 경우 CPU 렌더링 막기"
-    },
-    "backgroundColor": {
-        "message": "배경 색상"
-    },
-    "backgroundOpacity": {
-        "message": "배경 투명도"
-    },
-    "backupAndReset": {
-        "message": "백업 & 리셋"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "시스템 색상 구성표 기반"
-    },
-    "belowPlayer": {
-        "message": "플레이어 아래"
-    },
-    "black": {
-        "message": "검정"
-    },
-    "blockAll": {
-        "message": "모두 차단"
-    },
-    "blockAv1": {
-        "message": "AV1 차단"
-    },
-    "blockH264": {
-        "message": "H.264 차단"
-    },
-    "blocklist": {
-        "message": "블랙리스트"
-    },
-    "blockMusic": {
-        "message": "음악 차단"
-    },
-    "blockVp8": {
-        "message": "VP8 차단"
-    },
-    "blockVp9": {
-        "message": "VP9 차단"
-    },
-    "blue": {
-        "message": "파랑"
-    },
-    "blueGray": {
-        "message": "블루그레이"
-    },
-    "bluelight": {
-        "message": "블루라이트"
-    },
-    "brown": {
-        "message": "갈색"
-    },
-    "browser": {
-        "message": "브라우저"
-    },
-    "browserVersion": {
-        "message": "브라우저 버전"
-    },
-    "bubbles": {
-        "message": "버블"
-    },
-    "bug": {
-        "message": "버그"
-    },
-    "buttons": {
-        "message": "버튼"
-    },
-    "cancel": {
-        "message": "취소"
-    },
-    "categories": {
-        "message": "카테고리"
-    },
-    "channel": {
-        "message": "채널"
-    },
-    "channels": {
-        "message": "채널"
-    },
-    "characterEdgeStyle": {
-        "message": "글꼴 테두리 스타일"
-    },
-    "clip": {
-        "message": "클립"
-    },
-    "clipboard": {
-        "message": "클립보드"
-    },
-    "codecH264": {
-        "message": "코덱 h.264"
-    },
-    "codecs": {
-        "message": "코덱"
-    },
-    "collapsed": {
-        "message": "접기"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "구독 섹션 접기"
-    },
-    "comments": {
-        "message": "댓글"
-    },
-    "confirmationBeforeClosing": {
-        "message": "창을 닫기 전에 확인하기"
-    },
-    "cookies": {
-        "message": "쿠키"
-    },
-    "cores": {
-        "message": "코어"
-    },
-    "cropChapterTitles": {
-        "message": "긴 챕터 이름 자르기"
-    },
-    "custom": {
-        "message": "사용자 지정"
-    },
-    "customCss": {
-        "message": "사용자 지정 캐스캐이팅 스타일 시트(CSS)"
-    },
-    "customJs": {
-        "message": "사용자 지정 자바스크립트(JS)"
-    },
-    "customMiniPlayer": {
-        "message": "커스텀 미니플레이어"
-    },
-    "cyan": {
-        "message": "옥색"
-    },
-    "dark": {
-        "message": "다크"
-    },
-    "darkTheme": {
-        "message": "다크 테마"
-    },
-    "dateAndTime": {
-        "message": "날짜와 시간"
-    },
-    "dawn": {
-        "message": "석양"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "재생 속도 빠르게"
-    },
-    "decreaseVolume": {
-        "message": "볼륨 감소"
-    },
-    "deepOrange": {
-        "message": "진한 주황"
-    },
-    "deepPurple": {
-        "message": "진한 보라"
-    },
-    "default": {
-        "message": "기본값"
-    },
-    "defaultChannelTab": {
-        "message": "기본 채널 탭"
-    },
-    "defaultContentCountry": {
-        "message": "기본 콘텐츠 지역"
-    },
-    "deleteWatchedVideos": {
-        "message": "시청한 영상 삭제"
-    },
-    "deleteYoutubeCookies": {
-        "message": "유튜브 쿠키 삭제"
-    },
-    "depressed": {
-        "message": "음각"
-    },
-    "description": {
-        "message": "영상 설명란"
-    },
-    "description_ext": {
-        "message": "YouTube, YouTube, YouTube: 유튜브를 깔끔하고 스마트하게 만들어줍니다! 유튜브 비디오의 색상, 광고 제거, 음량, 배속, 채널 툴, 스타일, HD, 광고 차단, 태그, 키워드, 재생목록"
-    },
-    "desert": {
-        "message": "사막"
-    },
-    "details": {
-        "message": "자세히"
-    },
-    "developerOptions": {
-        "message": "개발자 옵션"
-    },
-    "device": {
-        "message": "디바이스"
-    },
-    "dim": {
-        "message": "어둡게"
-    },
-    "disabled": {
-        "message": "비활성화"
-    },
-    "dislike": {
-        "message": "싫어요"
-    },
-    "displayDayOfTheWeak": {
-        "message": "요일 표시"
-    },
-    "donate": {
-        "message": "후원하기"
-    },
-    "doNotChange": {
-        "message": "바꾸지 않음"
-    },
-    "download": {
-        "message": "오프라인 저장"
-    },
-    "draggable": {
-        "message": "드래그 가능"
-    },
-    "dropShadow": {
-        "message": "그림자"
-    },
-    "durationWithSpeed": {
-        "message": "남은 시간을 재생속도에 맞춰 표시하기"
-    },
-    "email": {
-        "message": "이메일"
-    },
-    "empty": {
-        "message": "비어있음"
-    },
-    "enabled": {
-        "message": "활성화"
-    },
-    "enabledForced": {
-        "message": "강제 활성화"
-    },
-    "expanded": {
-        "message": "확장"
-    },
-    "exportSettings": {
-        "message": "설정 내보내기"
-    },
-    "extension": {
-        "message": "확장 프로그램"
-    },
-    "file": {
-        "message": "파일"
-    },
-    "filters": {
-        "message": "필터"
-    },
-    "fitToWindow": {
-        "message": "창 크기에 맞추기"
-    },
-    "flash": {
-        "message": "플래시"
-    },
-    "font": {
-        "message": "글꼴"
-    },
-    "fontColor": {
-        "message": "글꼴 색상"
-    },
-    "fontFamily": {
-        "message": "글꼴 설정"
-    },
-    "fontOpacity": {
-        "message": "글꼴 투명도"
-    },
-    "fontSize": {
-        "message": "글꼴 크기"
-    },
-    "footer": {
-        "message": "하단"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "재생 속도 강제 설정"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "유튜브 뮤직 재생 속도 강제 설정"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "영상을 무조건 처음부터 보기"
-    },
-    "forcedTheaterMode": {
-        "message": "강제 영화관 모드"
-    },
-    "forcedVolume": {
-        "message": "볼륨 강제설정"
-    },
-    "forceSDR": {
-        "message": "SDR 강제 적용"
-    },
-    "foundABug": {
-        "message": "버그 신고"
-    },
-    "fullWindow": {
-        "message": "전체 화면"
-    },
-    "general": {
-        "message": "일반"
-    },
-    "github": {
-        "message": "깃허브(GitHub)"
-    },
-    "goToSearchBox": {
-        "message": "검색창으로 이동"
-    },
-    "gpu": {
-        "message": "그래픽 처리 장치"
-    },
-    "green": {
-        "message": "초록"
-    },
-    "hardwareInformation": {
-        "message": "하드웨어 정보"
-    },
-    "hdThumbnail": {
-        "message": "HD 섬네일"
-    },
-    "header": {
-        "message": "헤더"
-    },
-    "hidden": {
-        "message": "숨기기"
-    },
-    "hiddenOnVideoPage": {
-        "message": "영상이 있을 때 숨기기"
-    },
-    "hide_author_avatars": {
-        "message": "사용자 사진 숨기기"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "섬네일 재생 끄기"
-    },
-    "hideAnnotations": {
-        "message": "설명 숨기기"
-    },
-    "hideCards": {
-        "message": "카드 숨기기"
-    },
-    "hideCategories": {
-        "message": "카테고리 숨기기"
-    },
-    "hideCommentsCount": {
-        "message": "댓글 개수 숨기기"
-    },
-    "hideCountryCode": {
-        "message": "국가코드 숨기기"
-    },
-    "hideDate": {
-        "message": "날짜 숨기기"
-    },
-    "hideDetailButton": {
-        "message": "상세 버튼 숨기기"
-    },
-    "hideDetails": {
-        "message": "영상 설명란 숨기기"
-    },
-    "hideEndscreen": {
-        "message": "영상 끝난 후 추천 영상 숨기기"
-    },
-    "hideFeaturedContent": {
-        "message": "추천 영상 숨기기"
-    },
-    "hideFooter": {
-        "message": "하단 숨기기"
-    },
-    "hideGradientBottom": {
-        "message": "영상 아래 그라데이션 숨기기"
-    },
-    "hideHomePageShorts": {
-        "message": "홈 페이지의 쇼츠 제거"
-    },
-    "hidePlayerControlsBar": {
-        "message": "플레이어 컨트롤 바 숨기기"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "플레이어 컨트롤 버튼 숨기기"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "플레이어 컨트롤 옵션 숨기기"
-    },
-    "hidePlaylist": {
-        "message": "재생 목록 숨기기"
-    },
-    "hideRightButtons": {
-        "message": "오른쪽 버튼 숨기기"
-    },
-    "hideScrollForDetails": {
-        "message": "«스크롤 하여 자세한 설명» 숨기기"
-    },
-    "hideSkipOverlay": {
-        "message": "\"오버레이 건너뛰기\" 숨기기"
-    },
-    "hideThumbnailOverlay": {
-        "message": "섬네일 오버레이 숨기기"
-    },
-    "hideThumbnails": {
-        "message": "섬네일 숨기기"
-    },
-    "hideViewsCount": {
-        "message": "조회 수 숨기기"
-    },
-    "hideVoiceSearchButton": {
-        "message": "\"음성으로 찾기\" 버튼 숨기기"
-    },
-    "high": {
-        "message": "고화질"
-    },
-    "history": {
-        "message": "시청 기록"
-    },
-    "home": {
-        "message": "홈"
-    },
-    "hover": {
-        "message": "마우스를 올리면 띄우기"
-    },
-    "hoverOnVideoPage": {
-        "message": "영상이 있을 때 마우스를 올리면 띄우기"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "업로드 시기"
-    },
-    "icons": {
-        "message": "아이콘"
-    },
-    "iconsOnly": {
-        "message": "아이콘만"
-    },
-    "importSettings": {
-        "message": "설정 불러오기"
-    },
-    "improvedtubeButtons": {
-        "message": "ImprovedTube 버튼"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube 아이콘"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube 언어"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube 버전"
-    },
-    "improveLogo": {
-        "message": "향상된 로고"
-    },
-    "increasePlaybackSpeed": {
-        "message": "재생 속도 느리게"
-    },
-    "increaseVolume": {
-        "message": "볼륨 증가"
-    },
-    "indigo": {
-        "message": "남색"
-    },
-    "items": {
-        "message": "요소"
-    },
-    "language": {
-        "message": "언어"
-    },
-    "languages": {
-        "message": "언어"
-    },
-    "layerAnimationScale": {
-        "message": "레이어 애니메이션 배속"
-    },
-    "layout": {
-        "message": "모양"
-    },
-    "legacyYoutube": {
-        "message": "레거시 유튜브"
-    },
-    "library": {
-        "message": "보관함"
-    },
-    "light": {
-        "message": "밝게"
-    },
-    "lightBlue": {
-        "message": "연파랑"
-    },
-    "lightGreen": {
-        "message": "연초록"
-    },
-    "like": {
-        "message": "좋아요"
-    },
-    "liked": {
-        "message": "좋아요 표시한 동영상"
-    },
-    "lime": {
-        "message": "라임"
-    },
-    "limitPageWidth": {
-        "message": "페이지 너비 제한"
-    },
-    "list": {
-        "message": "리스트"
-    },
-    "liveChat": {
-        "message": "실시간 채팅"
-    },
-    "liveChatType": {
-        "message": "실시간 채팅 유형"
-    },
-    "location": {
-        "message": "지역"
-    },
-    "loudnessNormalization": {
-        "message": "볼륨 자동조정"
-    },
-    "low": {
-        "message": "저화질"
-    },
-    "markWatchedVideos": {
-        "message": "시청한 영상 표시"
-    },
-    "medium": {
-        "message": "보통 화질"
-    },
-    "mixer": {
-        "message": "믹서"
-    },
-    "mostViewedChannels": {
-        "message": "가장 많이 본 채널"
-    },
-    "moveSidebarLeft": {
-        "message": "사이드바 왼쪽으로 이동"
-    },
-    "moveThumbnailsRight": {
-        "message": "섬네일 오른쪽으로 이동"
-    },
-    "myColors": {
-        "message": "내 색상"
-    },
-    "name": {
-        "message": "이름"
-    },
-    "nativeMiniPlayer": {
-        "message": "네이티브 미니플레이어"
-    },
-    "new": {
-        "message": "새로운 소식"
-    },
-    "nextVideo": {
-        "message": "다음 영상"
-    },
-    "night": {
-        "message": "저녁"
-    },
-    "nightMode": {
-        "message": "수면 도움 모드"
-    },
-    "noActiveFeatures": {
-        "message": "활성 기능 없음"
-    },
-    "none": {
-        "message": "없음"
-    },
-    "noOpenVideoTabs": {
-        "message": "열린 비디오 탭 없음"
-    },
-    "normal": {
-        "message": "기본"
-    },
-    "old": {
-        "message": "오래됨"
-    },
-    "onAllVideos": {
-        "message": "모든 동영상"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "유튜브만 활성화"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "하나의 플레이어만 재생"
-    },
-    "onSubscribedChannels": {
-        "message": "구독한 채널"
-    },
-    "openPopupPlayer": {
-        "message": "동영상/재생목록을 새 창에서 열기"
-    },
-    "orange": {
-        "message": "주황"
-    },
-    "os": {
-        "message": "운영체제"
-    },
-    "other": {
-        "message": "기타"
-    },
-    "outline": {
-        "message": "외곽선"
-    },
-    "overlay": {
-        "message": "오버레이"
-    },
-    "permissions": {
-        "message": "권한"
-    },
-    "pictureInPicture": {
-        "message": "픽처 인 픽처(PIP) 재생"
-    },
-    "pink": {
-        "message": "분홍"
-    },
-    "plain": {
-        "message": "무색"
-    },
-    "platform": {
-        "message": "플랫폼"
-    },
-    "playAllButton": {
-        "message": "\"모두 재생\"버튼"
-    },
-    "playbackSpeed": {
-        "message": "영상 재생 속도"
-    },
-    "player": {
-        "message": "플레이어"
-    },
-    "playerColor": {
-        "message": "플레이어 색상"
-    },
-    "playerSize": {
-        "message": "플레이어 크기"
-    },
-    "playlist": {
-        "message": "플레이리스트"
-    },
-    "playlists": {
-        "message": "플레이리스트"
-    },
-    "playPause": {
-        "message": "재생 / 일시중지"
-    },
-    "popupPlayer": {
-        "message": "팝업 플레이어"
-    },
-    "position": {
-        "message": "위치"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "사용할 단축키 또는 마우스 휠을 누르세요."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "사용할 단축키 또는 마우스 휠을 누르세요."
-    },
-    "previousVideo": {
-        "message": "이전 영상"
-    },
-    "primaryColor": {
-        "message": "주 색상"
-    },
-    "purple": {
-        "message": "보라"
-    },
-    "quality": {
-        "message": "화질"
-    },
-    "raised": {
-        "message": "양각"
-    },
-    "ram": {
-        "message": "램"
-    },
-    "rateUs": {
-        "message": "평가하기"
-    },
-    "red": {
-        "message": "빨강"
-    },
-    "redDislikeButton": {
-        "message": "싫어요 버튼 빨간색으로 표시"
-    },
-    "relatedVideos": {
-        "message": "관련 영상"
-    },
-    "remote": {
-        "message": "TV에서 재생"
-    },
-    "removeRelatedSearchResults": {
-        "message": "관련 검색 결과 제거"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "검색 결과에서 Shorts 리얼 제거"
-    },
-    "repeat": {
-        "message": "반복"
-    },
-    "report": {
-        "message": "신고"
-    },
-    "reset": {
-        "message": "리셋"
-    },
-    "resetAllSettings": {
-        "message": "모든 설정 리셋"
-    },
-    "resetAllShortcuts": {
-        "message": "모든 단축키 리셋"
-    },
-    "reverse": {
-        "message": "거꾸로"
-    },
-    "rotate": {
-        "message": "회전"
-    },
-    "save": {
-        "message": "오프라인 저장"
-    },
-    "saveAs": {
-        "message": "다른 이름으로 저장"
-    },
-    "schedule": {
-        "message": "스케줄"
-    },
-    "screen": {
-        "message": "스크린"
-    },
-    "screenshot": {
-        "message": "스크린샷"
-    },
-    "search": {
-        "message": "검색"
-    },
-    "searchBarOnly": {
-        "message": "검색창만"
-    },
-    "seekBackward10Seconds": {
-        "message": "뒤로 10초"
-    },
-    "seekForward10Seconds": {
-        "message": "앞으로 10초"
-    },
-    "seekNextChapter": {
-        "message": "다음 챕터 보기"
-    },
-    "seekPreviousChapter": {
-        "message": "이전 챕터 보기"
-    },
-    "settings": {
-        "message": "설정"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "설정 내보내기 완료"
-    },
-    "shortcuts": {
-        "message": "단축키"
-    },
-    "showCardsOnMouseHover": {
-        "message": "마우스 올릴 때 카드 보기"
-    },
-    "showChannelVideosCount": {
-        "message": "채널의 동영상 수 표시"
-    },
-    "showLess": {
-        "message": "간략히"
-    },
-    "showMore": {
-        "message": "더보기"
-    },
-    "showRemainingDuration": {
-        "message": "동영상 남은 시간 표시"
-    },
-    "showVersion": {
-        "message": "버전 표시"
-    },
-    "shuffle": {
-        "message": "셔플"
-    },
-    "sidebar": {
-        "message": "사이드바"
-    },
-    "softwareInformation": {
-        "message": "소프트웨어 정보"
-    },
-    "spacebar": {
-        "message": "스페이스바"
-    },
-    "squaredUserImages": {
-        "message": "정사각형 프로필 사진"
-    },
-    "static": {
-        "message": "밑으로 내릴 때 숨기기"
-    },
-    "statsForNerds": {
-        "message": "전문 통계 표시"
-    },
-    "step": {
-        "message": "간격"
-    },
-    "stop": {
-        "message": "정지"
-    },
-    "style": {
-        "message": "스타일"
-    },
-    "styles": {
-        "message": "스타일"
-    },
-    "subscribe": {
-        "message": "구독하기"
-    },
-    "subscriptions": {
-        "message": "구독"
-    },
-    "subtitles": {
-        "message": "자막"
-    },
-    "sunset": {
-        "message": "일몰"
-    },
-    "sunsetToSunrise": {
-        "message": "적용 시간 설정"
-    },
-    "systemPeferenceDark": {
-        "message": "개인 설정: 다크"
-    },
-    "systemPeferenceLight": {
-        "message": "개인 설정: 라이트"
-    },
-    "teal": {
-        "message": "청록"
-    },
-    "textColor": {
-        "message": "텍스트 색상"
-    },
-    "themes": {
-        "message": "테마"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "모든 쿠키를 삭제합니다."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "모든 시청한 영상을 삭제합니다."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "모든 유튜브 쿠키를 삭제합니다."
-    },
-    "thisWillResetAllSettings": {
-        "message": "모든 설정을 초기화 합니다."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "모든 단축키를 초기화 합니다."
-    },
-    "thumbnails": {
-        "message": "섬네일"
-    },
-    "thumbnailsQuality": {
-        "message": "섬네일 화질"
-    },
-    "timeFrom": {
-        "message": "이 시간 부터"
-    },
-    "timeTo": {
-        "message": "이 시간 까지"
-    },
-    "todayAt": {
-        "message": "오늘의"
-    },
-    "toggleAutoplay": {
-        "message": "자동재생 켜기/끄기"
-    },
-    "toggleCards": {
-        "message": "카드 켜기/끄기"
-    },
-    "toggleControls": {
-        "message": "컨트롤 켜기/끄기"
-    },
-    "topChat": {
-        "message": "탑 챗"
-    },
-    "trackWatchedVideos": {
-        "message": "시청한 동영상 추적"
-    },
-    "trailerAutoplay": {
-        "message": "트레일러 자동재생"
-    },
-    "translations": {
-        "message": "번역"
-    },
-    "transparentBackground": {
-        "message": "투명한 배경"
-    },
-    "trending": {
-        "message": "인기"
-    },
-    "tryToReloadThePage": {
-        "message": "새로고침을 시도하십시오"
-    },
-    "type": {
-        "message": "타입"
-    },
-    "upNextAutoplay": {
-        "message": "다음 영상 자동재생"
-    },
-    "use24HourFormat": {
-        "message": "24시간 형식 사용"
-    },
-    "version": {
-        "message": "버전"
-    },
-    "video": {
-        "message": "영상"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "카테고리의 이름을 얻기 위해 동영상 설명이 확장됩니다"
-    },
-    "videoFormats": {
-        "message": "동영상 형식"
-    },
-    "videos": {
-        "message": "동영상"
-    },
-    "viewMode": {
-        "message": "영화관 모드 전환"
-    },
-    "volume": {
-        "message": "음량"
-    },
-    "watchLater": {
-        "message": "나중에 볼 동영상"
-    },
-    "watchTime": {
-        "message": "시간 보기"
-    },
-    "whenPaused": {
-        "message": "일시중지 중에"
-    },
-    "whenTabIsChanged": {
-        "message": "탭이 바뀔 때"
-    },
-    "white": {
-        "message": "하양"
-    },
-    "windowColor": {
-        "message": "자막 칸 색상"
-    },
-    "windowOpacity": {
-        "message": "자막 칸 투명도"
-    },
-    "yellow": {
-        "message": "노랑"
-    },
-    "youtubeHeaderLeft": {
-        "message": "유튜브 헤더 (왼쪽)"
-    },
-    "youtubeHeaderRight": {
-        "message": "유튜브 헤더 (오른쪽)"
-    },
-    "youtubeHomePage": {
-        "message": "유튜브 홈페이지"
-    },
-    "youtubeLanguage": {
-        "message": "유튜브 언어"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "유튜브는 h.264 코덱에서 비디오 품질을 1080p로 제한합니다."
-    }
+	"about": {
+		"message": "정보"
+	},
+	"accept": {
+		"message": "동의"
+	},
+	"activate": {
+		"message": "활성화"
+	},
+	"activateCaptions": {
+		"message": "자막 활성화"
+	},
+	"activated": {
+		"message": "활성화됨"
+	},
+	"activatedFeatures": {
+		"message": "활성화된 기능"
+	},
+	"activateFullscreen": {
+		"message": "전체화면 활성화"
+	},
+	"activeFeatures": {
+		"message": "활성 기능"
+	},
+	"addScrollToTop": {
+		"message": "<<맨 위로>> 버튼 추가"
+	},
+	"ads": {
+		"message": "광고"
+	},
+	"all": {
+		"message": "모두"
+	},
+	"allow": {
+		"message": "허용"
+	},
+	"always": {
+		"message": "항상"
+	},
+	"alwaysActive": {
+		"message": "항상 활성화"
+	},
+	"alwaysShowProgressBar": {
+		"message": "재생 진행상태(Progress Bar) 항상 표시"
+	},
+	"amber": {
+		"message": "호박색"
+	},
+	"analyzer": {
+		"message": "분석"
+	},
+	"appearance": {
+		"message": "외관"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "데이터를 내보낼까요?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "데이터를 불러올까요?"
+	},
+	"audio": {
+		"message": "오디오"
+	},
+	"audioFormats": {
+		"message": "오디오 형식"
+	},
+	"auto": {
+		"message": "자동"
+	},
+	"autoFullscreen": {
+		"message": "자동 전체화면"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "탭 전환 시 자동 일시중지"
+	},
+	"autoplay": {
+		"message": "자동재생"
+	},
+	"avoidAv1": {
+		"message": "AV1 막기"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "AV1, VP8, VP9 막기"
+	},
+	"avoidAv1Vp9": {
+		"message": "AV1, VP9 막기"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "가능한 경우 CPU 렌더링 막기"
+	},
+	"backgroundColor": {
+		"message": "배경 색상"
+	},
+	"backgroundOpacity": {
+		"message": "배경 투명도"
+	},
+	"backupAndReset": {
+		"message": "백업 & 리셋"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "시스템 색상 구성표 기반"
+	},
+	"belowPlayer": {
+		"message": "플레이어 아래"
+	},
+	"black": {
+		"message": "검정"
+	},
+	"blockAll": {
+		"message": "모두 차단"
+	},
+	"blockAv1": {
+		"message": "AV1 차단"
+	},
+	"blockH264": {
+		"message": "H.264 차단"
+	},
+	"blocklist": {
+		"message": "블랙리스트"
+	},
+	"blockMusic": {
+		"message": "음악 차단"
+	},
+	"blockVp8": {
+		"message": "VP8 차단"
+	},
+	"blockVp9": {
+		"message": "VP9 차단"
+	},
+	"blue": {
+		"message": "파랑"
+	},
+	"blueGray": {
+		"message": "블루그레이"
+	},
+	"bluelight": {
+		"message": "블루라이트"
+	},
+	"brown": {
+		"message": "갈색"
+	},
+	"browser": {
+		"message": "브라우저"
+	},
+	"browserVersion": {
+		"message": "브라우저 버전"
+	},
+	"bubbles": {
+		"message": "버블"
+	},
+	"bug": {
+		"message": "버그"
+	},
+	"buttons": {
+		"message": "버튼"
+	},
+	"cancel": {
+		"message": "취소"
+	},
+	"categories": {
+		"message": "카테고리"
+	},
+	"channel": {
+		"message": "채널"
+	},
+	"channels": {
+		"message": "채널"
+	},
+	"characterEdgeStyle": {
+		"message": "글꼴 테두리 스타일"
+	},
+	"clip": {
+		"message": "클립"
+	},
+	"clipboard": {
+		"message": "클립보드"
+	},
+	"codecH264": {
+		"message": "코덱 h.264"
+	},
+	"codecs": {
+		"message": "코덱"
+	},
+	"collapsed": {
+		"message": "접기"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "구독 섹션 접기"
+	},
+	"comments": {
+		"message": "댓글"
+	},
+	"confirmationBeforeClosing": {
+		"message": "창을 닫기 전에 확인하기"
+	},
+	"cookies": {
+		"message": "쿠키"
+	},
+	"cores": {
+		"message": "코어"
+	},
+	"cropChapterTitles": {
+		"message": "긴 챕터 이름 자르기"
+	},
+	"custom": {
+		"message": "사용자 지정"
+	},
+	"customCss": {
+		"message": "사용자 지정 캐스캐이팅 스타일 시트(CSS)"
+	},
+	"customJs": {
+		"message": "사용자 지정 자바스크립트(JS)"
+	},
+	"customMiniPlayer": {
+		"message": "커스텀 미니플레이어"
+	},
+	"cyan": {
+		"message": "옥색"
+	},
+	"dark": {
+		"message": "다크"
+	},
+	"darkTheme": {
+		"message": "다크 테마"
+	},
+	"dateAndTime": {
+		"message": "날짜와 시간"
+	},
+	"dawn": {
+		"message": "석양"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "재생 속도 빠르게"
+	},
+	"decreaseVolume": {
+		"message": "볼륨 감소"
+	},
+	"deepOrange": {
+		"message": "진한 주황"
+	},
+	"deepPurple": {
+		"message": "진한 보라"
+	},
+	"default": {
+		"message": "기본값"
+	},
+	"defaultChannelTab": {
+		"message": "기본 채널 탭"
+	},
+	"defaultContentCountry": {
+		"message": "기본 콘텐츠 지역"
+	},
+	"deleteWatchedVideos": {
+		"message": "시청한 영상 삭제"
+	},
+	"deleteYoutubeCookies": {
+		"message": "유튜브 쿠키 삭제"
+	},
+	"depressed": {
+		"message": "음각"
+	},
+	"description": {
+		"message": "영상 설명란"
+	},
+	"description_ext": {
+		"message": "YouTube, YouTube, YouTube: 유튜브를 깔끔하고 스마트하게 만들어줍니다! 유튜브 비디오의 색상, 광고 제거, 음량, 배속, 채널 툴, 스타일, HD, 광고 차단, 태그, 키워드, 재생목록"
+	},
+	"desert": {
+		"message": "사막"
+	},
+	"details": {
+		"message": "자세히"
+	},
+	"developerOptions": {
+		"message": "개발자 옵션"
+	},
+	"device": {
+		"message": "디바이스"
+	},
+	"dim": {
+		"message": "어둡게"
+	},
+	"disabled": {
+		"message": "비활성화"
+	},
+	"dislike": {
+		"message": "싫어요"
+	},
+	"displayDayOfTheWeak": {
+		"message": "요일 표시"
+	},
+	"donate": {
+		"message": "후원하기"
+	},
+	"doNotChange": {
+		"message": "바꾸지 않음"
+	},
+	"download": {
+		"message": "오프라인 저장"
+	},
+	"draggable": {
+		"message": "드래그 가능"
+	},
+	"dropShadow": {
+		"message": "그림자"
+	},
+	"durationWithSpeed": {
+		"message": "남은 시간을 재생속도에 맞춰 표시하기"
+	},
+	"email": {
+		"message": "이메일"
+	},
+	"empty": {
+		"message": "비어있음"
+	},
+	"enabled": {
+		"message": "활성화"
+	},
+	"enabledForced": {
+		"message": "강제 활성화"
+	},
+	"expanded": {
+		"message": "확장"
+	},
+	"exportSettings": {
+		"message": "설정 내보내기"
+	},
+	"extension": {
+		"message": "확장 프로그램"
+	},
+	"file": {
+		"message": "파일"
+	},
+	"filters": {
+		"message": "필터"
+	},
+	"fitToWindow": {
+		"message": "창 크기에 맞추기"
+	},
+	"flash": {
+		"message": "플래시"
+	},
+	"font": {
+		"message": "글꼴"
+	},
+	"fontColor": {
+		"message": "글꼴 색상"
+	},
+	"fontFamily": {
+		"message": "글꼴 설정"
+	},
+	"fontOpacity": {
+		"message": "글꼴 투명도"
+	},
+	"fontSize": {
+		"message": "글꼴 크기"
+	},
+	"footer": {
+		"message": "하단"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "재생 속도 강제 설정"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "유튜브 뮤직 재생 속도 강제 설정"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "영상을 무조건 처음부터 보기"
+	},
+	"forcedTheaterMode": {
+		"message": "강제 영화관 모드"
+	},
+	"forcedVolume": {
+		"message": "볼륨 강제설정"
+	},
+	"forceSDR": {
+		"message": "SDR 강제 적용"
+	},
+	"foundABug": {
+		"message": "버그 신고"
+	},
+	"fullWindow": {
+		"message": "전체 화면"
+	},
+	"general": {
+		"message": "일반"
+	},
+	"github": {
+		"message": "깃허브(GitHub)"
+	},
+	"goToSearchBox": {
+		"message": "검색창으로 이동"
+	},
+	"gpu": {
+		"message": "그래픽 처리 장치"
+	},
+	"green": {
+		"message": "초록"
+	},
+	"hardwareInformation": {
+		"message": "하드웨어 정보"
+	},
+	"hdThumbnail": {
+		"message": "HD 섬네일"
+	},
+	"header": {
+		"message": "헤더"
+	},
+	"hidden": {
+		"message": "숨기기"
+	},
+	"hiddenOnVideoPage": {
+		"message": "영상이 있을 때 숨기기"
+	},
+	"hide_author_avatars": {
+		"message": "사용자 사진 숨기기"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "섬네일 재생 끄기"
+	},
+	"hideAnnotations": {
+		"message": "설명 숨기기"
+	},
+	"hideCards": {
+		"message": "카드 숨기기"
+	},
+	"hideCategories": {
+		"message": "카테고리 숨기기"
+	},
+	"hideCommentsCount": {
+		"message": "댓글 개수 숨기기"
+	},
+	"hideCountryCode": {
+		"message": "국가코드 숨기기"
+	},
+	"hideDate": {
+		"message": "날짜 숨기기"
+	},
+	"hideDetailButton": {
+		"message": "상세 버튼 숨기기"
+	},
+	"hideDetails": {
+		"message": "영상 설명란 숨기기"
+	},
+	"hideEndscreen": {
+		"message": "영상 끝난 후 추천 영상 숨기기"
+	},
+	"hideFeaturedContent": {
+		"message": "추천 영상 숨기기"
+	},
+	"hideFooter": {
+		"message": "하단 숨기기"
+	},
+	"hideGradientBottom": {
+		"message": "영상 아래 그라데이션 숨기기"
+	},
+	"hideHomePageShorts": {
+		"message": "홈 페이지의 쇼츠 제거"
+	},
+	"hidePlayerControlsBar": {
+		"message": "플레이어 컨트롤 바 숨기기"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "플레이어 컨트롤 버튼 숨기기"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "플레이어 컨트롤 옵션 숨기기"
+	},
+	"hidePlaylist": {
+		"message": "재생 목록 숨기기"
+	},
+	"hideRightButtons": {
+		"message": "오른쪽 버튼 숨기기"
+	},
+	"hideScrollForDetails": {
+		"message": "«스크롤 하여 자세한 설명» 숨기기"
+	},
+	"hideSkipOverlay": {
+		"message": "\"오버레이 건너뛰기\" 숨기기"
+	},
+	"hideThumbnailOverlay": {
+		"message": "섬네일 오버레이 숨기기"
+	},
+	"hideThumbnails": {
+		"message": "섬네일 숨기기"
+	},
+	"hideViewsCount": {
+		"message": "조회 수 숨기기"
+	},
+	"hideVoiceSearchButton": {
+		"message": "\"음성으로 찾기\" 버튼 숨기기"
+	},
+	"high": {
+		"message": "고화질"
+	},
+	"history": {
+		"message": "시청 기록"
+	},
+	"home": {
+		"message": "홈"
+	},
+	"hover": {
+		"message": "마우스를 올리면 띄우기"
+	},
+	"hoverOnVideoPage": {
+		"message": "영상이 있을 때 마우스를 올리면 띄우기"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "업로드 시기"
+	},
+	"icons": {
+		"message": "아이콘"
+	},
+	"iconsOnly": {
+		"message": "아이콘만"
+	},
+	"importSettings": {
+		"message": "설정 불러오기"
+	},
+	"improvedtubeButtons": {
+		"message": "ImprovedTube 버튼"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube 아이콘"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube 언어"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube 버전"
+	},
+	"improveLogo": {
+		"message": "향상된 로고"
+	},
+	"increasePlaybackSpeed": {
+		"message": "재생 속도 느리게"
+	},
+	"increaseVolume": {
+		"message": "볼륨 증가"
+	},
+	"indigo": {
+		"message": "남색"
+	},
+	"items": {
+		"message": "요소"
+	},
+	"language": {
+		"message": "언어"
+	},
+	"languages": {
+		"message": "언어"
+	},
+	"layerAnimationScale": {
+		"message": "레이어 애니메이션 배속"
+	},
+	"layout": {
+		"message": "모양"
+	},
+	"legacyYoutube": {
+		"message": "레거시 유튜브"
+	},
+	"library": {
+		"message": "보관함"
+	},
+	"light": {
+		"message": "밝게"
+	},
+	"lightBlue": {
+		"message": "연파랑"
+	},
+	"lightGreen": {
+		"message": "연초록"
+	},
+	"like": {
+		"message": "좋아요"
+	},
+	"liked": {
+		"message": "좋아요 표시한 동영상"
+	},
+	"lime": {
+		"message": "라임"
+	},
+	"limitPageWidth": {
+		"message": "페이지 너비 제한"
+	},
+	"list": {
+		"message": "리스트"
+	},
+	"liveChat": {
+		"message": "실시간 채팅"
+	},
+	"liveChatType": {
+		"message": "실시간 채팅 유형"
+	},
+	"location": {
+		"message": "지역"
+	},
+	"loudnessNormalization": {
+		"message": "볼륨 자동조정"
+	},
+	"low": {
+		"message": "저화질"
+	},
+	"markWatchedVideos": {
+		"message": "시청한 영상 표시"
+	},
+	"medium": {
+		"message": "보통 화질"
+	},
+	"mixer": {
+		"message": "믹서"
+	},
+	"mostViewedChannels": {
+		"message": "가장 많이 본 채널"
+	},
+	"moveSidebarLeft": {
+		"message": "사이드바 왼쪽으로 이동"
+	},
+	"moveThumbnailsRight": {
+		"message": "섬네일 오른쪽으로 이동"
+	},
+	"myColors": {
+		"message": "내 색상"
+	},
+	"name": {
+		"message": "이름"
+	},
+	"nativeMiniPlayer": {
+		"message": "네이티브 미니플레이어"
+	},
+	"new": {
+		"message": "새로운 소식"
+	},
+	"nextVideo": {
+		"message": "다음 영상"
+	},
+	"night": {
+		"message": "저녁"
+	},
+	"nightMode": {
+		"message": "수면 도움 모드"
+	},
+	"noActiveFeatures": {
+		"message": "활성 기능 없음"
+	},
+	"none": {
+		"message": "없음"
+	},
+	"noOpenVideoTabs": {
+		"message": "열린 비디오 탭 없음"
+	},
+	"normal": {
+		"message": "기본"
+	},
+	"old": {
+		"message": "오래됨"
+	},
+	"onAllVideos": {
+		"message": "모든 동영상"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "유튜브만 활성화"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "하나의 플레이어만 재생"
+	},
+	"onSubscribedChannels": {
+		"message": "구독한 채널"
+	},
+	"openPopupPlayer": {
+		"message": "동영상/재생목록을 새 창에서 열기"
+	},
+	"orange": {
+		"message": "주황"
+	},
+	"os": {
+		"message": "운영체제"
+	},
+	"other": {
+		"message": "기타"
+	},
+	"outline": {
+		"message": "외곽선"
+	},
+	"overlay": {
+		"message": "오버레이"
+	},
+	"permissions": {
+		"message": "권한"
+	},
+	"pictureInPicture": {
+		"message": "픽처 인 픽처(PIP) 재생"
+	},
+	"pink": {
+		"message": "분홍"
+	},
+	"plain": {
+		"message": "무색"
+	},
+	"platform": {
+		"message": "플랫폼"
+	},
+	"playAllButton": {
+		"message": "\"모두 재생\"버튼"
+	},
+	"playbackSpeed": {
+		"message": "영상 재생 속도"
+	},
+	"player": {
+		"message": "플레이어"
+	},
+	"playerColor": {
+		"message": "플레이어 색상"
+	},
+	"playerSize": {
+		"message": "플레이어 크기"
+	},
+	"playlist": {
+		"message": "플레이리스트"
+	},
+	"playlists": {
+		"message": "플레이리스트"
+	},
+	"playPause": {
+		"message": "재생 / 일시중지"
+	},
+	"popupPlayer": {
+		"message": "팝업 플레이어"
+	},
+	"position": {
+		"message": "위치"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "사용할 단축키 또는 마우스 휠을 누르세요."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "사용할 단축키 또는 마우스 휠을 누르세요."
+	},
+	"previousVideo": {
+		"message": "이전 영상"
+	},
+	"primaryColor": {
+		"message": "주 색상"
+	},
+	"purple": {
+		"message": "보라"
+	},
+	"quality": {
+		"message": "화질"
+	},
+	"raised": {
+		"message": "양각"
+	},
+	"ram": {
+		"message": "램"
+	},
+	"rateUs": {
+		"message": "평가하기"
+	},
+	"red": {
+		"message": "빨강"
+	},
+	"redDislikeButton": {
+		"message": "싫어요 버튼 빨간색으로 표시"
+	},
+	"relatedVideos": {
+		"message": "관련 영상"
+	},
+	"remote": {
+		"message": "TV에서 재생"
+	},
+	"removeRelatedSearchResults": {
+		"message": "관련 검색 결과 제거"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "검색 결과에서 Shorts 리얼 제거"
+	},
+	"repeat": {
+		"message": "반복"
+	},
+	"report": {
+		"message": "신고"
+	},
+	"reset": {
+		"message": "리셋"
+	},
+	"resetAllSettings": {
+		"message": "모든 설정 리셋"
+	},
+	"resetAllShortcuts": {
+		"message": "모든 단축키 리셋"
+	},
+	"reverse": {
+		"message": "거꾸로"
+	},
+	"rotate": {
+		"message": "회전"
+	},
+	"save": {
+		"message": "오프라인 저장"
+	},
+	"saveAs": {
+		"message": "다른 이름으로 저장"
+	},
+	"schedule": {
+		"message": "스케줄"
+	},
+	"screen": {
+		"message": "스크린"
+	},
+	"screenshot": {
+		"message": "스크린샷"
+	},
+	"search": {
+		"message": "검색"
+	},
+	"searchBarOnly": {
+		"message": "검색창만"
+	},
+	"seekBackward10Seconds": {
+		"message": "뒤로 10초"
+	},
+	"seekForward10Seconds": {
+		"message": "앞으로 10초"
+	},
+	"seekNextChapter": {
+		"message": "다음 챕터 보기"
+	},
+	"seekPreviousChapter": {
+		"message": "이전 챕터 보기"
+	},
+	"settings": {
+		"message": "설정"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "설정 내보내기 완료"
+	},
+	"shortcuts": {
+		"message": "단축키"
+	},
+	"showCardsOnMouseHover": {
+		"message": "마우스 올릴 때 카드 보기"
+	},
+	"showChannelVideosCount": {
+		"message": "채널의 동영상 수 표시"
+	},
+	"showLess": {
+		"message": "간략히"
+	},
+	"showMore": {
+		"message": "더보기"
+	},
+	"showRemainingDuration": {
+		"message": "동영상 남은 시간 표시"
+	},
+	"showVersion": {
+		"message": "버전 표시"
+	},
+	"shuffle": {
+		"message": "셔플"
+	},
+	"sidebar": {
+		"message": "사이드바"
+	},
+	"softwareInformation": {
+		"message": "소프트웨어 정보"
+	},
+	"spacebar": {
+		"message": "스페이스바"
+	},
+	"squaredUserImages": {
+		"message": "정사각형 프로필 사진"
+	},
+	"static": {
+		"message": "밑으로 내릴 때 숨기기"
+	},
+	"statsForNerds": {
+		"message": "전문 통계 표시"
+	},
+	"step": {
+		"message": "간격"
+	},
+	"stop": {
+		"message": "정지"
+	},
+	"style": {
+		"message": "스타일"
+	},
+	"styles": {
+		"message": "스타일"
+	},
+	"subscribe": {
+		"message": "구독하기"
+	},
+	"subscriptions": {
+		"message": "구독"
+	},
+	"subtitles": {
+		"message": "자막"
+	},
+	"sunset": {
+		"message": "일몰"
+	},
+	"sunsetToSunrise": {
+		"message": "적용 시간 설정"
+	},
+	"systemPeferenceDark": {
+		"message": "개인 설정: 다크"
+	},
+	"systemPeferenceLight": {
+		"message": "개인 설정: 라이트"
+	},
+	"teal": {
+		"message": "청록"
+	},
+	"textColor": {
+		"message": "텍스트 색상"
+	},
+	"themes": {
+		"message": "테마"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "모든 쿠키를 삭제합니다."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "모든 시청한 영상을 삭제합니다."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "모든 유튜브 쿠키를 삭제합니다."
+	},
+	"thisWillResetAllSettings": {
+		"message": "모든 설정을 초기화 합니다."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "모든 단축키를 초기화 합니다."
+	},
+	"thumbnails": {
+		"message": "섬네일"
+	},
+	"thumbnailsQuality": {
+		"message": "섬네일 화질"
+	},
+	"timeFrom": {
+		"message": "이 시간 부터"
+	},
+	"timeTo": {
+		"message": "이 시간 까지"
+	},
+	"todayAt": {
+		"message": "오늘의"
+	},
+	"toggleAutoplay": {
+		"message": "자동재생 켜기/끄기"
+	},
+	"toggleCards": {
+		"message": "카드 켜기/끄기"
+	},
+	"toggleControls": {
+		"message": "컨트롤 켜기/끄기"
+	},
+	"topChat": {
+		"message": "탑 챗"
+	},
+	"trackWatchedVideos": {
+		"message": "시청한 동영상 추적"
+	},
+	"trailerAutoplay": {
+		"message": "트레일러 자동재생"
+	},
+	"translations": {
+		"message": "번역"
+	},
+	"transparentBackground": {
+		"message": "투명한 배경"
+	},
+	"trending": {
+		"message": "인기"
+	},
+	"tryToReloadThePage": {
+		"message": "새로고침을 시도하십시오"
+	},
+	"type": {
+		"message": "타입"
+	},
+	"upNextAutoplay": {
+		"message": "다음 영상 자동재생"
+	},
+	"use24HourFormat": {
+		"message": "24시간 형식 사용"
+	},
+	"version": {
+		"message": "버전"
+	},
+	"video": {
+		"message": "영상"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "카테고리의 이름을 얻기 위해 동영상 설명이 확장됩니다"
+	},
+	"videoFormats": {
+		"message": "동영상 형식"
+	},
+	"videos": {
+		"message": "동영상"
+	},
+	"viewMode": {
+		"message": "영화관 모드 전환"
+	},
+	"volume": {
+		"message": "음량"
+	},
+	"watchLater": {
+		"message": "나중에 볼 동영상"
+	},
+	"watchTime": {
+		"message": "시간 보기"
+	},
+	"whenPaused": {
+		"message": "일시중지 중에"
+	},
+	"whenTabIsChanged": {
+		"message": "탭이 바뀔 때"
+	},
+	"white": {
+		"message": "하양"
+	},
+	"windowColor": {
+		"message": "자막 칸 색상"
+	},
+	"windowOpacity": {
+		"message": "자막 칸 투명도"
+	},
+	"yellow": {
+		"message": "노랑"
+	},
+	"youtubeHeaderLeft": {
+		"message": "유튜브 헤더 (왼쪽)"
+	},
+	"youtubeHeaderRight": {
+		"message": "유튜브 헤더 (오른쪽)"
+	},
+	"youtubeHomePage": {
+		"message": "유튜브 홈페이지"
+	},
+	"youtubeLanguage": {
+		"message": "유튜브 언어"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "유튜브는 h.264 코덱에서 비디오 품질을 1080p로 제한합니다."
+	}
 }

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Pašalinkite Shorts iš pagrindinio puslapio"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Pašalinkite Shorts ritinį iš paieškos rezultatų"
-    }
+	"hideHomePageShorts": {
+		"message": "Pašalinkite Shorts iš pagrindinio puslapio"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Pašalinkite Shorts ritinį iš paieškos rezultatų"
+	}
 }

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Noņem Shorts no sākumlapas"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Noņemiet Shorts rullīti no meklēšanas rezultātiem"
-    }
+	"hideHomePageShorts": {
+		"message": "Noņem Shorts no sākumlapas"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Noņemiet Shorts rullīti no meklēšanas rezultātiem"
+	}
 }

--- a/_locales/ml/messages.json
+++ b/_locales/ml/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "ഹോം പേജിന്റെ ഷോർട്ട് നീക്കം"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "തിരച്ചില്‍ ഫലങ്ങളില്‍നിന്ന് ഷോര്‍ട്സ് റീല്‍ നീക്കം"
-    }
+	"hideHomePageShorts": {
+		"message": "ഹോം പേജിന്റെ ഷോർട്ട് നീക്കം"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "തിരച്ചില്‍ ഫലങ്ങളില്‍നിന്ന് ഷോര്‍ട്സ് റീല്‍ നീക്കം"
+	}
 }

--- a/_locales/mr/messages.json
+++ b/_locales/mr/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "मुख्य पृष्ठाच्या शॉर्ट्स काढा"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "शोध निकाला लावा परिणामातील शॉर्ट्स रील"
-    }
+	"hideHomePageShorts": {
+		"message": "मुख्य पृष्ठाच्या शॉर्ट्स काढा"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "शोध निकाला लावा परिणामातील शॉर्ट्स रील"
+	}
 }

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Alihkan Shorts dari laman utama"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Alihkan gulungan Shorts dari hasil carian"
-    }
+	"hideHomePageShorts": {
+		"message": "Alihkan Shorts dari laman utama"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Alihkan gulungan Shorts dari hasil carian"
+	}
 }

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -1,758 +1,746 @@
 {
-    "about": {
-        "message": "Om"
-    },
-    "accept": {
-        "message": "aksepter"
-    },
-    "activate": {
-        "message": "Aktiver"
-    },
-    "activateCaptions": {
-        "message": "Aktiver underteksting"
-    },
-    "activated": {
-        "message": "Aktivert"
-    },
-    "activatedFeatures": {
-        "message": "Aktiverte funksjoner"
-    },
-    "activateFullscreen": {
-        "message": "Aktiver fullskjerm"
-    },
-    "activeFeatures": {
-        "message": "Aktive funksjoner"
-    },
-    "addScrollToTop": {
-        "message": "Legg til «Rull til toppen»"
-    },
-    "ads": {
-        "message": "Reklamer"
-    },
-    "all": {
-        "message": "Alle"
-    },
-    "allow": {
-        "message": "Tillat"
-    },
-    "alwaysActive": {
-        "message": "Alltid aktiv"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Alltid vis fremdriftslinje"
-    },
-    "analyzer": {
-        "message": "Analysator"
-    },
-    "appearance": {
-        "message": "Utseende"
-    },
-    "audio": {
-        "message": "Lyd"
-    },
-    "audioFormats": {
-        "message": "Lydformater"
-    },
-    "autoFullscreen": {
-        "message": "Auto-fullskjerm"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Autopause når du bytter faner"
-    },
-    "backupAndReset": {
-        "message": "Sikkerhetskopiering og tilbakestilling"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baser på systemfargevalg"
-    },
-    "belowPlayer": {
-        "message": "Nedenfor avspiller"
-    },
-    "black": {
-        "message": "Svart"
-    },
-    "blockAll": {
-        "message": "Blokker alle"
-    },
-    "blocklist": {
-        "message": "Svartelist"
-    },
-    "blue": {
-        "message": "Blå"
-    },
-    "blueGray": {
-        "message": "Blågrå"
-    },
-    "bluelight": {
-        "message": "Blålys"
-    },
-    "brown": {
-        "message": "Brun"
-    },
-    "browser": {
-        "message": "Nettleser"
-    },
-    "browserVersion": {
-        "message": "Nettleser-versjon"
-    },
-    "bubbles": {
-        "message": "Bobler"
-    },
-    "buttons": {
-        "message": "Knapper"
-    },
-    "cancel": {
-        "message": "Avbryt"
-    },
-    "categories": {
-        "message": "Kategorier"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanaler"
-    },
-    "clipboard": {
-        "message": "Utklippstavle"
-    },
-    "codecH264": {
-        "message": "H.264-kodek"
-    },
-    "collapsed": {
-        "message": "kollapset"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Kollaps av abonnementsdelene"
-    },
-    "comments": {
-        "message": "Kommentarer"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Bekreftelse før stenging"
-    },
-    "cookies": {
-        "message": "Informasjonskapslene"
-    },
-    "cores": {
-        "message": "Kjerner"
-    },
-    "cropChapterTitles": {
-        "message": "Beskjær kapitteltitler"
-    },
-    "customCss": {
-        "message": "Tilpasset CSS"
-    },
-    "customJs": {
-        "message": "Tilpasset JS"
-    },
-    "customMiniPlayer": {
-        "message": "Egendefinert miniavspiller"
-    },
-    "cyan": {
-        "message": "Blålilla"
-    },
-    "dark": {
-        "message": "Mørk"
-    },
-    "darkTheme": {
-        "message": "Mørk drakt"
-    },
-    "dateAndTime": {
-        "message": "Dato og klokkeslett"
-    },
-    "dawn": {
-        "message": "Soloppgang"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Reduser avspillingshastighet"
-    },
-    "decreaseVolume": {
-        "message": "Reduser lydstyrken"
-    },
-    "deepOrange": {
-        "message": "Dyporansje"
-    },
-    "deepPurple": {
-        "message": "Mørkelilla"
-    },
-    "defaultChannelTab": {
-        "message": "Forvalgt kanalfane"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Slett YouTube-informasjonskapsler"
-    },
-    "desert": {
-        "message": "Ørken"
-    },
-    "details": {
-        "message": "Detaljer"
-    },
-    "developerOptions": {
-        "message": "Utviklermuligheter"
-    },
-    "device": {
-        "message": "Enhet"
-    },
-    "disabled": {
-        "message": "Avslått"
-    },
-    "dislike": {
-        "message": "Mislik"
-    },
-    "donate": {
-        "message": "Doner"
-    },
-    "doNotChange": {
-        "message": "Ikke endre"
-    },
-    "draggable": {
-        "message": "Flyttbare"
-    },
-    "email": {
-        "message": "E-post"
-    },
-    "empty": {
-        "message": "Tom"
-    },
-    "enabled": {
-        "message": "Aktivert"
-    },
-    "enabledForced": {
-        "message": "Aktivert (tvunget)"
-    },
-    "expanded": {
-        "message": "Utvidet"
-    },
-    "exportSettings": {
-        "message": "Eksporter innstillinger"
-    },
-    "extension": {
-        "message": "Utvidelse"
-    },
-    "file": {
-        "message": "Fil"
-    },
-    "filters": {
-        "message": "Filtre"
-    },
-    "fitToWindow": {
-        "message": "Tilpass til vindu"
-    },
-    "footer": {
-        "message": "Bunntekst"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Tvungen avspillingshastighet"
-    },
-    "forcedTheaterMode": {
-        "message": "Tvunget teater-modus"
-    },
-    "forcedVolume": {
-        "message": "Tvunget lydstyrke"
-    },
-    "foundABug": {
-        "message": "Fant du en feil?"
-    },
-    "fullWindow": {
-        "message": "Fullt vindu"
-    },
-    "general": {
-        "message": "Generelt"
-    },
-    "geoPreference": {
-        "message": "Geo-preferanse"
-    },
-    "goToSearchBox": {
-        "message": "Gå til søkefeltet"
-    },
-    "green": {
-        "message": "Grønn"
-    },
-    "hdThumbnail": {
-        "message": "HD-miniatyrbilde"
-    },
-    "header": {
-        "message": "Overskrift"
-    },
-    "hidden": {
-        "message": "Skjult"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Skjult på videosiden"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Skjul animerte miniatyrbilder"
-    },
-    "hideAnnotations": {
-        "message": "Skjul annoteringer"
-    },
-    "hideCards": {
-        "message": "Skjul kort"
-    },
-    "hideDetails": {
-        "message": "Skjul detaljer"
-    },
-    "hideEndscreen": {
-        "message": "Skjul sluttskjerm"
-    },
-    "hideFeaturedContent": {
-        "message": "Skjul omtalt innhold"
-    },
-    "hideFooter": {
-        "message": "Skjul bunntekst"
-    },
-    "hideGradientBottom": {
-        "message": "Skjul bunn-fargeovergang"
-    },
-    "hideHomePageShorts": {
-        "message": "Fjern Shorts fra hjemmesiden"
-    },
-    "hidePlaylist": {
-        "message": "Skjul spilleliste"
-    },
-    "hideRightButtons": {
-        "message": "Skjul høyre-knapper"
-    },
-    "hideScrollForDetails": {
-        "message": "Skjul «Bla for detaljer»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "Skjul visningsteller"
-    },
-    "history": {
-        "message": "Historie"
-    },
-    "home": {
-        "message": "Hjem"
-    },
-    "hover": {
-        "message": "Hold"
-    },
-    "hoverOnVideoPage": {
-        "message": "Hold musepekeren på videosiden"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Hvor lenge siden videoen ble opplastet"
-    },
-    "icons": {
-        "message": "Ikoner"
-    },
-    "iconsOnly": {
-        "message": "Kun ikoner"
-    },
-    "importSettings": {
-        "message": "Importer innstillinger"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube-ikonet på YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube-språk"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube-versjon"
-    },
-    "improveLogo": {
-        "message": "Forbedre logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Øk avspillingshastigheten"
-    },
-    "increaseVolume": {
-        "message": "Øk lydstyrken"
-    },
-    "items": {
-        "message": "Elementer"
-    },
-    "languages": {
-        "message": "Språk"
-    },
-    "legacyYoutube": {
-        "message": "Gammeldags YouTube"
-    },
-    "light": {
-        "message": "Lys"
-    },
-    "lightBlue": {
-        "message": "Lyseblå"
-    },
-    "lightGreen": {
-        "message": "Lysegrønn"
-    },
-    "like": {
-        "message": "Gunst"
-    },
-    "list": {
-        "message": "Liste"
-    },
-    "liveChat": {
-        "message": "Sanntidssludring"
-    },
-    "liveChatType": {
-        "message": "Sanntidssludringstype"
-    },
-    "loudnessNormalization": {
-        "message": "Lydstyrkenormalisering"
-    },
-    "markWatchedVideos": {
-        "message": "Marker sette videoer"
-    },
-    "mixer": {
-        "message": "Mikser"
-    },
-    "myColors": {
-        "message": "Mine farger"
-    },
-    "name": {
-        "message": "Navn"
-    },
-    "nativeMiniPlayer": {
-        "message": "Innebygd miniavspiller"
-    },
-    "new": {
-        "message": "Ny"
-    },
-    "nextVideo": {
-        "message": "Neste video"
-    },
-    "night": {
-        "message": "Natt"
-    },
-    "noActiveFeatures": {
-        "message": "Ingen aktive funksjoner"
-    },
-    "none": {
-        "message": "Ingen"
-    },
-    "noOpenVideoTabs": {
-        "message": "Ingen åpne videofaner"
-    },
-    "old": {
-        "message": "Gammel"
-    },
-    "onAllVideos": {
-        "message": "På alle videoer"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Kun aktiv på YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Kun én avspiller viser noe"
-    },
-    "onSubscribedChannels": {
-        "message": "På abonnementskanaler"
-    },
-    "orange": {
-        "message": "Oransje"
-    },
-    "other": {
-        "message": "Andre"
-    },
-    "permissions": {
-        "message": "rettigheter"
-    },
-    "pictureInPicture": {
-        "message": "Bilde-i-bilde"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Vanlig"
-    },
-    "platform": {
-        "message": "Plattform"
-    },
-    "playbackSpeed": {
-        "message": "Avspillingshastighet"
-    },
-    "player": {
-        "message": "Avspiller"
-    },
-    "playerColor": {
-        "message": "Avspiller-farge"
-    },
-    "playerSize": {
-        "message": "Avspiller-størrelse"
-    },
-    "playlist": {
-        "message": "Spilleliste"
-    },
-    "playlists": {
-        "message": "Spillelister"
-    },
-    "playPause": {
-        "message": "Spill / Pause"
-    },
-    "popupPlayer": {
-        "message": "Oppsprettsspiller"
-    },
-    "position": {
-        "message": "Posisjon"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Trykk på hvilken som helst tast, eller bruk musehjulet."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Trykk på hvilken som helst tast, eller bruk musehjulet"
-    },
-    "previousVideo": {
-        "message": "Forrige video"
-    },
-    "primaryColor": {
-        "message": "Hovedfarge"
-    },
-    "purple": {
-        "message": "Lilla"
-    },
-    "quality": {
-        "message": "Kvalitet"
-    },
-    "ram": {
-        "message": "Minne"
-    },
-    "rateUs": {
-        "message": "Rangere oss"
-    },
-    "red": {
-        "message": "Rød"
-    },
-    "redDislikeButton": {
-        "message": "Vis tommel ned i rød farge"
-    },
-    "relatedVideos": {
-        "message": "Relaterte videoer"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Fjern relaterte søkeresultater"
-    },
-    "repeat": {
-        "message": "Gjenta"
-    },
-    "reset": {
-        "message": "Tilbakestill"
-    },
-    "resetAllSettings": {
-        "message": "Tilbakestill alle instillinger"
-    },
-    "resetAllShortcuts": {
-        "message": "Tilbakestill alle snarveier"
-    },
-    "reverse": {
-        "message": "Omvendt"
-    },
-    "rotate": {
-        "message": "Roter"
-    },
-    "save": {
-        "message": "Lagre"
-    },
-    "saveAs": {
-        "message": "Lagre som"
-    },
-    "schedule": {
-        "message": "Tidsplan"
-    },
-    "screen": {
-        "message": "Skjerm"
-    },
-    "screenshot": {
-        "message": "Skjeravbildning"
-    },
-    "search": {
-        "message": "Søk"
-    },
-    "searchBarOnly": {
-        "message": "Bare søkefelt"
-    },
-    "seekBackward10Seconds": {
-        "message": "Spol 10 sekunder bakover"
-    },
-    "seekForward10Seconds": {
-        "message": "Spol 10 sekunder fremover"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Innstillinger"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Innstillinger importert"
-    },
-    "shortcuts": {
-        "message": "Snarveier"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Vis kort på musepekeren"
-    },
-    "showChannelVideosCount": {
-        "message": "Vis antall kanaler"
-    },
-    "shuffle": {
-        "message": "Tilfeldig rekkefølge"
-    },
-    "sidebar": {
-        "message": "Sidepanel"
-    },
-    "spacebar": {
-        "message": "Mellomrom"
-    },
-    "squaredUserImages": {
-        "message": "Kvadratiske brukerbilder"
-    },
-    "static": {
-        "message": "Statisk"
-    },
-    "statsForNerds": {
-        "message": "Vis statistikk for nerder"
-    },
-    "step": {
-        "message": "Steg"
-    },
-    "stop": {
-        "message": "Stopp"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stiler"
-    },
-    "subscriptions": {
-        "message": "Abonnementer"
-    },
-    "subtitles": {
-        "message": "Undertekster"
-    },
-    "sunset": {
-        "message": "Solnedgang"
-    },
-    "sunsetToSunrise": {
-        "message": "Solnedgang til soloppgang"
-    },
-    "systemPeferenceDark": {
-        "message": "Systeminnstillinger: mørk"
-    },
-    "systemPeferenceLight": {
-        "message": "Systeminnstillinger: lys"
-    },
-    "teal": {
-        "message": "Blågrønn"
-    },
-    "textColor": {
-        "message": "Tekstfarge"
-    },
-    "themes": {
-        "message": "Drakter"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Dette vil fjerne alle informasjonskapsler."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Dette vil fjerne alle YouTube-informasjonskapsler"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Dette vil tilbakestille alle innstillinger."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Dette vil tilbakestille alle snarveier"
-    },
-    "thumbnails": {
-        "message": "miniatyrbilder "
-    },
-    "timeFrom": {
-        "message": "Fra"
-    },
-    "timeTo": {
-        "message": "Til"
-    },
-    "todayAt": {
-        "message": "I dag kl."
-    },
-    "toggleCards": {
-        "message": "Veksle kort"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "Hovedsludring"
-    },
-    "trailerAutoplay": {
-        "message": "Trailer autospilling"
-    },
-    "translations": {
-        "message": "Oversettelser"
-    },
-    "transparentBackground": {
-        "message": "Gjennomsiktig bakgrunn"
-    },
-    "trending": {
-        "message": "Trender"
-    },
-    "tryToReloadThePage": {
-        "message": "Forsøk å laste inn siden på nytt"
-    },
-    "upNextAutoplay": {
-        "message": "«Spilles senere»-autospilling"
-    },
-    "use24HourFormat": {
-        "message": "Bruk 24-timersformat"
-    },
-    "version": {
-        "message": "Versjon"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Videobeskrivelsen vil bli utvidet for å få med navnet på kategorien"
-    },
-    "videoFormats": {
-        "message": "Video-formater"
-    },
-    "videos": {
-        "message": "Videoer"
-    },
-    "volume": {
-        "message": "Lydstyrke"
-    },
-    "watchLater": {
-        "message": "Se senere"
-    },
-    "watchTime": {
-        "message": "Tid sett"
-    },
-    "whenTabIsChanged": {
-        "message": "Når fanen endres"
-    },
-    "white": {
-        "message": "Hvit"
-    },
-    "yellow": {
-        "message": "Gul"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube-topptekst (til venstre)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube-topptekst (til høyre)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube-startside"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube-språk"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube begrenser videokvaliteten til 1080p for H.264-kodeket"
-    }
+	"about": {
+		"message": "Om"
+	},
+	"accept": {
+		"message": "aksepter"
+	},
+	"activate": {
+		"message": "Aktiver"
+	},
+	"activateCaptions": {
+		"message": "Aktiver underteksting"
+	},
+	"activated": {
+		"message": "Aktivert"
+	},
+	"activatedFeatures": {
+		"message": "Aktiverte funksjoner"
+	},
+	"activateFullscreen": {
+		"message": "Aktiver fullskjerm"
+	},
+	"activeFeatures": {
+		"message": "Aktive funksjoner"
+	},
+	"addScrollToTop": {
+		"message": "Legg til «Rull til toppen»"
+	},
+	"ads": {
+		"message": "Reklamer"
+	},
+	"all": {
+		"message": "Alle"
+	},
+	"allow": {
+		"message": "Tillat"
+	},
+	"alwaysActive": {
+		"message": "Alltid aktiv"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Alltid vis fremdriftslinje"
+	},
+	"analyzer": {
+		"message": "Analysator"
+	},
+	"appearance": {
+		"message": "Utseende"
+	},
+	"audio": {
+		"message": "Lyd"
+	},
+	"audioFormats": {
+		"message": "Lydformater"
+	},
+	"autoFullscreen": {
+		"message": "Auto-fullskjerm"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Autopause når du bytter faner"
+	},
+	"backupAndReset": {
+		"message": "Sikkerhetskopiering og tilbakestilling"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baser på systemfargevalg"
+	},
+	"belowPlayer": {
+		"message": "Nedenfor avspiller"
+	},
+	"black": {
+		"message": "Svart"
+	},
+	"blockAll": {
+		"message": "Blokker alle"
+	},
+	"blocklist": {
+		"message": "Svartelist"
+	},
+	"blue": {
+		"message": "Blå"
+	},
+	"blueGray": {
+		"message": "Blågrå"
+	},
+	"bluelight": {
+		"message": "Blålys"
+	},
+	"brown": {
+		"message": "Brun"
+	},
+	"browser": {
+		"message": "Nettleser"
+	},
+	"browserVersion": {
+		"message": "Nettleser-versjon"
+	},
+	"bubbles": {
+		"message": "Bobler"
+	},
+	"buttons": {
+		"message": "Knapper"
+	},
+	"cancel": {
+		"message": "Avbryt"
+	},
+	"categories": {
+		"message": "Kategorier"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanaler"
+	},
+	"clipboard": {
+		"message": "Utklippstavle"
+	},
+	"codecH264": {
+		"message": "H.264-kodek"
+	},
+	"collapsed": {
+		"message": "kollapset"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Kollaps av abonnementsdelene"
+	},
+	"comments": {
+		"message": "Kommentarer"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Bekreftelse før stenging"
+	},
+	"cookies": {
+		"message": "Informasjonskapslene"
+	},
+	"cores": {
+		"message": "Kjerner"
+	},
+	"cropChapterTitles": {
+		"message": "Beskjær kapitteltitler"
+	},
+	"customCss": {
+		"message": "Tilpasset CSS"
+	},
+	"customJs": {
+		"message": "Tilpasset JS"
+	},
+	"customMiniPlayer": {
+		"message": "Egendefinert miniavspiller"
+	},
+	"cyan": {
+		"message": "Blålilla"
+	},
+	"dark": {
+		"message": "Mørk"
+	},
+	"darkTheme": {
+		"message": "Mørk drakt"
+	},
+	"dateAndTime": {
+		"message": "Dato og klokkeslett"
+	},
+	"dawn": {
+		"message": "Soloppgang"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Reduser avspillingshastighet"
+	},
+	"decreaseVolume": {
+		"message": "Reduser lydstyrken"
+	},
+	"deepOrange": {
+		"message": "Dyporansje"
+	},
+	"deepPurple": {
+		"message": "Mørkelilla"
+	},
+	"defaultChannelTab": {
+		"message": "Forvalgt kanalfane"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Slett YouTube-informasjonskapsler"
+	},
+	"desert": {
+		"message": "Ørken"
+	},
+	"details": {
+		"message": "Detaljer"
+	},
+	"developerOptions": {
+		"message": "Utviklermuligheter"
+	},
+	"device": {
+		"message": "Enhet"
+	},
+	"disabled": {
+		"message": "Avslått"
+	},
+	"dislike": {
+		"message": "Mislik"
+	},
+	"donate": {
+		"message": "Doner"
+	},
+	"doNotChange": {
+		"message": "Ikke endre"
+	},
+	"draggable": {
+		"message": "Flyttbare"
+	},
+	"email": {
+		"message": "E-post"
+	},
+	"empty": {
+		"message": "Tom"
+	},
+	"enabled": {
+		"message": "Aktivert"
+	},
+	"enabledForced": {
+		"message": "Aktivert (tvunget)"
+	},
+	"expanded": {
+		"message": "Utvidet"
+	},
+	"exportSettings": {
+		"message": "Eksporter innstillinger"
+	},
+	"extension": {
+		"message": "Utvidelse"
+	},
+	"file": {
+		"message": "Fil"
+	},
+	"filters": {
+		"message": "Filtre"
+	},
+	"fitToWindow": {
+		"message": "Tilpass til vindu"
+	},
+	"footer": {
+		"message": "Bunntekst"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Tvungen avspillingshastighet"
+	},
+	"forcedTheaterMode": {
+		"message": "Tvunget teater-modus"
+	},
+	"forcedVolume": {
+		"message": "Tvunget lydstyrke"
+	},
+	"foundABug": {
+		"message": "Fant du en feil?"
+	},
+	"fullWindow": {
+		"message": "Fullt vindu"
+	},
+	"general": {
+		"message": "Generelt"
+	},
+	"geoPreference": {
+		"message": "Geo-preferanse"
+	},
+	"goToSearchBox": {
+		"message": "Gå til søkefeltet"
+	},
+	"green": {
+		"message": "Grønn"
+	},
+	"hdThumbnail": {
+		"message": "HD-miniatyrbilde"
+	},
+	"header": {
+		"message": "Overskrift"
+	},
+	"hidden": {
+		"message": "Skjult"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Skjult på videosiden"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Skjul animerte miniatyrbilder"
+	},
+	"hideAnnotations": {
+		"message": "Skjul annoteringer"
+	},
+	"hideCards": {
+		"message": "Skjul kort"
+	},
+	"hideDetails": {
+		"message": "Skjul detaljer"
+	},
+	"hideEndscreen": {
+		"message": "Skjul sluttskjerm"
+	},
+	"hideFeaturedContent": {
+		"message": "Skjul omtalt innhold"
+	},
+	"hideFooter": {
+		"message": "Skjul bunntekst"
+	},
+	"hideGradientBottom": {
+		"message": "Skjul bunn-fargeovergang"
+	},
+	"hideHomePageShorts": {
+		"message": "Fjern Shorts fra hjemmesiden"
+	},
+	"hidePlaylist": {
+		"message": "Skjul spilleliste"
+	},
+	"hideRightButtons": {
+		"message": "Skjul høyre-knapper"
+	},
+	"hideScrollForDetails": {
+		"message": "Skjul «Bla for detaljer»"
+	},
+	"hideViewsCount": {
+		"message": "Skjul visningsteller"
+	},
+	"history": {
+		"message": "Historie"
+	},
+	"home": {
+		"message": "Hjem"
+	},
+	"hover": {
+		"message": "Hold"
+	},
+	"hoverOnVideoPage": {
+		"message": "Hold musepekeren på videosiden"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Hvor lenge siden videoen ble opplastet"
+	},
+	"icons": {
+		"message": "Ikoner"
+	},
+	"iconsOnly": {
+		"message": "Kun ikoner"
+	},
+	"importSettings": {
+		"message": "Importer innstillinger"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube-ikonet på YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube-språk"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube-versjon"
+	},
+	"improveLogo": {
+		"message": "Forbedre logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Øk avspillingshastigheten"
+	},
+	"increaseVolume": {
+		"message": "Øk lydstyrken"
+	},
+	"items": {
+		"message": "Elementer"
+	},
+	"languages": {
+		"message": "Språk"
+	},
+	"legacyYoutube": {
+		"message": "Gammeldags YouTube"
+	},
+	"light": {
+		"message": "Lys"
+	},
+	"lightBlue": {
+		"message": "Lyseblå"
+	},
+	"lightGreen": {
+		"message": "Lysegrønn"
+	},
+	"like": {
+		"message": "Gunst"
+	},
+	"list": {
+		"message": "Liste"
+	},
+	"liveChat": {
+		"message": "Sanntidssludring"
+	},
+	"liveChatType": {
+		"message": "Sanntidssludringstype"
+	},
+	"loudnessNormalization": {
+		"message": "Lydstyrkenormalisering"
+	},
+	"markWatchedVideos": {
+		"message": "Marker sette videoer"
+	},
+	"mixer": {
+		"message": "Mikser"
+	},
+	"myColors": {
+		"message": "Mine farger"
+	},
+	"name": {
+		"message": "Navn"
+	},
+	"nativeMiniPlayer": {
+		"message": "Innebygd miniavspiller"
+	},
+	"new": {
+		"message": "Ny"
+	},
+	"nextVideo": {
+		"message": "Neste video"
+	},
+	"night": {
+		"message": "Natt"
+	},
+	"noActiveFeatures": {
+		"message": "Ingen aktive funksjoner"
+	},
+	"none": {
+		"message": "Ingen"
+	},
+	"noOpenVideoTabs": {
+		"message": "Ingen åpne videofaner"
+	},
+	"old": {
+		"message": "Gammel"
+	},
+	"onAllVideos": {
+		"message": "På alle videoer"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Kun aktiv på YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Kun én avspiller viser noe"
+	},
+	"onSubscribedChannels": {
+		"message": "På abonnementskanaler"
+	},
+	"orange": {
+		"message": "Oransje"
+	},
+	"other": {
+		"message": "Andre"
+	},
+	"permissions": {
+		"message": "rettigheter"
+	},
+	"pictureInPicture": {
+		"message": "Bilde-i-bilde"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Vanlig"
+	},
+	"platform": {
+		"message": "Plattform"
+	},
+	"playbackSpeed": {
+		"message": "Avspillingshastighet"
+	},
+	"player": {
+		"message": "Avspiller"
+	},
+	"playerColor": {
+		"message": "Avspiller-farge"
+	},
+	"playerSize": {
+		"message": "Avspiller-størrelse"
+	},
+	"playlist": {
+		"message": "Spilleliste"
+	},
+	"playlists": {
+		"message": "Spillelister"
+	},
+	"playPause": {
+		"message": "Spill / Pause"
+	},
+	"popupPlayer": {
+		"message": "Oppsprettsspiller"
+	},
+	"position": {
+		"message": "Posisjon"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Trykk på hvilken som helst tast, eller bruk musehjulet."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Trykk på hvilken som helst tast, eller bruk musehjulet"
+	},
+	"previousVideo": {
+		"message": "Forrige video"
+	},
+	"primaryColor": {
+		"message": "Hovedfarge"
+	},
+	"purple": {
+		"message": "Lilla"
+	},
+	"quality": {
+		"message": "Kvalitet"
+	},
+	"ram": {
+		"message": "Minne"
+	},
+	"rateUs": {
+		"message": "Rangere oss"
+	},
+	"red": {
+		"message": "Rød"
+	},
+	"redDislikeButton": {
+		"message": "Vis tommel ned i rød farge"
+	},
+	"relatedVideos": {
+		"message": "Relaterte videoer"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Fjern relaterte søkeresultater"
+	},
+	"repeat": {
+		"message": "Gjenta"
+	},
+	"reset": {
+		"message": "Tilbakestill"
+	},
+	"resetAllSettings": {
+		"message": "Tilbakestill alle instillinger"
+	},
+	"resetAllShortcuts": {
+		"message": "Tilbakestill alle snarveier"
+	},
+	"reverse": {
+		"message": "Omvendt"
+	},
+	"rotate": {
+		"message": "Roter"
+	},
+	"save": {
+		"message": "Lagre"
+	},
+	"saveAs": {
+		"message": "Lagre som"
+	},
+	"schedule": {
+		"message": "Tidsplan"
+	},
+	"screen": {
+		"message": "Skjerm"
+	},
+	"screenshot": {
+		"message": "Skjeravbildning"
+	},
+	"search": {
+		"message": "Søk"
+	},
+	"searchBarOnly": {
+		"message": "Bare søkefelt"
+	},
+	"seekBackward10Seconds": {
+		"message": "Spol 10 sekunder bakover"
+	},
+	"seekForward10Seconds": {
+		"message": "Spol 10 sekunder fremover"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Innstillinger"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Innstillinger importert"
+	},
+	"shortcuts": {
+		"message": "Snarveier"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Vis kort på musepekeren"
+	},
+	"showChannelVideosCount": {
+		"message": "Vis antall kanaler"
+	},
+	"shuffle": {
+		"message": "Tilfeldig rekkefølge"
+	},
+	"spacebar": {
+		"message": "Mellomrom"
+	},
+	"squaredUserImages": {
+		"message": "Kvadratiske brukerbilder"
+	},
+	"static": {
+		"message": "Statisk"
+	},
+	"statsForNerds": {
+		"message": "Vis statistikk for nerder"
+	},
+	"step": {
+		"message": "Steg"
+	},
+	"stop": {
+		"message": "Stopp"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stiler"
+	},
+	"subscriptions": {
+		"message": "Abonnementer"
+	},
+	"subtitles": {
+		"message": "Undertekster"
+	},
+	"sunset": {
+		"message": "Solnedgang"
+	},
+	"sunsetToSunrise": {
+		"message": "Solnedgang til soloppgang"
+	},
+	"systemPeferenceDark": {
+		"message": "Systeminnstillinger: mørk"
+	},
+	"systemPeferenceLight": {
+		"message": "Systeminnstillinger: lys"
+	},
+	"teal": {
+		"message": "Blågrønn"
+	},
+	"textColor": {
+		"message": "Tekstfarge"
+	},
+	"themes": {
+		"message": "Drakter"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Dette vil fjerne alle informasjonskapsler."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Dette vil fjerne alle YouTube-informasjonskapsler"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Dette vil tilbakestille alle innstillinger."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Dette vil tilbakestille alle snarveier"
+	},
+	"thumbnails": {
+		"message": "miniatyrbilder"
+	},
+	"timeFrom": {
+		"message": "Fra"
+	},
+	"timeTo": {
+		"message": "Til"
+	},
+	"todayAt": {
+		"message": "I dag kl."
+	},
+	"toggleCards": {
+		"message": "Veksle kort"
+	},
+	"topChat": {
+		"message": "Hovedsludring"
+	},
+	"trailerAutoplay": {
+		"message": "Trailer autospilling"
+	},
+	"translations": {
+		"message": "Oversettelser"
+	},
+	"transparentBackground": {
+		"message": "Gjennomsiktig bakgrunn"
+	},
+	"trending": {
+		"message": "Trender"
+	},
+	"tryToReloadThePage": {
+		"message": "Forsøk å laste inn siden på nytt"
+	},
+	"upNextAutoplay": {
+		"message": "«Spilles senere»-autospilling"
+	},
+	"use24HourFormat": {
+		"message": "Bruk 24-timersformat"
+	},
+	"version": {
+		"message": "Versjon"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Videobeskrivelsen vil bli utvidet for å få med navnet på kategorien"
+	},
+	"videoFormats": {
+		"message": "Video-formater"
+	},
+	"videos": {
+		"message": "Videoer"
+	},
+	"volume": {
+		"message": "Lydstyrke"
+	},
+	"watchLater": {
+		"message": "Se senere"
+	},
+	"watchTime": {
+		"message": "Tid sett"
+	},
+	"whenTabIsChanged": {
+		"message": "Når fanen endres"
+	},
+	"white": {
+		"message": "Hvit"
+	},
+	"yellow": {
+		"message": "Gul"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube-topptekst (til venstre)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube-topptekst (til høyre)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube-startside"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube-språk"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube begrenser videokvaliteten til 1080p for H.264-kodeket"
+	}
 }

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -1,1094 +1,740 @@
 {
-    "about": {
-        "message": "Om"
-    },
-    "accept": {
-        "message": "aksepter"
-    },
-    "activate": {
-        "message": "Aktiver"
-    },
-    "activateCaptions": {
-        "message": "Aktiver underteksting"
-    },
-    "activated": {
-        "message": "Aktivert"
-    },
-    "activatedFeatures": {
-        "message": "Aktiverte funksjoner"
-    },
-    "activateFullscreen": {
-        "message": "Aktiver fullskjerm"
-    },
-    "activeFeatures": {
-        "message": "Aktive funksjoner"
-    },
-    "addScrollToTop": {
-        "message": "Legg til «Rull til toppen»"
-    },
-    "ads": {
-        "message": "Reklamer"
-    },
-    "all": {
-        "message": "Alle"
-    },
-    "allow": {
-        "message": "Tillat"
-    },
-    "alwaysActive": {
-        "message": "Alltid aktiv"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Alltid vis fremdriftslinje"
-    },
-    "amber": {
-        "message": "Amber"
-    },
-    "analyzer": {
-        "message": "Analysator"
-    },
-    "animations": {
-        "message": "Animations"
-    },
-    "appearance": {
-        "message": "Utseende"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Are you sure you want to export the data?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Are you sure you want to import the data?"
-    },
-    "ARROWDOWN": {
-        "message": "⇩"
-    },
-    "ARROWLEFT": {
-        "message": "⇦"
-    },
-    "ARROWRIGHT": {
-        "message": "⇨"
-    },
-    "ARROWUP": {
-        "message": "⇧"
-    },
-    "audio": {
-        "message": "Lyd"
-    },
-    "audioFormats": {
-        "message": "Lydformater"
-    },
-    "auto": {
-        "message": "Auto"
-    },
-    "autoFullscreen": {
-        "message": "Auto-fullskjerm"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Autopause når du bytter faner"
-    },
-    "autoplay": {
-        "message": "Autoplay"
-    },
-    "avoidAv1": {
-        "message": "Avoid AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Avoid AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Avoid AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Avoid CPU rendering when possible"
-    },
-    "backgroundColor": {
-        "message": "Background color"
-    },
-    "backgroundOpacity": {
-        "message": "Background opacity"
-    },
-    "backupAndReset": {
-        "message": "Sikkerhetskopiering og tilbakestilling"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baser på systemfargevalg"
-    },
-    "belowPlayer": {
-        "message": "Nedenfor avspiller"
-    },
-    "black": {
-        "message": "Svart"
-    },
-    "blockAll": {
-        "message": "Blokker alle"
-    },
-    "blockAv1": {
-        "message": "Block AV1"
-    },
-    "blockH264": {
-        "message": "Block H.264"
-    },
-    "blocklist": {
-        "message": "Svartelist"
-    },
-    "blockMusic": {
-        "message": "Skip ads while I play music"
-    },
-    "blockVp8": {
-        "message": "Block VP8"
-    },
-    "blockVp9": {
-        "message": "Block VP9"
-    },
-    "blue": {
-        "message": "Blå"
-    },
-    "blueGray": {
-        "message": "Blågrå"
-    },
-    "bluelight": {
-        "message": "Blålys"
-    },
-    "brown": {
-        "message": "Brun"
-    },
-    "browser": {
-        "message": "Nettleser"
-    },
-    "browserVersion": {
-        "message": "Nettleser-versjon"
-    },
-    "bubbles": {
-        "message": "Bobler"
-    },
-    "bug": {
-        "message": "Bug"
-    },
-    "buttons": {
-        "message": "Knapper"
-    },
-    "cancel": {
-        "message": "Avbryt"
-    },
-    "categories": {
-        "message": "Kategorier"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanaler"
-    },
-    "characterEdgeStyle": {
-        "message": "Character edge style"
-    },
-    "clip": {
-        "message": "Clip"
-    },
-    "clipboard": {
-        "message": "Utklippstavle"
-    },
-    "codecH264": {
-        "message": "H.264-kodek"
-    },
-    "codecs": {
-        "message": "Codecs"
-    },
-    "collapsed": {
-        "message": "kollapset"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Kollaps av abonnementsdelene"
-    },
-    "comments": {
-        "message": "Kommentarer"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Bekreftelse før stenging"
-    },
-    "cookies": {
-        "message": "Informasjonskapslene"
-    },
-    "cores": {
-        "message": "Kjerner"
-    },
-    "cropChapterTitles": {
-        "message": "Beskjær kapitteltitler"
-    },
-    "custom": {
-        "message": "Custom"
-    },
-    "customCss": {
-        "message": "Tilpasset CSS"
-    },
-    "customJs": {
-        "message": "Tilpasset JS"
-    },
-    "customMiniPlayer": {
-        "message": "Egendefinert miniavspiller"
-    },
-    "cyan": {
-        "message": "Blålilla"
-    },
-    "dark": {
-        "message": "Mørk"
-    },
-    "darkTheme": {
-        "message": "Mørk drakt"
-    },
-    "dateAndTime": {
-        "message": "Dato og klokkeslett"
-    },
-    "dawn": {
-        "message": "Soloppgang"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Reduser avspillingshastighet"
-    },
-    "decreaseVolume": {
-        "message": "Reduser lydstyrken"
-    },
-    "deepOrange": {
-        "message": "Dyporansje"
-    },
-    "deepPurple": {
-        "message": "Mørkelilla"
-    },
-    "default": {
-        "message": "Default"
-    },
-    "defaultChannelTab": {
-        "message": "Forvalgt kanalfane"
-    },
-    "defaultContentCountry": {
-        "message": "Country (virtual travel)"
-    },
-    "deleteWatchedVideos": {
-        "message": "Delete watched videos"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Slett YouTube-informasjonskapsler"
-    },
-    "depressed": {
-        "message": "Depressed"
-    },
-    "description": {
-        "message": "Description"
-    },
-    "description_ext": {
-        "message": "YouTube, tidy + smart? Youtube video youtube player size youtube color ad skip speed volume channel skipper tags playlist hide"
-    },
-    "desert": {
-        "message": "Ørken"
-    },
-    "details": {
-        "message": "Detaljer"
-    },
-    "developerOptions": {
-        "message": "Utviklermuligheter"
-    },
-    "device": {
-        "message": "Enhet"
-    },
-    "dim": {
-        "message": "Dim"
-    },
-    "disabled": {
-        "message": "Avslått"
-    },
-    "dislike": {
-        "message": "Mislik"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Display day of the week"
-    },
-    "donate": {
-        "message": "Doner"
-    },
-    "doNotChange": {
-        "message": "Ikke endre"
-    },
-    "download": {
-        "message": "Download"
-    },
-    "draggable": {
-        "message": "Flyttbare"
-    },
-    "dropShadow": {
-        "message": "Drop shadow"
-    },
-    "durationWithSpeed": {
-        "message": "Show time remaining with reference to playback speed"
-    },
-    "email": {
-        "message": "E-post"
-    },
-    "empty": {
-        "message": "Tom"
-    },
-    "enabled": {
-        "message": "Aktivert"
-    },
-    "enabledForced": {
-        "message": "Aktivert (tvunget)"
-    },
-    "expanded": {
-        "message": "Utvidet"
-    },
-    "exportSettings": {
-        "message": "Eksporter innstillinger"
-    },
-    "extension": {
-        "message": "Utvidelse"
-    },
-    "file": {
-        "message": "Fil"
-    },
-    "filters": {
-        "message": "Filtre"
-    },
-    "fitToWindow": {
-        "message": "Tilpass til vindu"
-    },
-    "flash": {
-        "message": "Flash"
-    },
-    "font": {
-        "message": "Font"
-    },
-    "fontColor": {
-        "message": "Font color"
-    },
-    "fontFamily": {
-        "message": "Font family"
-    },
-    "fontOpacity": {
-        "message": "Font opacity"
-    },
-    "fontSize": {
-        "message": "Font size"
-    },
-    "footer": {
-        "message": "Bunntekst"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Tvungen avspillingshastighet"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Force playback speed even for music?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forced play video from the beginning"
-    },
-    "forcedTheaterMode": {
-        "message": "Tvunget teater-modus"
-    },
-    "forcedVolume": {
-        "message": "Tvunget lydstyrke"
-    },
-    "forceSDR": {
-        "message": "Avoid HDR, keep SDR"
-    },
-    "foundABug": {
-        "message": "Fant du en feil?"
-    },
-    "fullWindow": {
-        "message": "Fullt vindu"
-    },
-    "general": {
-        "message": "Generelt"
-    },
-    "geoPreference": {
-        "message": "Geo-preferanse"
-    },
-    "github": {
-        "message": "GitHub"
-    },
-    "googleApiKey": {
-        "message": "Google API key"
-    },
-    "goToSearchBox": {
-        "message": "Gå til søkefeltet"
-    },
-    "gpu": {
-        "message": "GPU"
-    },
-    "green": {
-        "message": "Grønn"
-    },
-    "hardwareInformation": {
-        "message": "Hardware information"
-    },
-    "hd": {
-        "message": "HD"
-    },
-    "hdThumbnail": {
-        "message": "HD-miniatyrbilde"
-    },
-    "header": {
-        "message": "Overskrift"
-    },
-    "hidden": {
-        "message": "Skjult"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Skjult på videosiden"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Skjul animerte miniatyrbilder"
-    },
-    "hideAnnotations": {
-        "message": "Skjul annoteringer"
-    },
-    "hideCards": {
-        "message": "Skjul kort"
-    },
-    "hideCategories": {
-        "message": "Hide categories"
-    },
-    "hideCommentsCount": {
-        "message": "Hide comments count"
-    },
-    "hideCountryCode": {
-        "message": "Hide country code"
-    },
-    "hideDate": {
-        "message": "Hide date"
-    },
-    "hideDetailButton": {
-        "message": "Buttons"
-    },
-    "hideDetails": {
-        "message": "Skjul detaljer"
-    },
-    "hideEndscreen": {
-        "message": "Skjul sluttskjerm"
-    },
-    "hideFeaturedContent": {
-        "message": "Skjul omtalt innhold"
-    },
-    "hideFooter": {
-        "message": "Skjul bunntekst"
-    },
-    "hideGradientBottom": {
-        "message": "Skjul bunn-fargeovergang"
-    },
-    "hideHomePageShorts": {
-        "message": "Fjern Shorts fra hjemmesiden"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Hide player controls bar"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Hide player controls bar buttons"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Hide player controls options"
-    },
-    "hidePlaylist": {
-        "message": "Skjul spilleliste"
-    },
-    "hideRightButtons": {
-        "message": "Skjul høyre-knapper"
-    },
-    "hideScrollForDetails": {
-        "message": "Skjul «Bla for detaljer»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideThumbnails": {
-        "message": "Hide thumbnails"
-    },
-    "hideViewsCount": {
-        "message": "Skjul visningsteller"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Hide voice search button"
-    },
-    "high": {
-        "message": "High"
-    },
-    "history": {
-        "message": "Historie"
-    },
-    "home": {
-        "message": "Hjem"
-    },
-    "hover": {
-        "message": "Hold"
-    },
-    "hoverOnVideoPage": {
-        "message": "Hold musepekeren på videosiden"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Hvor lenge siden videoen ble opplastet"
-    },
-    "icons": {
-        "message": "Ikoner"
-    },
-    "iconsOnly": {
-        "message": "Kun ikoner"
-    },
-    "importSettings": {
-        "message": "Importer innstillinger"
-    },
-    "improvedtubeButtons": {
-        "message": "ImprovedTube buttons"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube-ikonet på YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube-språk"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube-versjon"
-    },
-    "improveLogo": {
-        "message": "Forbedre logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Øk avspillingshastigheten"
-    },
-    "increaseVolume": {
-        "message": "Øk lydstyrken"
-    },
-    "indigo": {
-        "message": "Indigo"
-    },
-    "items": {
-        "message": "Elementer"
-    },
-    "language": {
-        "message": "Language"
-    },
-    "languages": {
-        "message": "Språk"
-    },
-    "layerAnimationScale": {
-        "message": "Layer animation scale"
-    },
-    "layout": {
-        "message": "Layout"
-    },
-    "legacyYoutube": {
-        "message": "Gammeldags YouTube"
-    },
-    "library": {
-        "message": "Library"
-    },
-    "light": {
-        "message": "Lys"
-    },
-    "lightBlue": {
-        "message": "Lyseblå"
-    },
-    "lightGreen": {
-        "message": "Lysegrønn"
-    },
-    "like": {
-        "message": "Gunst"
-    },
-    "liked": {
-        "message": "Liked"
-    },
-    "likes": {
-        "message": "Likes"
-    },
-    "lime": {
-        "message": "Lime"
-    },
-    "limitPageWidth": {
-        "message": "Limit page width"
-    },
-    "list": {
-        "message": "Liste"
-    },
-    "liveChat": {
-        "message": "Sanntidssludring"
-    },
-    "liveChatType": {
-        "message": "Sanntidssludringstype"
-    },
-    "location": {
-        "message": "Location"
-    },
-    "loop": {
-        "message": "Loop"
-    },
-    "loudnessNormalization": {
-        "message": "Lydstyrkenormalisering"
-    },
-    "low": {
-        "message": "Low"
-    },
-    "markWatchedVideos": {
-        "message": "Marker sette videoer"
-    },
-    "medium": {
-        "message": "Medium"
-    },
-    "mixer": {
-        "message": "Mikser"
-    },
-    "more": {
-        "message": "More"
-    },
-    "mostViewedChannels": {
-        "message": "Most viewed channels"
-    },
-    "moveSidebarLeft": {
-        "message": "To the left!"
-    },
-    "moveThumbnailsRight": {
-        "message": "Thumbnails to the right!"
-    },
-    "myColors": {
-        "message": "Mine farger"
-    },
-    "name": {
-        "message": "Navn"
-    },
-    "nativeMiniPlayer": {
-        "message": "Innebygd miniavspiller"
-    },
-    "new": {
-        "message": "Ny"
-    },
-    "nextVideo": {
-        "message": "Neste video"
-    },
-    "night": {
-        "message": "Natt"
-    },
-    "nightMode": {
-        "message": "Night mode"
-    },
-    "noActiveFeatures": {
-        "message": "Ingen aktive funksjoner"
-    },
-    "none": {
-        "message": "Ingen"
-    },
-    "noOpenVideoTabs": {
-        "message": "Ingen åpne videofaner"
-    },
-    "normal": {
-        "message": "Normal"
-    },
-    "ok": {
-        "message": "Ok"
-    },
-    "old": {
-        "message": "Gammel"
-    },
-    "onAllVideos": {
-        "message": "På alle videoer"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Kun aktiv på YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Kun én avspiller viser noe"
-    },
-    "onSubscribedChannels": {
-        "message": "På abonnementskanaler"
-    },
-    "openPopupPlayer": {
-        "message": "Open video/playlist in a new window"
-    },
-    "orange": {
-        "message": "Oransje"
-    },
-    "os": {
-        "message": "OS"
-    },
-    "other": {
-        "message": "Andre"
-    },
-    "outline": {
-        "message": "Outline"
-    },
-    "overlay": {
-        "message": "Overlay"
-    },
-    "permissions": {
-        "message": "rettigheter"
-    },
-    "pictureInPicture": {
-        "message": "Bilde-i-bilde"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Vanlig"
-    },
-    "platform": {
-        "message": "Plattform"
-    },
-    "playAllButton": {
-        "message": "\"Play all\" button"
-    },
-    "playbackSpeed": {
-        "message": "Avspillingshastighet"
-    },
-    "player": {
-        "message": "Avspiller"
-    },
-    "playerColor": {
-        "message": "Avspiller-farge"
-    },
-    "playerSize": {
-        "message": "Avspiller-størrelse"
-    },
-    "playlist": {
-        "message": "Spilleliste"
-    },
-    "playlists": {
-        "message": "Spillelister"
-    },
-    "playPause": {
-        "message": "Spill / Pause"
-    },
-    "popupPlayer": {
-        "message": "Oppsprettsspiller"
-    },
-    "popupWindowButtons": {
-        "message": "popup_window_buttons"
-    },
-    "position": {
-        "message": "Posisjon"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Trykk på hvilken som helst tast, eller bruk musehjulet."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Trykk på hvilken som helst tast, eller bruk musehjulet"
-    },
-    "previousVideo": {
-        "message": "Forrige video"
-    },
-    "primaryColor": {
-        "message": "Hovedfarge"
-    },
-    "purple": {
-        "message": "Lilla"
-    },
-    "quality": {
-        "message": "Kvalitet"
-    },
-    "raised": {
-        "message": "Raised"
-    },
-    "ram": {
-        "message": "Minne"
-    },
-    "rateMe": {
-        "message": "Rate me"
-    },
-    "rateUs": {
-        "message": "Rangere oss"
-    },
-    "red": {
-        "message": "Rød"
-    },
-    "redDislikeButton": {
-        "message": "Vis tommel ned i rød farge"
-    },
-    "relatedVideos": {
-        "message": "Relaterte videoer"
-    },
-    "remote": {
-        "message": "Play on TV"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Fjern relaterte søkeresultater"
-    },
-    "repeat": {
-        "message": "Gjenta"
-    },
-    "report": {
-        "message": "Report"
-    },
-    "reset": {
-        "message": "Tilbakestill"
-    },
-    "resetAllSettings": {
-        "message": "Tilbakestill alle instillinger"
-    },
-    "resetAllShortcuts": {
-        "message": "Tilbakestill alle snarveier"
-    },
-    "reverse": {
-        "message": "Omvendt"
-    },
-    "rotate": {
-        "message": "Roter"
-    },
-    "save": {
-        "message": "Lagre"
-    },
-    "saveAs": {
-        "message": "Lagre som"
-    },
-    "schedule": {
-        "message": "Tidsplan"
-    },
-    "screen": {
-        "message": "Skjerm"
-    },
-    "screenshot": {
-        "message": "Skjeravbildning"
-    },
-    "scrollBar": {
-        "message": "Scroll Bar"
-    },
-    "sd": {
-        "message": "SD"
-    },
-    "search": {
-        "message": "Søk"
-    },
-    "searchBarOnly": {
-        "message": "Bare søkefelt"
-    },
-    "seekBackward10Seconds": {
-        "message": "Spol 10 sekunder bakover"
-    },
-    "seekForward10Seconds": {
-        "message": "Spol 10 sekunder fremover"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Innstillinger"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Innstillinger importert"
-    },
-    "share": {
-        "message": "Share"
-    },
-    "shortcuts": {
-        "message": "Snarveier"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Vis kort på musepekeren"
-    },
-    "showChannelVideosCount": {
-        "message": "Vis antall kanaler"
-    },
-    "showLess": {
-        "message": "Show less"
-    },
-    "showMore": {
-        "message": "Show more"
-    },
-    "showRemainingDuration": {
-        "message": "Show video remaining duration"
-    },
-    "showVersion": {
-        "message": "Show version"
-    },
-    "shuffle": {
-        "message": "Tilfeldig rekkefølge"
-    },
-    "sidebar": {
-        "message": "Sidepanel"
-    },
-    "softwareInformation": {
-        "message": "Software information"
-    },
-    "spacebar": {
-        "message": "Mellomrom"
-    },
-    "squaredUserImages": {
-        "message": "Kvadratiske brukerbilder"
-    },
-    "static": {
-        "message": "Statisk"
-    },
-    "statsForNerds": {
-        "message": "Vis statistikk for nerder"
-    },
-    "step": {
-        "message": "Steg"
-    },
-    "stop": {
-        "message": "Stopp"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stiler"
-    },
-    "subscribe": {
-        "message": "Subscribe"
-    },
-    "subscriptions": {
-        "message": "Abonnementer"
-    },
-    "subtitles": {
-        "message": "Undertekster"
-    },
-    "sunset": {
-        "message": "Solnedgang"
-    },
-    "sunsetToSunrise": {
-        "message": "Solnedgang til soloppgang"
-    },
-    "systemPeferenceDark": {
-        "message": "Systeminnstillinger: mørk"
-    },
-    "systemPeferenceLight": {
-        "message": "Systeminnstillinger: lys"
-    },
-    "teal": {
-        "message": "Blågrønn"
-    },
-    "textColor": {
-        "message": "Tekstfarge"
-    },
-    "thanks": {
-        "message": "Thanks"
-    },
-    "themes": {
-        "message": "Drakter"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Dette vil fjerne alle informasjonskapsler."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "This will remove all watched videos."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Dette vil fjerne alle YouTube-informasjonskapsler"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Dette vil tilbakestille alle innstillinger."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Dette vil tilbakestille alle snarveier"
-    },
-    "thumbnails": {
-        "message": "miniatyrbilder "
-    },
-    "thumbnailsQuality": {
-        "message": "Thumbnails Quality"
-    },
-    "timeFrom": {
-        "message": "Fra"
-    },
-    "timeTo": {
-        "message": "Til"
-    },
-    "todayAt": {
-        "message": "I dag kl."
-    },
-    "toggleAutoplay": {
-        "message": "Toggle autoplay"
-    },
-    "toggleCards": {
-        "message": "Veksle kort"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "Hovedsludring"
-    },
-    "trackWatchedVideos": {
-        "message": "Track watched videos"
-    },
-    "trailerAutoplay": {
-        "message": "Trailer autospilling"
-    },
-    "translations": {
-        "message": "Oversettelser"
-    },
-    "transparentBackground": {
-        "message": "Gjennomsiktig bakgrunn"
-    },
-    "trending": {
-        "message": "Trender"
-    },
-    "tryToReloadThePage": {
-        "message": "Forsøk å laste inn siden på nytt"
-    },
-    "type": {
-        "message": "Type"
-    },
-    "upNextAutoplay": {
-        "message": "«Spilles senere»-autospilling"
-    },
-    "use24HourFormat": {
-        "message": "Bruk 24-timersformat"
-    },
-    "version": {
-        "message": "Versjon"
-    },
-    "video": {
-        "message": "Video"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Videobeskrivelsen vil bli utvidet for å få med navnet på kategorien"
-    },
-    "videoFormats": {
-        "message": "Video-formater"
-    },
-    "videos": {
-        "message": "Videoer"
-    },
-    "viewMode": {
-        "message": "View Mode"
-    },
-    "volume": {
-        "message": "Lydstyrke"
-    },
-    "watchLater": {
-        "message": "Se senere"
-    },
-    "watchTime": {
-        "message": "Tid sett"
-    },
-    "whenTabIsChanged": {
-        "message": "Når fanen endres"
-    },
-    "white": {
-        "message": "Hvit"
-    },
-    "windowColor": {
-        "message": "Window color"
-    },
-    "windowOpacity": {
-        "message": "Window opacity"
-    },
-    "yellow": {
-        "message": "Gul"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube-topptekst (til venstre)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube-topptekst (til høyre)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube-startside"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube-språk"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube begrenser videokvaliteten til 1080p for H.264-kodeket"
-    }
+	"about": {
+		"message": "Om"
+	},
+	"accept": {
+		"message": "aksepter"
+	},
+	"activate": {
+		"message": "Aktiver"
+	},
+	"activateCaptions": {
+		"message": "Aktiver underteksting"
+	},
+	"activated": {
+		"message": "Aktivert"
+	},
+	"activatedFeatures": {
+		"message": "Aktiverte funksjoner"
+	},
+	"activateFullscreen": {
+		"message": "Aktiver fullskjerm"
+	},
+	"activeFeatures": {
+		"message": "Aktive funksjoner"
+	},
+	"addScrollToTop": {
+		"message": "Legg til «Rull til toppen»"
+	},
+	"ads": {
+		"message": "Reklamer"
+	},
+	"all": {
+		"message": "Alle"
+	},
+	"allow": {
+		"message": "Tillat"
+	},
+	"alwaysActive": {
+		"message": "Alltid aktiv"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Alltid vis fremdriftslinje"
+	},
+	"analyzer": {
+		"message": "Analysator"
+	},
+	"appearance": {
+		"message": "Utseende"
+	},
+	"audio": {
+		"message": "Lyd"
+	},
+	"audioFormats": {
+		"message": "Lydformater"
+	},
+	"autoFullscreen": {
+		"message": "Auto-fullskjerm"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Autopause når du bytter faner"
+	},
+	"backupAndReset": {
+		"message": "Sikkerhetskopiering og tilbakestilling"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baser på systemfargevalg"
+	},
+	"belowPlayer": {
+		"message": "Nedenfor avspiller"
+	},
+	"black": {
+		"message": "Svart"
+	},
+	"blockAll": {
+		"message": "Blokker alle"
+	},
+	"blocklist": {
+		"message": "Svartelist"
+	},
+	"blue": {
+		"message": "Blå"
+	},
+	"blueGray": {
+		"message": "Blågrå"
+	},
+	"bluelight": {
+		"message": "Blålys"
+	},
+	"brown": {
+		"message": "Brun"
+	},
+	"browser": {
+		"message": "Nettleser"
+	},
+	"browserVersion": {
+		"message": "Nettleser-versjon"
+	},
+	"bubbles": {
+		"message": "Bobler"
+	},
+	"buttons": {
+		"message": "Knapper"
+	},
+	"cancel": {
+		"message": "Avbryt"
+	},
+	"categories": {
+		"message": "Kategorier"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanaler"
+	},
+	"clipboard": {
+		"message": "Utklippstavle"
+	},
+	"codecH264": {
+		"message": "H.264-kodek"
+	},
+	"collapsed": {
+		"message": "kollapset"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Kollaps av abonnementsdelene"
+	},
+	"comments": {
+		"message": "Kommentarer"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Bekreftelse før stenging"
+	},
+	"cookies": {
+		"message": "Informasjonskapslene"
+	},
+	"cores": {
+		"message": "Kjerner"
+	},
+	"cropChapterTitles": {
+		"message": "Beskjær kapitteltitler"
+	},
+	"customCss": {
+		"message": "Tilpasset CSS"
+	},
+	"customJs": {
+		"message": "Tilpasset JS"
+	},
+	"customMiniPlayer": {
+		"message": "Egendefinert miniavspiller"
+	},
+	"cyan": {
+		"message": "Blålilla"
+	},
+	"dark": {
+		"message": "Mørk"
+	},
+	"darkTheme": {
+		"message": "Mørk drakt"
+	},
+	"dateAndTime": {
+		"message": "Dato og klokkeslett"
+	},
+	"dawn": {
+		"message": "Soloppgang"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Reduser avspillingshastighet"
+	},
+	"decreaseVolume": {
+		"message": "Reduser lydstyrken"
+	},
+	"deepOrange": {
+		"message": "Dyporansje"
+	},
+	"deepPurple": {
+		"message": "Mørkelilla"
+	},
+	"defaultChannelTab": {
+		"message": "Forvalgt kanalfane"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Slett YouTube-informasjonskapsler"
+	},
+	"desert": {
+		"message": "Ørken"
+	},
+	"details": {
+		"message": "Detaljer"
+	},
+	"developerOptions": {
+		"message": "Utviklermuligheter"
+	},
+	"device": {
+		"message": "Enhet"
+	},
+	"disabled": {
+		"message": "Avslått"
+	},
+	"dislike": {
+		"message": "Mislik"
+	},
+	"donate": {
+		"message": "Doner"
+	},
+	"doNotChange": {
+		"message": "Ikke endre"
+	},
+	"draggable": {
+		"message": "Flyttbare"
+	},
+	"email": {
+		"message": "E-post"
+	},
+	"empty": {
+		"message": "Tom"
+	},
+	"enabled": {
+		"message": "Aktivert"
+	},
+	"enabledForced": {
+		"message": "Aktivert (tvunget)"
+	},
+	"expanded": {
+		"message": "Utvidet"
+	},
+	"exportSettings": {
+		"message": "Eksporter innstillinger"
+	},
+	"extension": {
+		"message": "Utvidelse"
+	},
+	"file": {
+		"message": "Fil"
+	},
+	"filters": {
+		"message": "Filtre"
+	},
+	"fitToWindow": {
+		"message": "Tilpass til vindu"
+	},
+	"footer": {
+		"message": "Bunntekst"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Tvungen avspillingshastighet"
+	},
+	"forcedTheaterMode": {
+		"message": "Tvunget teater-modus"
+	},
+	"forcedVolume": {
+		"message": "Tvunget lydstyrke"
+	},
+	"foundABug": {
+		"message": "Fant du en feil?"
+	},
+	"fullWindow": {
+		"message": "Fullt vindu"
+	},
+	"general": {
+		"message": "Generelt"
+	},
+	"geoPreference": {
+		"message": "Geo-preferanse"
+	},
+	"goToSearchBox": {
+		"message": "Gå til søkefeltet"
+	},
+	"green": {
+		"message": "Grønn"
+	},
+	"hdThumbnail": {
+		"message": "HD-miniatyrbilde"
+	},
+	"header": {
+		"message": "Overskrift"
+	},
+	"hidden": {
+		"message": "Skjult"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Skjult på videosiden"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Skjul animerte miniatyrbilder"
+	},
+	"hideAnnotations": {
+		"message": "Skjul annoteringer"
+	},
+	"hideCards": {
+		"message": "Skjul kort"
+	},
+	"hideDetails": {
+		"message": "Skjul detaljer"
+	},
+	"hideEndscreen": {
+		"message": "Skjul sluttskjerm"
+	},
+	"hideFeaturedContent": {
+		"message": "Skjul omtalt innhold"
+	},
+	"hideFooter": {
+		"message": "Skjul bunntekst"
+	},
+	"hideGradientBottom": {
+		"message": "Skjul bunn-fargeovergang"
+	},
+	"hideHomePageShorts": {
+		"message": "Fjern Shorts fra hjemmesiden"
+	},
+	"hidePlaylist": {
+		"message": "Skjul spilleliste"
+	},
+	"hideRightButtons": {
+		"message": "Skjul høyre-knapper"
+	},
+	"hideScrollForDetails": {
+		"message": "Skjul «Bla for detaljer»"
+	},
+	"hideViewsCount": {
+		"message": "Skjul visningsteller"
+	},
+	"history": {
+		"message": "Historie"
+	},
+	"home": {
+		"message": "Hjem"
+	},
+	"hover": {
+		"message": "Hold"
+	},
+	"hoverOnVideoPage": {
+		"message": "Hold musepekeren på videosiden"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Hvor lenge siden videoen ble opplastet"
+	},
+	"icons": {
+		"message": "Ikoner"
+	},
+	"iconsOnly": {
+		"message": "Kun ikoner"
+	},
+	"importSettings": {
+		"message": "Importer innstillinger"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube-ikonet på YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube-språk"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube-versjon"
+	},
+	"improveLogo": {
+		"message": "Forbedre logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Øk avspillingshastigheten"
+	},
+	"increaseVolume": {
+		"message": "Øk lydstyrken"
+	},
+	"items": {
+		"message": "Elementer"
+	},
+	"languages": {
+		"message": "Språk"
+	},
+	"legacyYoutube": {
+		"message": "Gammeldags YouTube"
+	},
+	"light": {
+		"message": "Lys"
+	},
+	"lightBlue": {
+		"message": "Lyseblå"
+	},
+	"lightGreen": {
+		"message": "Lysegrønn"
+	},
+	"like": {
+		"message": "Gunst"
+	},
+	"list": {
+		"message": "Liste"
+	},
+	"liveChat": {
+		"message": "Sanntidssludring"
+	},
+	"liveChatType": {
+		"message": "Sanntidssludringstype"
+	},
+	"loudnessNormalization": {
+		"message": "Lydstyrkenormalisering"
+	},
+	"markWatchedVideos": {
+		"message": "Marker sette videoer"
+	},
+	"mixer": {
+		"message": "Mikser"
+	},
+	"myColors": {
+		"message": "Mine farger"
+	},
+	"name": {
+		"message": "Navn"
+	},
+	"nativeMiniPlayer": {
+		"message": "Innebygd miniavspiller"
+	},
+	"new": {
+		"message": "Ny"
+	},
+	"nextVideo": {
+		"message": "Neste video"
+	},
+	"night": {
+		"message": "Natt"
+	},
+	"noActiveFeatures": {
+		"message": "Ingen aktive funksjoner"
+	},
+	"none": {
+		"message": "Ingen"
+	},
+	"noOpenVideoTabs": {
+		"message": "Ingen åpne videofaner"
+	},
+	"old": {
+		"message": "Gammel"
+	},
+	"onAllVideos": {
+		"message": "På alle videoer"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Kun aktiv på YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Kun én avspiller viser noe"
+	},
+	"onSubscribedChannels": {
+		"message": "På abonnementskanaler"
+	},
+	"orange": {
+		"message": "Oransje"
+	},
+	"other": {
+		"message": "Andre"
+	},
+	"permissions": {
+		"message": "rettigheter"
+	},
+	"pictureInPicture": {
+		"message": "Bilde-i-bilde"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Vanlig"
+	},
+	"platform": {
+		"message": "Plattform"
+	},
+	"playbackSpeed": {
+		"message": "Avspillingshastighet"
+	},
+	"player": {
+		"message": "Avspiller"
+	},
+	"playerColor": {
+		"message": "Avspiller-farge"
+	},
+	"playerSize": {
+		"message": "Avspiller-størrelse"
+	},
+	"playlist": {
+		"message": "Spilleliste"
+	},
+	"playlists": {
+		"message": "Spillelister"
+	},
+	"playPause": {
+		"message": "Spill / Pause"
+	},
+	"popupPlayer": {
+		"message": "Oppsprettsspiller"
+	},
+	"position": {
+		"message": "Posisjon"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Trykk på hvilken som helst tast, eller bruk musehjulet."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Trykk på hvilken som helst tast, eller bruk musehjulet"
+	},
+	"previousVideo": {
+		"message": "Forrige video"
+	},
+	"primaryColor": {
+		"message": "Hovedfarge"
+	},
+	"purple": {
+		"message": "Lilla"
+	},
+	"quality": {
+		"message": "Kvalitet"
+	},
+	"ram": {
+		"message": "Minne"
+	},
+	"rateUs": {
+		"message": "Rangere oss"
+	},
+	"red": {
+		"message": "Rød"
+	},
+	"redDislikeButton": {
+		"message": "Vis tommel ned i rød farge"
+	},
+	"relatedVideos": {
+		"message": "Relaterte videoer"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Fjern relaterte søkeresultater"
+	},
+	"repeat": {
+		"message": "Gjenta"
+	},
+	"reset": {
+		"message": "Tilbakestill"
+	},
+	"resetAllSettings": {
+		"message": "Tilbakestill alle instillinger"
+	},
+	"resetAllShortcuts": {
+		"message": "Tilbakestill alle snarveier"
+	},
+	"reverse": {
+		"message": "Omvendt"
+	},
+	"rotate": {
+		"message": "Roter"
+	},
+	"save": {
+		"message": "Lagre"
+	},
+	"saveAs": {
+		"message": "Lagre som"
+	},
+	"schedule": {
+		"message": "Tidsplan"
+	},
+	"screen": {
+		"message": "Skjerm"
+	},
+	"screenshot": {
+		"message": "Skjeravbildning"
+	},
+	"search": {
+		"message": "Søk"
+	},
+	"searchBarOnly": {
+		"message": "Bare søkefelt"
+	},
+	"seekBackward10Seconds": {
+		"message": "Spol 10 sekunder bakover"
+	},
+	"seekForward10Seconds": {
+		"message": "Spol 10 sekunder fremover"
+	},
+	"settings": {
+		"message": "Innstillinger"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Innstillinger importert"
+	},
+	"shortcuts": {
+		"message": "Snarveier"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Vis kort på musepekeren"
+	},
+	"showChannelVideosCount": {
+		"message": "Vis antall kanaler"
+	},
+	"shuffle": {
+		"message": "Tilfeldig rekkefølge"
+	},
+	"spacebar": {
+		"message": "Mellomrom"
+	},
+	"squaredUserImages": {
+		"message": "Kvadratiske brukerbilder"
+	},
+	"static": {
+		"message": "Statisk"
+	},
+	"statsForNerds": {
+		"message": "Vis statistikk for nerder"
+	},
+	"step": {
+		"message": "Steg"
+	},
+	"stop": {
+		"message": "Stopp"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stiler"
+	},
+	"subscriptions": {
+		"message": "Abonnementer"
+	},
+	"subtitles": {
+		"message": "Undertekster"
+	},
+	"sunset": {
+		"message": "Solnedgang"
+	},
+	"sunsetToSunrise": {
+		"message": "Solnedgang til soloppgang"
+	},
+	"systemPeferenceDark": {
+		"message": "Systeminnstillinger: mørk"
+	},
+	"systemPeferenceLight": {
+		"message": "Systeminnstillinger: lys"
+	},
+	"teal": {
+		"message": "Blågrønn"
+	},
+	"textColor": {
+		"message": "Tekstfarge"
+	},
+	"themes": {
+		"message": "Drakter"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Dette vil fjerne alle informasjonskapsler."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Dette vil fjerne alle YouTube-informasjonskapsler"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Dette vil tilbakestille alle innstillinger."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Dette vil tilbakestille alle snarveier"
+	},
+	"thumbnails": {
+		"message": "miniatyrbilder"
+	},
+	"timeFrom": {
+		"message": "Fra"
+	},
+	"timeTo": {
+		"message": "Til"
+	},
+	"todayAt": {
+		"message": "I dag kl."
+	},
+	"toggleCards": {
+		"message": "Veksle kort"
+	},
+	"topChat": {
+		"message": "Hovedsludring"
+	},
+	"trailerAutoplay": {
+		"message": "Trailer autospilling"
+	},
+	"translations": {
+		"message": "Oversettelser"
+	},
+	"transparentBackground": {
+		"message": "Gjennomsiktig bakgrunn"
+	},
+	"trending": {
+		"message": "Trender"
+	},
+	"tryToReloadThePage": {
+		"message": "Forsøk å laste inn siden på nytt"
+	},
+	"upNextAutoplay": {
+		"message": "«Spilles senere»-autospilling"
+	},
+	"use24HourFormat": {
+		"message": "Bruk 24-timersformat"
+	},
+	"version": {
+		"message": "Versjon"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Videobeskrivelsen vil bli utvidet for å få med navnet på kategorien"
+	},
+	"videoFormats": {
+		"message": "Video-formater"
+	},
+	"videos": {
+		"message": "Videoer"
+	},
+	"volume": {
+		"message": "Lydstyrke"
+	},
+	"watchLater": {
+		"message": "Se senere"
+	},
+	"watchTime": {
+		"message": "Tid sett"
+	},
+	"whenTabIsChanged": {
+		"message": "Når fanen endres"
+	},
+	"white": {
+		"message": "Hvit"
+	},
+	"yellow": {
+		"message": "Gul"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube-topptekst (til venstre)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube-topptekst (til høyre)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube-startside"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube-språk"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube begrenser videokvaliteten til 1080p for H.264-kodeket"
+	}
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -1,914 +1,914 @@
 {
-    "about": {
-        "message": "Over"
-    },
-    "accept": {
-        "message": "Accepteren"
-    },
-    "activate": {
-        "message": "Activeren"
-    },
-    "activateCaptions": {
-        "message": "Activeer bijschriften"
-    },
-    "activated": {
-        "message": "Geactiveerd"
-    },
-    "activatedFeatures": {
-        "message": "Geactiveerde features"
-    },
-    "activateFullscreen": {
-        "message": "Activeer volledig scherm"
-    },
-    "activeFeatures": {
-        "message": "Actieve features"
-    },
-    "addScrollToTop": {
-        "message": "Voeg «Scroll to top» toe"
-    },
-    "ads": {
-        "message": "Reclames"
-    },
-    "all": {
-        "message": "Alles"
-    },
-    "allow": {
-        "message": "Toestaan"
-    },
-    "alwaysActive": {
-        "message": "Altijd actief"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Altijd voortgangsbalk laten zien"
-    },
-    "analyzer": {
-        "message": "Analyse"
-    },
-    "appearance": {
-        "message": "Uiterlijk"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Weet je zeker dat je deze data wilt exporteren?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Weet je zeker dat je deze wilt importeren? "
-    },
-    "audio": {
-        "message": "Geluid"
-    },
-    "audioFormats": {
-        "message": "Geluidsformaten"
-    },
-    "auto": {
-        "message": "Automatisch"
-    },
-    "autoFullscreen": {
-        "message": "Automatisch naar volledig scherm"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Automatisch pauzeren bij het wisselen van tabbladen"
-    },
-    "autoplay": {
-        "message": "Automatisch afspelen"
-    },
-    "backgroundColor": {
-        "message": "Achtergrondkleur"
-    },
-    "backgroundOpacity": {
-        "message": "Doorzichtigheid achtergrond"
-    },
-    "backupAndReset": {
-        "message": "Backup maken & resetten"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baseer op kleurenschema van systeem"
-    },
-    "belowPlayer": {
-        "message": "Onder de speler"
-    },
-    "black": {
-        "message": "Zwart"
-    },
-    "blockAll": {
-        "message": "Alles blokkeren"
-    },
-    "blocklist": {
-        "message": "Zwarte lijst"
-    },
-    "blockMusic": {
-        "message": "Blokkeer muziek"
-    },
-    "blue": {
-        "message": "Blauw"
-    },
-    "blueGray": {
-        "message": "Blauwgrijs"
-    },
-    "bluelight": {
-        "message": "Lichtblauw"
-    },
-    "brown": {
-        "message": "Bruin"
-    },
-    "browserVersion": {
-        "message": "Browserversie"
-    },
-    "bubbles": {
-        "message": "Bubbels"
-    },
-    "buttons": {
-        "message": "Knoppen"
-    },
-    "cancel": {
-        "message": "Annuleren"
-    },
-    "categories": {
-        "message": "Categorieën"
-    },
-    "channel": {
-        "message": "Kanaal"
-    },
-    "channels": {
-        "message": "Kanalen"
-    },
-    "characterEdgeStyle": {
-        "message": "Stijl omlijning letters"
-    },
-    "clipboard": {
-        "message": "Klembord"
-    },
-    "codecH264": {
-        "message": "Encoderen in H.264"
-    },
-    "collapsed": {
-        "message": "Ingeklapt"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Uitklappen van abonneesecties"
-    },
-    "comments": {
-        "message": "Reacties"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Bevestiging voor sluiten"
-    },
-    "cores": {
-        "message": "Kernen"
-    },
-    "cropChapterTitles": {
-        "message": "Schrap hoofdstuktitels"
-    },
-    "custom": {
-        "message": "Aangepast"
-    },
-    "customCss": {
-        "message": "Aangepaste CSS"
-    },
-    "customJs": {
-        "message": "Aangepaste JS"
-    },
-    "customMiniPlayer": {
-        "message": "Aangepaste MiniPlayer"
-    },
-    "cyan": {
-        "message": "Cyaan"
-    },
-    "dark": {
-        "message": "Donker"
-    },
-    "darkTheme": {
-        "message": "Donker thema"
-    },
-    "dateAndTime": {
-        "message": "Datum & tijd"
-    },
-    "dawn": {
-        "message": "Morgenrood"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Verminder afspeelsnelheid"
-    },
-    "decreaseVolume": {
-        "message": "Verminder volume"
-    },
-    "deepOrange": {
-        "message": "Donkeroranje"
-    },
-    "deepPurple": {
-        "message": "Donkerpaars"
-    },
-    "default": {
-        "message": "Standaard"
-    },
-    "defaultChannelTab": {
-        "message": "Standaard kanaaltabblad"
-    },
-    "defaultContentCountry": {
-        "message": "Standaardland voor inhoud"
-    },
-    "deleteWatchedVideos": {
-        "message": "Verwijder bekeken video's"
-    },
-    "deleteYoutubeCookies": {
-        "message": "YouTube-cookies verwijderen"
-    },
-    "depressed": {
-        "message": "Uitgedrukt"
-    },
-    "description_ext": {
-        "message": "Maak YouTube opgeruimd+slim! YouTube video kleur advertentie skippen overslaan volume snelheid kanaal gereedschap stijl HD advertenties adblock adblocker tags zoektermen afspeelijsten"
-    },
-    "desert": {
-        "message": "Woestijn"
-    },
-    "developerOptions": {
-        "message": "Ontwikkelaarsopties"
-    },
-    "device": {
-        "message": "Apparaat"
-    },
-    "dim": {
-        "message": "Dimmen"
-    },
-    "disabled": {
-        "message": "Uitgeschakeld"
-    },
-    "dislike": {
-        "message": "Niet leuk vinden"
-    },
-    "donate": {
-        "message": "Doneer"
-    },
-    "doNotChange": {
-        "message": "Niet aanpassen"
-    },
-    "draggable": {
-        "message": "Sleepbaar"
-    },
-    "dropShadow": {
-        "message": "Toon Schaduw"
-    },
-    "email": {
-        "message": "E-mailadres"
-    },
-    "empty": {
-        "message": "Leeg"
-    },
-    "enabled": {
-        "message": "Ingeschakeld"
-    },
-    "enabledForced": {
-        "message": "Ingeschakeld (geforceerd)"
-    },
-    "expanded": {
-        "message": "Uitgeklapt"
-    },
-    "exportSettings": {
-        "message": "Instellingen exporteren"
-    },
-    "extension": {
-        "message": "Extensie"
-    },
-    "file": {
-        "message": "Bestand"
-    },
-    "fitToWindow": {
-        "message": "Aanpassen aan vensterbreedte"
-    },
-    "flash": {
-        "message": "Flits"
-    },
-    "font": {
-        "message": "Lettertype"
-    },
-    "fontColor": {
-        "message": "Kleur lettertype"
-    },
-    "fontFamily": {
-        "message": "Lettertype-familie"
-    },
-    "fontOpacity": {
-        "message": "Doorzichtigheid lettertype"
-    },
-    "fontSize": {
-        "message": "Lettergrootte"
-    },
-    "footer": {
-        "message": "Voettekst"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Forceer afspeelsnelheid"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forceer video's af te spelen vanaf het begin"
-    },
-    "forcedTheaterMode": {
-        "message": "Forceer Theatermodus"
-    },
-    "forcedVolume": {
-        "message": "Forceer volume"
-    },
-    "forceSDR": {
-        "message": "Forceer SDR"
-    },
-    "foundABug": {
-        "message": "Heb je een bug gevonden?"
-    },
-    "fullWindow": {
-        "message": "Volledig scherm"
-    },
-    "general": {
-        "message": "Algemeen"
-    },
-    "googleApiKey": {
-        "message": "Google API-key"
-    },
-    "goToSearchBox": {
-        "message": "Ga naar de zoekbalk"
-    },
-    "green": {
-        "message": "Groen"
-    },
-    "hdThumbnail": {
-        "message": "HD-miniatuurvoorbeeld"
-    },
-    "header": {
-        "message": "Kop"
-    },
-    "hidden": {
-        "message": "Verborgen"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Verborgen op videopagina"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Verberg geanimeerde miniatuurvoorbeelden"
-    },
-    "hideAnnotations": {
-        "message": "Verberg annotaties"
-    },
-    "hideCards": {
-        "message": "Verberg kaarten"
-    },
-    "hideCountryCode": {
-        "message": "Verberg landcode"
-    },
-    "hideDate": {
-        "message": "Verberg datum"
-    },
-    "hideDetails": {
-        "message": "Verberg details"
-    },
-    "hideEndscreen": {
-        "message": "Verberg eindscherm"
-    },
-    "hideFeaturedContent": {
-        "message": "Verberg uitgelichte inhoud"
-    },
-    "hideFooter": {
-        "message": "Verberg voettekst"
-    },
-    "hideGradientBottom": {
-        "message": "Verberg Gradient Onderkant"
-    },
-    "hideHomePageShorts": {
-        "message": "Verwijder Shorts van de startpagina"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Verberg afspeelbalk"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Verberg knoppen voor afspeelcontrole"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Verberg opties voor afspeelbalk"
-    },
-    "hidePlaylist": {
-        "message": "Verberg afspeellijst"
-    },
-    "hideRightButtons": {
-        "message": "Verberg knoppen rechterkant"
-    },
-    "hideScrollForDetails": {
-        "message": "Verberg «Scrollen voor meer details»"
-    },
-    "hideSkipOverlay": {
-        "message": "Verberg knop voor overslaan omslag"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Verberg miniatuurafbeeldingen omslag"
-    },
-    "hideThumbnails": {
-        "message": "Verberg miniatuurafbeeldingen"
-    },
-    "hideViewsCount": {
-        "message": "Verberg aantal afgespeeld"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Verberg zoekknop via stem"
-    },
-    "high": {
-        "message": "Hoog"
-    },
-    "history": {
-        "message": "Geschiedenis"
-    },
-    "home": {
-        "message": "Thuis"
-    },
-    "hover": {
-        "message": "Overzweven met cursor"
-    },
-    "hoverOnVideoPage": {
-        "message": "Overzweven met cursor op videopagina"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Toon uploaddatum"
-    },
-    "icons": {
-        "message": "Pictogrammen"
-    },
-    "iconsOnly": {
-        "message": "Alleen pictogrammen"
-    },
-    "importSettings": {
-        "message": "Importeer instellingen"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube-icoon instellen voor YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Taal voor ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube-versie"
-    },
-    "improveLogo": {
-        "message": "YouTube-logo verbeteren"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Verhoog afspeelsnelheid"
-    },
-    "increaseVolume": {
-        "message": "Verhoog volume"
-    },
-    "language": {
-        "message": "Taal"
-    },
-    "languages": {
-        "message": "Talen"
-    },
-    "legacyYoutube": {
-        "message": "Klassieke YouTube-uiterlijk"
-    },
-    "library": {
-        "message": "Bibliotheek"
-    },
-    "light": {
-        "message": "Licht"
-    },
-    "lightBlue": {
-        "message": "Lichtblauw"
-    },
-    "lightGreen": {
-        "message": "Lichtgroen"
-    },
-    "like": {
-        "message": "Vind ik leuk"
-    },
-    "liked": {
-        "message": "Leuk gevonden"
-    },
-    "lime": {
-        "message": "Limoen"
-    },
-    "limitPageWidth": {
-        "message": "Limiteer paginabreedte"
-    },
-    "list": {
-        "message": "Lijst"
-    },
-    "liveChat": {
-        "message": "Live Chat"
-    },
-    "liveChatType": {
-        "message": "Type Live Chat"
-    },
-    "location": {
-        "message": "Locatie"
-    },
-    "loop": {
-        "message": "Lus"
-    },
-    "loudnessNormalization": {
-        "message": "Volume normaliseren"
-    },
-    "markWatchedVideos": {
-        "message": "Markeer bekeken video's"
-    },
-    "moveSidebarLeft": {
-        "message": "Verplaats zijbalk naar links"
-    },
-    "moveThumbnailsRight": {
-        "message": "Verplaats miniatuurafbeeldingen naar links"
-    },
-    "myColors": {
-        "message": "Mijn kleuren"
-    },
-    "name": {
-        "message": "Naam"
-    },
-    "nativeMiniPlayer": {
-        "message": "Ingebouwde minispeler"
-    },
-    "new": {
-        "message": "Nieuw"
-    },
-    "nextVideo": {
-        "message": "Volgende video afspelen"
-    },
-    "night": {
-        "message": "Nacht"
-    },
-    "noActiveFeatures": {
-        "message": "Geen actieve functies"
-    },
-    "none": {
-        "message": "Geen"
-    },
-    "noOpenVideoTabs": {
-        "message": "Geen openstaande videotabbladen"
-    },
-    "normal": {
-        "message": "Normaal"
-    },
-    "ok": {
-        "message": "OK"
-    },
-    "old": {
-        "message": "Oud"
-    },
-    "onAllVideos": {
-        "message": "Bij alle videos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Alleen actief op YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Slechts één actieve speler toestaan"
-    },
-    "onSubscribedChannels": {
-        "message": "Op geabonneerde kanalen"
-    },
-    "orange": {
-        "message": "Oranje"
-    },
-    "os": {
-        "message": "Besturingssysteem"
-    },
-    "other": {
-        "message": "Anders"
-    },
-    "outline": {
-        "message": "Uitlijning"
-    },
-    "overlay": {
-        "message": "Omslag"
-    },
-    "permissions": {
-        "message": "Machtigingen"
-    },
-    "pink": {
-        "message": "Roze"
-    },
-    "plain": {
-        "message": "Vlakte"
-    },
-    "playAllButton": {
-        "message": "\"Alles afspelen\"-knop"
-    },
-    "playbackSpeed": {
-        "message": "Afspeelsnelheid"
-    },
-    "player": {
-        "message": "Speler"
-    },
-    "playerColor": {
-        "message": "Spelerkleur"
-    },
-    "playerSize": {
-        "message": "Spelergrootte"
-    },
-    "playlist": {
-        "message": "Afspeellijst"
-    },
-    "playlists": {
-        "message": "Afspeellijsten"
-    },
-    "playPause": {
-        "message": "Video afspelen/pauzeren"
-    },
-    "popupPlayer": {
-        "message": "Pop-upspeler"
-    },
-    "position": {
-        "message": "Positie"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Druk op een toets of scroll met muiswiel."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Druk op een toets of gebruik muiswiel"
-    },
-    "previousVideo": {
-        "message": "Vorige video afspelen"
-    },
-    "primaryColor": {
-        "message": "Primaire kleur"
-    },
-    "purple": {
-        "message": "Paars"
-    },
-    "quality": {
-        "message": "Kwaliteit"
-    },
-    "raised": {
-        "message": "Opgeklapt"
-    },
-    "ram": {
-        "message": "Geheugen (RAM)"
-    },
-    "rateMe": {
-        "message": "Beoordeel mij"
-    },
-    "rateUs": {
-        "message": "Beoordeel ons"
-    },
-    "red": {
-        "message": "Rood"
-    },
-    "redDislikeButton": {
-        "message": "Laat Vind ik niet leuk-knop zien in het rood"
-    },
-    "relatedVideos": {
-        "message": "Gerelateerde video's"
-    },
-    "remote": {
-        "message": "Speel af op TV"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Verwijder resultaten van gerelateerde videos"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Verwijder Shorts-reel uit de zoekresultaten"
-    },
-    "repeat": {
-        "message": "Herhalen"
-    },
-    "reset": {
-        "message": "Herstel"
-    },
-    "resetAllSettings": {
-        "message": "Standaardwaarden herstellen"
-    },
-    "resetAllShortcuts": {
-        "message": "Herstel alle snelkoppelingen"
-    },
-    "reverse": {
-        "message": "Omdraaien"
-    },
-    "rotate": {
-        "message": "Draaien"
-    },
-    "save": {
-        "message": "Opslaan"
-    },
-    "saveAs": {
-        "message": "Opslaan als"
-    },
-    "schedule": {
-        "message": "Schema"
-    },
-    "screen": {
-        "message": "Beeldscherm"
-    },
-    "screenshot": {
-        "message": "Schermafbeelding"
-    },
-    "scrollBar": {
-        "message": "Scrollbalk"
-    },
-    "search": {
-        "message": "Zoeken"
-    },
-    "searchBarOnly": {
-        "message": "Alleen zoekbalk"
-    },
-    "seekBackward10Seconds": {
-        "message": "Ga 10 seconden terug"
-    },
-    "seekForward10Seconds": {
-        "message": "Ga 10 seconden naar voren"
-    },
-    "seekNextChapter": {
-        "message": "Ga naar volgend hoofdstuk"
-    },
-    "seekPreviousChapter": {
-        "message": "Ga naar vorig hoofdstuk"
-    },
-    "settings": {
-        "message": "Instellingen"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Instellingen succesvol geïmporteerd"
-    },
-    "shortcuts": {
-        "message": "Sneltoetsen"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Laat infokaarten zien onder muisaanwijzer"
-    },
-    "showChannelVideosCount": {
-        "message": "Aantal kanaalvideo's tonen"
-    },
-    "showLess": {
-        "message": "Minder zien"
-    },
-    "showMore": {
-        "message": "Meer zien"
-    },
-    "showRemainingDuration": {
-        "message": "Laat resterende afspeelduur zien"
-    },
-    "shuffle": {
-        "message": "Willekeurig"
-    },
-    "sidebar": {
-        "message": "Zijbalk"
-    },
-    "spacebar": {
-        "message": "Spatiebalk"
-    },
-    "squaredUserImages": {
-        "message": "Vierkante profielfoto's"
-    },
-    "static": {
-        "message": "Statisch"
-    },
-    "statsForNerds": {
-        "message": "Toon statistieken voor Nerds"
-    },
-    "step": {
-        "message": "Stap"
-    },
-    "style": {
-        "message": "Stijl"
-    },
-    "styles": {
-        "message": "Stijlen"
-    },
-    "subscribe": {
-        "message": "Abonneer"
-    },
-    "subscriptions": {
-        "message": "Abonnementen"
-    },
-    "subtitles": {
-        "message": "Ondertiteling"
-    },
-    "sunset": {
-        "message": "Zonsondergang"
-    },
-    "sunsetToSunrise": {
-        "message": "Zonsondergang tot zonsopkomst"
-    },
-    "systemPeferenceDark": {
-        "message": "Systeemvoorkeur: donker"
-    },
-    "systemPeferenceLight": {
-        "message": "Systeemvoorkeur: licht"
-    },
-    "teal": {
-        "message": "Groenblauw"
-    },
-    "textColor": {
-        "message": "Tekstkleur"
-    },
-    "themes": {
-        "message": "Thema's"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Dit verwijdert alle cookies."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Dit verwijdert alle YouTube-cookies"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Dit wist alle instellingen."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Dit wist alle snelkoppelingen"
-    },
-    "thumbnails": {
-        "message": "Miniatuurvoorbeelden"
-    },
-    "thumbnailsQuality": {
-        "message": "Kwaliteit miniatuurvoorbeelden"
-    },
-    "timeFrom": {
-        "message": "Tijd vanaf"
-    },
-    "timeTo": {
-        "message": "Tijd tot"
-    },
-    "todayAt": {
-        "message": "Vandaag om"
-    },
-    "toggleAutoplay": {
-        "message": "Automatisch afspelen aanzetten"
-    },
-    "toggleCards": {
-        "message": "Infokaarten aanzetten"
-    },
-    "toggleControls": {
-        "message": "Controleknoppen aanzetten"
-    },
-    "topChat": {
-        "message": "Top-chat"
-    },
-    "trackWatchedVideos": {
-        "message": "Houd afgespeelde video's bij"
-    },
-    "trailerAutoplay": {
-        "message": "Automatisch afspelen van trailers"
-    },
-    "translations": {
-        "message": "vertalingen"
-    },
-    "transparentBackground": {
-        "message": "Doorzichtige achtergrond"
-    },
-    "tryToReloadThePage": {
-        "message": "Probeer de pagina te herladen"
-    },
-    "type": {
-        "message": "Soort"
-    },
-    "upNextAutoplay": {
-        "message": "Volgende in wachtrij automatisch afspelen"
-    },
-    "use24HourFormat": {
-        "message": "24-uursnotatie gebruiken"
-    },
-    "version": {
-        "message": "Versie"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "De video-omschrijving wordt uitgeklapt om de naam van de categorie te verkrijgen"
-    },
-    "videoFormats": {
-        "message": "Videoformaten"
-    },
-    "videos": {
-        "message": "Video's"
-    },
-    "viewMode": {
-        "message": "Afspeelmodus"
-    },
-    "watchLater": {
-        "message": "Later bekijken"
-    },
-    "watchTime": {
-        "message": "Tijd van bekijken"
-    },
-    "whenTabIsChanged": {
-        "message": "Wanneer het tabblad is veranderd"
-    },
-    "white": {
-        "message": "Wit"
-    },
-    "windowColor": {
-        "message": "Vensterkleur"
-    },
-    "windowOpacity": {
-        "message": "Doorzichtigheid venster"
-    },
-    "yellow": {
-        "message": "Geel"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube-kop (links)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube-kop (rechts)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube-startpagina"
-    },
-    "youtubeLanguage": {
-        "message": "Taal van YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limiteert videokwaliteit tot 1080p voor H.264 codec"
-    }
+	"about": {
+		"message": "Over"
+	},
+	"accept": {
+		"message": "Accepteren"
+	},
+	"activate": {
+		"message": "Activeren"
+	},
+	"activateCaptions": {
+		"message": "Activeer bijschriften"
+	},
+	"activated": {
+		"message": "Geactiveerd"
+	},
+	"activatedFeatures": {
+		"message": "Geactiveerde features"
+	},
+	"activateFullscreen": {
+		"message": "Activeer volledig scherm"
+	},
+	"activeFeatures": {
+		"message": "Actieve features"
+	},
+	"addScrollToTop": {
+		"message": "Voeg «Scroll to top» toe"
+	},
+	"ads": {
+		"message": "Reclames"
+	},
+	"all": {
+		"message": "Alles"
+	},
+	"allow": {
+		"message": "Toestaan"
+	},
+	"alwaysActive": {
+		"message": "Altijd actief"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Altijd voortgangsbalk laten zien"
+	},
+	"analyzer": {
+		"message": "Analyse"
+	},
+	"appearance": {
+		"message": "Uiterlijk"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Weet je zeker dat je deze data wilt exporteren?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Weet je zeker dat je deze wilt importeren?"
+	},
+	"audio": {
+		"message": "Geluid"
+	},
+	"audioFormats": {
+		"message": "Geluidsformaten"
+	},
+	"auto": {
+		"message": "Automatisch"
+	},
+	"autoFullscreen": {
+		"message": "Automatisch naar volledig scherm"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Automatisch pauzeren bij het wisselen van tabbladen"
+	},
+	"autoplay": {
+		"message": "Automatisch afspelen"
+	},
+	"backgroundColor": {
+		"message": "Achtergrondkleur"
+	},
+	"backgroundOpacity": {
+		"message": "Doorzichtigheid achtergrond"
+	},
+	"backupAndReset": {
+		"message": "Backup maken & resetten"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baseer op kleurenschema van systeem"
+	},
+	"belowPlayer": {
+		"message": "Onder de speler"
+	},
+	"black": {
+		"message": "Zwart"
+	},
+	"blockAll": {
+		"message": "Alles blokkeren"
+	},
+	"blocklist": {
+		"message": "Zwarte lijst"
+	},
+	"blockMusic": {
+		"message": "Blokkeer muziek"
+	},
+	"blue": {
+		"message": "Blauw"
+	},
+	"blueGray": {
+		"message": "Blauwgrijs"
+	},
+	"bluelight": {
+		"message": "Lichtblauw"
+	},
+	"brown": {
+		"message": "Bruin"
+	},
+	"browserVersion": {
+		"message": "Browserversie"
+	},
+	"bubbles": {
+		"message": "Bubbels"
+	},
+	"buttons": {
+		"message": "Knoppen"
+	},
+	"cancel": {
+		"message": "Annuleren"
+	},
+	"categories": {
+		"message": "Categorieën"
+	},
+	"channel": {
+		"message": "Kanaal"
+	},
+	"channels": {
+		"message": "Kanalen"
+	},
+	"characterEdgeStyle": {
+		"message": "Stijl omlijning letters"
+	},
+	"clipboard": {
+		"message": "Klembord"
+	},
+	"codecH264": {
+		"message": "Encoderen in H.264"
+	},
+	"collapsed": {
+		"message": "Ingeklapt"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Uitklappen van abonneesecties"
+	},
+	"comments": {
+		"message": "Reacties"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Bevestiging voor sluiten"
+	},
+	"cores": {
+		"message": "Kernen"
+	},
+	"cropChapterTitles": {
+		"message": "Schrap hoofdstuktitels"
+	},
+	"custom": {
+		"message": "Aangepast"
+	},
+	"customCss": {
+		"message": "Aangepaste CSS"
+	},
+	"customJs": {
+		"message": "Aangepaste JS"
+	},
+	"customMiniPlayer": {
+		"message": "Aangepaste MiniPlayer"
+	},
+	"cyan": {
+		"message": "Cyaan"
+	},
+	"dark": {
+		"message": "Donker"
+	},
+	"darkTheme": {
+		"message": "Donker thema"
+	},
+	"dateAndTime": {
+		"message": "Datum & tijd"
+	},
+	"dawn": {
+		"message": "Morgenrood"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Verminder afspeelsnelheid"
+	},
+	"decreaseVolume": {
+		"message": "Verminder volume"
+	},
+	"deepOrange": {
+		"message": "Donkeroranje"
+	},
+	"deepPurple": {
+		"message": "Donkerpaars"
+	},
+	"default": {
+		"message": "Standaard"
+	},
+	"defaultChannelTab": {
+		"message": "Standaard kanaaltabblad"
+	},
+	"defaultContentCountry": {
+		"message": "Standaardland voor inhoud"
+	},
+	"deleteWatchedVideos": {
+		"message": "Verwijder bekeken video's"
+	},
+	"deleteYoutubeCookies": {
+		"message": "YouTube-cookies verwijderen"
+	},
+	"depressed": {
+		"message": "Uitgedrukt"
+	},
+	"description_ext": {
+		"message": "Maak YouTube opgeruimd+slim! YouTube video kleur advertentie skippen overslaan volume snelheid kanaal gereedschap stijl HD advertenties adblock adblocker tags zoektermen afspeelijsten"
+	},
+	"desert": {
+		"message": "Woestijn"
+	},
+	"developerOptions": {
+		"message": "Ontwikkelaarsopties"
+	},
+	"device": {
+		"message": "Apparaat"
+	},
+	"dim": {
+		"message": "Dimmen"
+	},
+	"disabled": {
+		"message": "Uitgeschakeld"
+	},
+	"dislike": {
+		"message": "Niet leuk vinden"
+	},
+	"donate": {
+		"message": "Doneer"
+	},
+	"doNotChange": {
+		"message": "Niet aanpassen"
+	},
+	"draggable": {
+		"message": "Sleepbaar"
+	},
+	"dropShadow": {
+		"message": "Toon Schaduw"
+	},
+	"email": {
+		"message": "E-mailadres"
+	},
+	"empty": {
+		"message": "Leeg"
+	},
+	"enabled": {
+		"message": "Ingeschakeld"
+	},
+	"enabledForced": {
+		"message": "Ingeschakeld (geforceerd)"
+	},
+	"expanded": {
+		"message": "Uitgeklapt"
+	},
+	"exportSettings": {
+		"message": "Instellingen exporteren"
+	},
+	"extension": {
+		"message": "Extensie"
+	},
+	"file": {
+		"message": "Bestand"
+	},
+	"fitToWindow": {
+		"message": "Aanpassen aan vensterbreedte"
+	},
+	"flash": {
+		"message": "Flits"
+	},
+	"font": {
+		"message": "Lettertype"
+	},
+	"fontColor": {
+		"message": "Kleur lettertype"
+	},
+	"fontFamily": {
+		"message": "Lettertype-familie"
+	},
+	"fontOpacity": {
+		"message": "Doorzichtigheid lettertype"
+	},
+	"fontSize": {
+		"message": "Lettergrootte"
+	},
+	"footer": {
+		"message": "Voettekst"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Forceer afspeelsnelheid"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Forceer video's af te spelen vanaf het begin"
+	},
+	"forcedTheaterMode": {
+		"message": "Forceer Theatermodus"
+	},
+	"forcedVolume": {
+		"message": "Forceer volume"
+	},
+	"forceSDR": {
+		"message": "Forceer SDR"
+	},
+	"foundABug": {
+		"message": "Heb je een bug gevonden?"
+	},
+	"fullWindow": {
+		"message": "Volledig scherm"
+	},
+	"general": {
+		"message": "Algemeen"
+	},
+	"googleApiKey": {
+		"message": "Google API-key"
+	},
+	"goToSearchBox": {
+		"message": "Ga naar de zoekbalk"
+	},
+	"green": {
+		"message": "Groen"
+	},
+	"hdThumbnail": {
+		"message": "HD-miniatuurvoorbeeld"
+	},
+	"header": {
+		"message": "Kop"
+	},
+	"hidden": {
+		"message": "Verborgen"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Verborgen op videopagina"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Verberg geanimeerde miniatuurvoorbeelden"
+	},
+	"hideAnnotations": {
+		"message": "Verberg annotaties"
+	},
+	"hideCards": {
+		"message": "Verberg kaarten"
+	},
+	"hideCountryCode": {
+		"message": "Verberg landcode"
+	},
+	"hideDate": {
+		"message": "Verberg datum"
+	},
+	"hideDetails": {
+		"message": "Verberg details"
+	},
+	"hideEndscreen": {
+		"message": "Verberg eindscherm"
+	},
+	"hideFeaturedContent": {
+		"message": "Verberg uitgelichte inhoud"
+	},
+	"hideFooter": {
+		"message": "Verberg voettekst"
+	},
+	"hideGradientBottom": {
+		"message": "Verberg Gradient Onderkant"
+	},
+	"hideHomePageShorts": {
+		"message": "Verwijder Shorts van de startpagina"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Verberg afspeelbalk"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Verberg knoppen voor afspeelcontrole"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Verberg opties voor afspeelbalk"
+	},
+	"hidePlaylist": {
+		"message": "Verberg afspeellijst"
+	},
+	"hideRightButtons": {
+		"message": "Verberg knoppen rechterkant"
+	},
+	"hideScrollForDetails": {
+		"message": "Verberg «Scrollen voor meer details»"
+	},
+	"hideSkipOverlay": {
+		"message": "Verberg knop voor overslaan omslag"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Verberg miniatuurafbeeldingen omslag"
+	},
+	"hideThumbnails": {
+		"message": "Verberg miniatuurafbeeldingen"
+	},
+	"hideViewsCount": {
+		"message": "Verberg aantal afgespeeld"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Verberg zoekknop via stem"
+	},
+	"high": {
+		"message": "Hoog"
+	},
+	"history": {
+		"message": "Geschiedenis"
+	},
+	"home": {
+		"message": "Thuis"
+	},
+	"hover": {
+		"message": "Overzweven met cursor"
+	},
+	"hoverOnVideoPage": {
+		"message": "Overzweven met cursor op videopagina"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Toon uploaddatum"
+	},
+	"icons": {
+		"message": "Pictogrammen"
+	},
+	"iconsOnly": {
+		"message": "Alleen pictogrammen"
+	},
+	"importSettings": {
+		"message": "Importeer instellingen"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube-icoon instellen voor YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Taal voor ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube-versie"
+	},
+	"improveLogo": {
+		"message": "YouTube-logo verbeteren"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Verhoog afspeelsnelheid"
+	},
+	"increaseVolume": {
+		"message": "Verhoog volume"
+	},
+	"language": {
+		"message": "Taal"
+	},
+	"languages": {
+		"message": "Talen"
+	},
+	"legacyYoutube": {
+		"message": "Klassieke YouTube-uiterlijk"
+	},
+	"library": {
+		"message": "Bibliotheek"
+	},
+	"light": {
+		"message": "Licht"
+	},
+	"lightBlue": {
+		"message": "Lichtblauw"
+	},
+	"lightGreen": {
+		"message": "Lichtgroen"
+	},
+	"like": {
+		"message": "Vind ik leuk"
+	},
+	"liked": {
+		"message": "Leuk gevonden"
+	},
+	"lime": {
+		"message": "Limoen"
+	},
+	"limitPageWidth": {
+		"message": "Limiteer paginabreedte"
+	},
+	"list": {
+		"message": "Lijst"
+	},
+	"liveChat": {
+		"message": "Live Chat"
+	},
+	"liveChatType": {
+		"message": "Type Live Chat"
+	},
+	"location": {
+		"message": "Locatie"
+	},
+	"loop": {
+		"message": "Lus"
+	},
+	"loudnessNormalization": {
+		"message": "Volume normaliseren"
+	},
+	"markWatchedVideos": {
+		"message": "Markeer bekeken video's"
+	},
+	"moveSidebarLeft": {
+		"message": "Verplaats zijbalk naar links"
+	},
+	"moveThumbnailsRight": {
+		"message": "Verplaats miniatuurafbeeldingen naar links"
+	},
+	"myColors": {
+		"message": "Mijn kleuren"
+	},
+	"name": {
+		"message": "Naam"
+	},
+	"nativeMiniPlayer": {
+		"message": "Ingebouwde minispeler"
+	},
+	"new": {
+		"message": "Nieuw"
+	},
+	"nextVideo": {
+		"message": "Volgende video afspelen"
+	},
+	"night": {
+		"message": "Nacht"
+	},
+	"noActiveFeatures": {
+		"message": "Geen actieve functies"
+	},
+	"none": {
+		"message": "Geen"
+	},
+	"noOpenVideoTabs": {
+		"message": "Geen openstaande videotabbladen"
+	},
+	"normal": {
+		"message": "Normaal"
+	},
+	"ok": {
+		"message": "OK"
+	},
+	"old": {
+		"message": "Oud"
+	},
+	"onAllVideos": {
+		"message": "Bij alle videos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Alleen actief op YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Slechts één actieve speler toestaan"
+	},
+	"onSubscribedChannels": {
+		"message": "Op geabonneerde kanalen"
+	},
+	"orange": {
+		"message": "Oranje"
+	},
+	"os": {
+		"message": "Besturingssysteem"
+	},
+	"other": {
+		"message": "Anders"
+	},
+	"outline": {
+		"message": "Uitlijning"
+	},
+	"overlay": {
+		"message": "Omslag"
+	},
+	"permissions": {
+		"message": "Machtigingen"
+	},
+	"pink": {
+		"message": "Roze"
+	},
+	"plain": {
+		"message": "Vlakte"
+	},
+	"playAllButton": {
+		"message": "\"Alles afspelen\"-knop"
+	},
+	"playbackSpeed": {
+		"message": "Afspeelsnelheid"
+	},
+	"player": {
+		"message": "Speler"
+	},
+	"playerColor": {
+		"message": "Spelerkleur"
+	},
+	"playerSize": {
+		"message": "Spelergrootte"
+	},
+	"playlist": {
+		"message": "Afspeellijst"
+	},
+	"playlists": {
+		"message": "Afspeellijsten"
+	},
+	"playPause": {
+		"message": "Video afspelen/pauzeren"
+	},
+	"popupPlayer": {
+		"message": "Pop-upspeler"
+	},
+	"position": {
+		"message": "Positie"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Druk op een toets of scroll met muiswiel."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Druk op een toets of gebruik muiswiel"
+	},
+	"previousVideo": {
+		"message": "Vorige video afspelen"
+	},
+	"primaryColor": {
+		"message": "Primaire kleur"
+	},
+	"purple": {
+		"message": "Paars"
+	},
+	"quality": {
+		"message": "Kwaliteit"
+	},
+	"raised": {
+		"message": "Opgeklapt"
+	},
+	"ram": {
+		"message": "Geheugen (RAM)"
+	},
+	"rateMe": {
+		"message": "Beoordeel mij"
+	},
+	"rateUs": {
+		"message": "Beoordeel ons"
+	},
+	"red": {
+		"message": "Rood"
+	},
+	"redDislikeButton": {
+		"message": "Laat Vind ik niet leuk-knop zien in het rood"
+	},
+	"relatedVideos": {
+		"message": "Gerelateerde video's"
+	},
+	"remote": {
+		"message": "Speel af op TV"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Verwijder resultaten van gerelateerde videos"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Verwijder Shorts-reel uit de zoekresultaten"
+	},
+	"repeat": {
+		"message": "Herhalen"
+	},
+	"reset": {
+		"message": "Herstel"
+	},
+	"resetAllSettings": {
+		"message": "Standaardwaarden herstellen"
+	},
+	"resetAllShortcuts": {
+		"message": "Herstel alle snelkoppelingen"
+	},
+	"reverse": {
+		"message": "Omdraaien"
+	},
+	"rotate": {
+		"message": "Draaien"
+	},
+	"save": {
+		"message": "Opslaan"
+	},
+	"saveAs": {
+		"message": "Opslaan als"
+	},
+	"schedule": {
+		"message": "Schema"
+	},
+	"screen": {
+		"message": "Beeldscherm"
+	},
+	"screenshot": {
+		"message": "Schermafbeelding"
+	},
+	"scrollBar": {
+		"message": "Scrollbalk"
+	},
+	"search": {
+		"message": "Zoeken"
+	},
+	"searchBarOnly": {
+		"message": "Alleen zoekbalk"
+	},
+	"seekBackward10Seconds": {
+		"message": "Ga 10 seconden terug"
+	},
+	"seekForward10Seconds": {
+		"message": "Ga 10 seconden naar voren"
+	},
+	"seekNextChapter": {
+		"message": "Ga naar volgend hoofdstuk"
+	},
+	"seekPreviousChapter": {
+		"message": "Ga naar vorig hoofdstuk"
+	},
+	"settings": {
+		"message": "Instellingen"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Instellingen succesvol geïmporteerd"
+	},
+	"shortcuts": {
+		"message": "Sneltoetsen"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Laat infokaarten zien onder muisaanwijzer"
+	},
+	"showChannelVideosCount": {
+		"message": "Aantal kanaalvideo's tonen"
+	},
+	"showLess": {
+		"message": "Minder zien"
+	},
+	"showMore": {
+		"message": "Meer zien"
+	},
+	"showRemainingDuration": {
+		"message": "Laat resterende afspeelduur zien"
+	},
+	"shuffle": {
+		"message": "Willekeurig"
+	},
+	"sidebar": {
+		"message": "Zijbalk"
+	},
+	"spacebar": {
+		"message": "Spatiebalk"
+	},
+	"squaredUserImages": {
+		"message": "Vierkante profielfoto's"
+	},
+	"static": {
+		"message": "Statisch"
+	},
+	"statsForNerds": {
+		"message": "Toon statistieken voor Nerds"
+	},
+	"step": {
+		"message": "Stap"
+	},
+	"style": {
+		"message": "Stijl"
+	},
+	"styles": {
+		"message": "Stijlen"
+	},
+	"subscribe": {
+		"message": "Abonneer"
+	},
+	"subscriptions": {
+		"message": "Abonnementen"
+	},
+	"subtitles": {
+		"message": "Ondertiteling"
+	},
+	"sunset": {
+		"message": "Zonsondergang"
+	},
+	"sunsetToSunrise": {
+		"message": "Zonsondergang tot zonsopkomst"
+	},
+	"systemPeferenceDark": {
+		"message": "Systeemvoorkeur: donker"
+	},
+	"systemPeferenceLight": {
+		"message": "Systeemvoorkeur: licht"
+	},
+	"teal": {
+		"message": "Groenblauw"
+	},
+	"textColor": {
+		"message": "Tekstkleur"
+	},
+	"themes": {
+		"message": "Thema's"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Dit verwijdert alle cookies."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Dit verwijdert alle YouTube-cookies"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Dit wist alle instellingen."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Dit wist alle snelkoppelingen"
+	},
+	"thumbnails": {
+		"message": "Miniatuurvoorbeelden"
+	},
+	"thumbnailsQuality": {
+		"message": "Kwaliteit miniatuurvoorbeelden"
+	},
+	"timeFrom": {
+		"message": "Tijd vanaf"
+	},
+	"timeTo": {
+		"message": "Tijd tot"
+	},
+	"todayAt": {
+		"message": "Vandaag om"
+	},
+	"toggleAutoplay": {
+		"message": "Automatisch afspelen aanzetten"
+	},
+	"toggleCards": {
+		"message": "Infokaarten aanzetten"
+	},
+	"toggleControls": {
+		"message": "Controleknoppen aanzetten"
+	},
+	"topChat": {
+		"message": "Top-chat"
+	},
+	"trackWatchedVideos": {
+		"message": "Houd afgespeelde video's bij"
+	},
+	"trailerAutoplay": {
+		"message": "Automatisch afspelen van trailers"
+	},
+	"translations": {
+		"message": "vertalingen"
+	},
+	"transparentBackground": {
+		"message": "Doorzichtige achtergrond"
+	},
+	"tryToReloadThePage": {
+		"message": "Probeer de pagina te herladen"
+	},
+	"type": {
+		"message": "Soort"
+	},
+	"upNextAutoplay": {
+		"message": "Volgende in wachtrij automatisch afspelen"
+	},
+	"use24HourFormat": {
+		"message": "24-uursnotatie gebruiken"
+	},
+	"version": {
+		"message": "Versie"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "De video-omschrijving wordt uitgeklapt om de naam van de categorie te verkrijgen"
+	},
+	"videoFormats": {
+		"message": "Videoformaten"
+	},
+	"videos": {
+		"message": "Video's"
+	},
+	"viewMode": {
+		"message": "Afspeelmodus"
+	},
+	"watchLater": {
+		"message": "Later bekijken"
+	},
+	"watchTime": {
+		"message": "Tijd van bekijken"
+	},
+	"whenTabIsChanged": {
+		"message": "Wanneer het tabblad is veranderd"
+	},
+	"white": {
+		"message": "Wit"
+	},
+	"windowColor": {
+		"message": "Vensterkleur"
+	},
+	"windowOpacity": {
+		"message": "Doorzichtigheid venster"
+	},
+	"yellow": {
+		"message": "Geel"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube-kop (links)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube-kop (rechts)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube-startpagina"
+	},
+	"youtubeLanguage": {
+		"message": "Taal van YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube limiteert videokwaliteit tot 1080p voor H.264 codec"
+	}
 }

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -1,722 +1,704 @@
 {
-    "about": {
-        "message": "Om"
-    },
-    "accept": {
-        "message": "aksepter"
-    },
-    "activate": {
-        "message": "Aktiver"
-    },
-    "activateCaptions": {
-        "message": "Aktiver texting"
-    },
-    "activated": {
-        "message": "Aktivert"
-    },
-    "activatedFeatures": {
-        "message": "Aktiverte funksjoner"
-    },
-    "activateFullscreen": {
-        "message": "Aktiver fullskjerm"
-    },
-    "activeFeatures": {
-        "message": "Aktive funksjoner"
-    },
-    "addScrollToTop": {
-        "message": "Legg til «Rull til toppen»"
-    },
-    "ads": {
-        "message": "Reklamer"
-    },
-    "all": {
-        "message": "Alle"
-    },
-    "allow": {
-        "message": "Tillat"
-    },
-    "alwaysActive": {
-        "message": "Alltid aktiv"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Alltid vis fremdriftslinje"
-    },
-    "analyzer": {
-        "message": "Analysator"
-    },
-    "appearance": {
-        "message": "Utseende"
-    },
-    "audio": {
-        "message": "Lyd"
-    },
-    "audioFormats": {
-        "message": "Lyd formater"
-    },
-    "autoFullscreen": {
-        "message": "Auto-fullskjerm"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Autopause når du bytter faner"
-    },
-    "backupAndReset": {
-        "message": "Sikkerhetskopiering og tilbakestilling"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baser på systemfargevalg"
-    },
-    "belowPlayer": {
-        "message": "Nedenfor spiller"
-    },
-    "black": {
-        "message": "Svart"
-    },
-    "blockAll": {
-        "message": "Blokker alle"
-    },
-    "blocklist": {
-        "message": "Svartelist"
-    },
-    "blue": {
-        "message": "Blå"
-    },
-    "blueGray": {
-        "message": "Blå grå"
-    },
-    "bluelight": {
-        "message": "Blålys"
-    },
-    "brown": {
-        "message": "Brun"
-    },
-    "browser": {
-        "message": "Nettleser"
-    },
-    "browserVersion": {
-        "message": "Nettleser versjon"
-    },
-    "bubbles": {
-        "message": "Bobler"
-    },
-    "buttons": {
-        "message": "Knapper"
-    },
-    "cancel": {
-        "message": "Avbryt"
-    },
-    "categories": {
-        "message": "Kategorier"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanaler"
-    },
-    "clipboard": {
-        "message": "Utklippstavle"
-    },
-    "collapsed": {
-        "message": "kollapset"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Kollaps av abonnements seksjonene"
-    },
-    "comments": {
-        "message": "Kommentarer"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Bekreftelse før stenging"
-    },
-    "cookies": {
-        "message": "Informasjonskapslene"
-    },
-    "cores": {
-        "message": "Kjerner"
-    },
-    "customCss": {
-        "message": "Tilpasset CSS"
-    },
-    "customJs": {
-        "message": "Tilpasset JS"
-    },
-    "dark": {
-        "message": "Mørk"
-    },
-    "darkTheme": {
-        "message": "Mørkt tema"
-    },
-    "dateAndTime": {
-        "message": "Dato og klokkeslett"
-    },
-    "dawn": {
-        "message": "Soloppgang"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Reduser avspillingshastighet"
-    },
-    "decreaseVolume": {
-        "message": "Reduser volumet"
-    },
-    "deepOrange": {
-        "message": "Dyporansje"
-    },
-    "deepPurple": {
-        "message": "Mørkelilla"
-    },
-    "defaultChannelTab": {
-        "message": "Standard kanalfane"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Slett YouTube-informasjonskapsler"
-    },
-    "desert": {
-        "message": "Ørken"
-    },
-    "details": {
-        "message": "Detaljer"
-    },
-    "developerOptions": {
-        "message": "Utviklermuligheter"
-    },
-    "device": {
-        "message": "Enhet"
-    },
-    "disabled": {
-        "message": "Avslått"
-    },
-    "dislike": {
-        "message": "Mislik"
-    },
-    "donate": {
-        "message": "Doner"
-    },
-    "doNotChange": {
-        "message": "Ikke endre"
-    },
-    "draggable": {
-        "message": "Flyttbare"
-    },
-    "email": {
-        "message": "E-post"
-    },
-    "empty": {
-        "message": "Tom"
-    },
-    "enabled": {
-        "message": "Aktivert"
-    },
-    "enabledForced": {
-        "message": "Aktivert (tvunget)"
-    },
-    "expanded": {
-        "message": "Utvidet"
-    },
-    "exportSettings": {
-        "message": "Eksporter innstillinger"
-    },
-    "extension": {
-        "message": "Utvidelse"
-    },
-    "file": {
-        "message": "Fil"
-    },
-    "filters": {
-        "message": "Filtre"
-    },
-    "fitToWindow": {
-        "message": "Tilpass til vindu"
-    },
-    "footer": {
-        "message": "Bunntekst"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Tvungen avspillingshastighet"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forced play video from the beginning"
-    },
-    "forcedTheaterMode": {
-        "message": "Tvunget teater-modus"
-    },
-    "forcedVolume": {
-        "message": "Tvangsvolum"
-    },
-    "foundABug": {
-        "message": "Fant du en feil?"
-    },
-    "fullWindow": {
-        "message": "Fullt vindu"
-    },
-    "general": {
-        "message": "Generell"
-    },
-    "goToSearchBox": {
-        "message": "Gå til søkefeltet"
-    },
-    "green": {
-        "message": "Grønn"
-    },
-    "hdThumbnail": {
-        "message": "HD-miniatyrbilde"
-    },
-    "header": {
-        "message": "Overskrift"
-    },
-    "hidden": {
-        "message": "Skjult"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Skjult på video siden"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Skjul animerte miniatyrbilder"
-    },
-    "hideAnnotations": {
-        "message": "Skjul annoteringer"
-    },
-    "hideCards": {
-        "message": "Skjul kort"
-    },
-    "hideDetails": {
-        "message": "Skjul detaljer"
-    },
-    "hideEndscreen": {
-        "message": "Skjul sluttskjerm"
-    },
-    "hideFeaturedContent": {
-        "message": "Skjul omtalt innhold"
-    },
-    "hideFooter": {
-        "message": "Skjul bunntekst "
-    },
-    "hideHomePageShorts": {
-        "message": "Fjern Shorts fra hjemmesiden"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Hide player controls bar buttons"
-    },
-    "hidePlaylist": {
-        "message": "Skjul spilleliste"
-    },
-    "hideRightButtons": {
-        "message": "Skjul høyre knapper"
-    },
-    "hideScrollForDetails": {
-        "message": "Skjul «Bla for detaljer»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "Skjul visninger teller"
-    },
-    "history": {
-        "message": "Historie"
-    },
-    "home": {
-        "message": "Hjem"
-    },
-    "hover": {
-        "message": "Hold"
-    },
-    "hoverOnVideoPage": {
-        "message": "Hold musepekeren på videosiden"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Hvor lenge siden videoen ble lastet opp"
-    },
-    "icons": {
-        "message": "Ikoner"
-    },
-    "iconsOnly": {
-        "message": "Bare Ikoner"
-    },
-    "importSettings": {
-        "message": "Importer innstillinger"
-    },
-    "improvedtubeButtons": {
-        "message": "ImprovedTube-knapper"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube-ikonet på YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube språk"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube versjon"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Øk avspillingshastigheten"
-    },
-    "increaseVolume": {
-        "message": "Øk volumet"
-    },
-    "items": {
-        "message": "Elementer"
-    },
-    "languages": {
-        "message": "Språk"
-    },
-    "light": {
-        "message": "Lys"
-    },
-    "lightBlue": {
-        "message": "Lyse blå"
-    },
-    "lightGreen": {
-        "message": "Lyse grønn"
-    },
-    "list": {
-        "message": "Liste"
-    },
-    "loudnessNormalization": {
-        "message": "Høytthetsnormalisering"
-    },
-    "markWatchedVideos": {
-        "message": "Marker sette videoer"
-    },
-    "mixer": {
-        "message": "Mikser"
-    },
-    "myColors": {
-        "message": "Mine farger"
-    },
-    "name": {
-        "message": "Navn"
-    },
-    "nativeMiniPlayer": {
-        "message": "Innfødt minispiller"
-    },
-    "new": {
-        "message": "Ny"
-    },
-    "nextVideo": {
-        "message": "Neste video"
-    },
-    "night": {
-        "message": "Natt"
-    },
-    "noActiveFeatures": {
-        "message": "Ingen aktive funksjoner"
-    },
-    "none": {
-        "message": "Ingen"
-    },
-    "noOpenVideoTabs": {
-        "message": "Ingen åpne videofaner"
-    },
-    "old": {
-        "message": "Gammel"
-    },
-    "onAllVideos": {
-        "message": "På alle videoer"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Bare aktiv på YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Bare en spillerforekomst som spiller"
-    },
-    "onSubscribedChannels": {
-        "message": "På abonnementskanaler"
-    },
-    "orange": {
-        "message": "Oransje"
-    },
-    "other": {
-        "message": "Andre"
-    },
-    "permissions": {
-        "message": "rettigheter"
-    },
-    "pictureInPicture": {
-        "message": "Bilde-i-bilde"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Vanlig"
-    },
-    "platform": {
-        "message": "Plattform"
-    },
-    "playbackSpeed": {
-        "message": "Avspillingshastighet"
-    },
-    "player": {
-        "message": "Spiller"
-    },
-    "playerColor": {
-        "message": "Spiller farge"
-    },
-    "playerSize": {
-        "message": "Spiller størrelse"
-    },
-    "playlist": {
-        "message": "Spilleliste"
-    },
-    "playlists": {
-        "message": "Spillelister"
-    },
-    "playPause": {
-        "message": "Spill / Pause"
-    },
-    "popupPlayer": {
-        "message": "Popup-spiller"
-    },
-    "position": {
-        "message": "Posisjon"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Trykk på hvilken som helst tast eller bruk musehjulet."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Trykk på hvilken som helst tast eller bruk musehjulet"
-    },
-    "previousVideo": {
-        "message": "Forrige video"
-    },
-    "primaryColor": {
-        "message": "Hovedfarge"
-    },
-    "purple": {
-        "message": "Lilla"
-    },
-    "rateUs": {
-        "message": "Rangere oss"
-    },
-    "red": {
-        "message": "Rød"
-    },
-    "relatedVideos": {
-        "message": "Relaterte videoer"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Fjern relaterte søkeresultater"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Fjern Shorts-rullen fra søkeresultatene"
-    },
-    "repeat": {
-        "message": "Gjenta"
-    },
-    "reset": {
-        "message": "Tilbakestill"
-    },
-    "resetAllSettings": {
-        "message": "Tilbakestill alle instillinger"
-    },
-    "resetAllShortcuts": {
-        "message": "Tilbakestill alle snarveier"
-    },
-    "reverse": {
-        "message": "Omvendt"
-    },
-    "rotate": {
-        "message": "Roter"
-    },
-    "save": {
-        "message": "Lagre"
-    },
-    "saveAs": {
-        "message": "Lagre som"
-    },
-    "schedule": {
-        "message": "Tidsplan"
-    },
-    "screen": {
-        "message": "Skjerm"
-    },
-    "screenshot": {
-        "message": "Skjermbilde"
-    },
-    "search": {
-        "message": "Søk"
-    },
-    "searchBarOnly": {
-        "message": "Bare søkefelt"
-    },
-    "seekBackward10Seconds": {
-        "message": "Spol 10 sekunder bakover"
-    },
-    "seekForward10Seconds": {
-        "message": "Spol 10 sekunder frem"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Innstillinger"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Innstillinger importert"
-    },
-    "shortcuts": {
-        "message": "Snarveier"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Vis kort på musepekeren"
-    },
-    "showChannelVideosCount": {
-        "message": "Vis antall kanaler"
-    },
-    "shuffle": {
-        "message": "Tilfeldig rekkefølge"
-    },
-    "sidebar": {
-        "message": "Sidepanel"
-    },
-    "spacebar": {
-        "message": "Mellomrom"
-    },
-    "squaredUserImages": {
-        "message": "Kvadratiske brukerbilder"
-    },
-    "static": {
-        "message": "Statisk"
-    },
-    "step": {
-        "message": "Steg"
-    },
-    "stop": {
-        "message": "Stopp"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stiler"
-    },
-    "subscriptions": {
-        "message": "Abonnementer"
-    },
-    "subtitles": {
-        "message": "Undertekster"
-    },
-    "sunset": {
-        "message": "Solnedgang"
-    },
-    "sunsetToSunrise": {
-        "message": "Solnedgang til soloppgang"
-    },
-    "systemPeferenceDark": {
-        "message": "Systeminnstillinger: mørk"
-    },
-    "systemPeferenceLight": {
-        "message": "Systeminnstillinger: lys"
-    },
-    "teal": {
-        "message": "Blågrønn"
-    },
-    "textColor": {
-        "message": "Tekstfarge"
-    },
-    "themes": {
-        "message": "Temaer"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Dette vil fjerne alle informasjonskapsler."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Dette vil fjerne alle YouTube-informasjonskapsler"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Dette vil tilbakestille alle innstillinger."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Dette vil tilbakestille alle snarveier"
-    },
-    "thumbnails": {
-        "message": "miniatyrbilder "
-    },
-    "timeFrom": {
-        "message": "Tid fra"
-    },
-    "timeTo": {
-        "message": "Tid til"
-    },
-    "todayAt": {
-        "message": "I dag kl"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "Hoved chat"
-    },
-    "trailerAutoplay": {
-        "message": "Trailer autospilling"
-    },
-    "translations": {
-        "message": "Oversettelser"
-    },
-    "transparentBackground": {
-        "message": "Gjennomsiktig bakgrunn"
-    },
-    "trending": {
-        "message": "Trender"
-    },
-    "tryToReloadThePage": {
-        "message": "Forsøk å laste inn siden på nytt"
-    },
-    "upNextAutoplay": {
-        "message": "Opp neste autospilling"
-    },
-    "use24HourFormat": {
-        "message": "Bruk 24-timers format"
-    },
-    "version": {
-        "message": "Versjon"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Videobeskrivelsen vil bli utvidet for å få navnet på kategorien"
-    },
-    "videoFormats": {
-        "message": "Video formater"
-    },
-    "videos": {
-        "message": "Videoer"
-    },
-    "watchLater": {
-        "message": "Se senere"
-    },
-    "watchTime": {
-        "message": "Tid sett"
-    },
-    "whenTabIsChanged": {
-        "message": "Når fanen endres"
-    },
-    "white": {
-        "message": "Hvit"
-    },
-    "yellow": {
-        "message": "Gul"
-    },
-    "youTubeButtons": {
-        "message": "YouTube knapper"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube Header (til venstre)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube Header (til høyre)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube startside"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube språk"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube begrenser videokvaliteten til 1080p for h.264-kodeken"
-    }
+	"about": {
+		"message": "Om"
+	},
+	"accept": {
+		"message": "aksepter"
+	},
+	"activate": {
+		"message": "Aktiver"
+	},
+	"activateCaptions": {
+		"message": "Aktiver texting"
+	},
+	"activated": {
+		"message": "Aktivert"
+	},
+	"activatedFeatures": {
+		"message": "Aktiverte funksjoner"
+	},
+	"activateFullscreen": {
+		"message": "Aktiver fullskjerm"
+	},
+	"activeFeatures": {
+		"message": "Aktive funksjoner"
+	},
+	"addScrollToTop": {
+		"message": "Legg til «Rull til toppen»"
+	},
+	"ads": {
+		"message": "Reklamer"
+	},
+	"all": {
+		"message": "Alle"
+	},
+	"allow": {
+		"message": "Tillat"
+	},
+	"alwaysActive": {
+		"message": "Alltid aktiv"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Alltid vis fremdriftslinje"
+	},
+	"analyzer": {
+		"message": "Analysator"
+	},
+	"appearance": {
+		"message": "Utseende"
+	},
+	"audio": {
+		"message": "Lyd"
+	},
+	"audioFormats": {
+		"message": "Lyd formater"
+	},
+	"autoFullscreen": {
+		"message": "Auto-fullskjerm"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Autopause når du bytter faner"
+	},
+	"backupAndReset": {
+		"message": "Sikkerhetskopiering og tilbakestilling"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baser på systemfargevalg"
+	},
+	"belowPlayer": {
+		"message": "Nedenfor spiller"
+	},
+	"black": {
+		"message": "Svart"
+	},
+	"blockAll": {
+		"message": "Blokker alle"
+	},
+	"blocklist": {
+		"message": "Svartelist"
+	},
+	"blue": {
+		"message": "Blå"
+	},
+	"blueGray": {
+		"message": "Blå grå"
+	},
+	"bluelight": {
+		"message": "Blålys"
+	},
+	"brown": {
+		"message": "Brun"
+	},
+	"browser": {
+		"message": "Nettleser"
+	},
+	"browserVersion": {
+		"message": "Nettleser versjon"
+	},
+	"bubbles": {
+		"message": "Bobler"
+	},
+	"buttons": {
+		"message": "Knapper"
+	},
+	"cancel": {
+		"message": "Avbryt"
+	},
+	"categories": {
+		"message": "Kategorier"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanaler"
+	},
+	"clipboard": {
+		"message": "Utklippstavle"
+	},
+	"collapsed": {
+		"message": "kollapset"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Kollaps av abonnements seksjonene"
+	},
+	"comments": {
+		"message": "Kommentarer"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Bekreftelse før stenging"
+	},
+	"cookies": {
+		"message": "Informasjonskapslene"
+	},
+	"cores": {
+		"message": "Kjerner"
+	},
+	"customCss": {
+		"message": "Tilpasset CSS"
+	},
+	"customJs": {
+		"message": "Tilpasset JS"
+	},
+	"dark": {
+		"message": "Mørk"
+	},
+	"darkTheme": {
+		"message": "Mørkt tema"
+	},
+	"dateAndTime": {
+		"message": "Dato og klokkeslett"
+	},
+	"dawn": {
+		"message": "Soloppgang"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Reduser avspillingshastighet"
+	},
+	"decreaseVolume": {
+		"message": "Reduser volumet"
+	},
+	"deepOrange": {
+		"message": "Dyporansje"
+	},
+	"deepPurple": {
+		"message": "Mørkelilla"
+	},
+	"defaultChannelTab": {
+		"message": "Standard kanalfane"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Slett YouTube-informasjonskapsler"
+	},
+	"desert": {
+		"message": "Ørken"
+	},
+	"details": {
+		"message": "Detaljer"
+	},
+	"developerOptions": {
+		"message": "Utviklermuligheter"
+	},
+	"device": {
+		"message": "Enhet"
+	},
+	"disabled": {
+		"message": "Avslått"
+	},
+	"dislike": {
+		"message": "Mislik"
+	},
+	"donate": {
+		"message": "Doner"
+	},
+	"doNotChange": {
+		"message": "Ikke endre"
+	},
+	"draggable": {
+		"message": "Flyttbare"
+	},
+	"email": {
+		"message": "E-post"
+	},
+	"empty": {
+		"message": "Tom"
+	},
+	"enabled": {
+		"message": "Aktivert"
+	},
+	"enabledForced": {
+		"message": "Aktivert (tvunget)"
+	},
+	"expanded": {
+		"message": "Utvidet"
+	},
+	"exportSettings": {
+		"message": "Eksporter innstillinger"
+	},
+	"extension": {
+		"message": "Utvidelse"
+	},
+	"file": {
+		"message": "Fil"
+	},
+	"filters": {
+		"message": "Filtre"
+	},
+	"fitToWindow": {
+		"message": "Tilpass til vindu"
+	},
+	"footer": {
+		"message": "Bunntekst"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Tvungen avspillingshastighet"
+	},
+	"forcedTheaterMode": {
+		"message": "Tvunget teater-modus"
+	},
+	"forcedVolume": {
+		"message": "Tvangsvolum"
+	},
+	"foundABug": {
+		"message": "Fant du en feil?"
+	},
+	"fullWindow": {
+		"message": "Fullt vindu"
+	},
+	"general": {
+		"message": "Generell"
+	},
+	"goToSearchBox": {
+		"message": "Gå til søkefeltet"
+	},
+	"green": {
+		"message": "Grønn"
+	},
+	"hdThumbnail": {
+		"message": "HD-miniatyrbilde"
+	},
+	"header": {
+		"message": "Overskrift"
+	},
+	"hidden": {
+		"message": "Skjult"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Skjult på video siden"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Skjul animerte miniatyrbilder"
+	},
+	"hideAnnotations": {
+		"message": "Skjul annoteringer"
+	},
+	"hideCards": {
+		"message": "Skjul kort"
+	},
+	"hideDetails": {
+		"message": "Skjul detaljer"
+	},
+	"hideEndscreen": {
+		"message": "Skjul sluttskjerm"
+	},
+	"hideFeaturedContent": {
+		"message": "Skjul omtalt innhold"
+	},
+	"hideFooter": {
+		"message": "Skjul bunntekst"
+	},
+	"hideHomePageShorts": {
+		"message": "Fjern Shorts fra hjemmesiden"
+	},
+	"hidePlaylist": {
+		"message": "Skjul spilleliste"
+	},
+	"hideRightButtons": {
+		"message": "Skjul høyre knapper"
+	},
+	"hideScrollForDetails": {
+		"message": "Skjul «Bla for detaljer»"
+	},
+	"hideViewsCount": {
+		"message": "Skjul visninger teller"
+	},
+	"history": {
+		"message": "Historie"
+	},
+	"home": {
+		"message": "Hjem"
+	},
+	"hover": {
+		"message": "Hold"
+	},
+	"hoverOnVideoPage": {
+		"message": "Hold musepekeren på videosiden"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Hvor lenge siden videoen ble lastet opp"
+	},
+	"icons": {
+		"message": "Ikoner"
+	},
+	"iconsOnly": {
+		"message": "Bare Ikoner"
+	},
+	"importSettings": {
+		"message": "Importer innstillinger"
+	},
+	"improvedtubeButtons": {
+		"message": "ImprovedTube-knapper"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube-ikonet på YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube språk"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube versjon"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Øk avspillingshastigheten"
+	},
+	"increaseVolume": {
+		"message": "Øk volumet"
+	},
+	"items": {
+		"message": "Elementer"
+	},
+	"languages": {
+		"message": "Språk"
+	},
+	"light": {
+		"message": "Lys"
+	},
+	"lightBlue": {
+		"message": "Lyse blå"
+	},
+	"lightGreen": {
+		"message": "Lyse grønn"
+	},
+	"list": {
+		"message": "Liste"
+	},
+	"loudnessNormalization": {
+		"message": "Høytthetsnormalisering"
+	},
+	"markWatchedVideos": {
+		"message": "Marker sette videoer"
+	},
+	"mixer": {
+		"message": "Mikser"
+	},
+	"myColors": {
+		"message": "Mine farger"
+	},
+	"name": {
+		"message": "Navn"
+	},
+	"nativeMiniPlayer": {
+		"message": "Innfødt minispiller"
+	},
+	"new": {
+		"message": "Ny"
+	},
+	"nextVideo": {
+		"message": "Neste video"
+	},
+	"night": {
+		"message": "Natt"
+	},
+	"noActiveFeatures": {
+		"message": "Ingen aktive funksjoner"
+	},
+	"none": {
+		"message": "Ingen"
+	},
+	"noOpenVideoTabs": {
+		"message": "Ingen åpne videofaner"
+	},
+	"old": {
+		"message": "Gammel"
+	},
+	"onAllVideos": {
+		"message": "På alle videoer"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Bare aktiv på YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Bare en spillerforekomst som spiller"
+	},
+	"onSubscribedChannels": {
+		"message": "På abonnementskanaler"
+	},
+	"orange": {
+		"message": "Oransje"
+	},
+	"other": {
+		"message": "Andre"
+	},
+	"permissions": {
+		"message": "rettigheter"
+	},
+	"pictureInPicture": {
+		"message": "Bilde-i-bilde"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Vanlig"
+	},
+	"platform": {
+		"message": "Plattform"
+	},
+	"playbackSpeed": {
+		"message": "Avspillingshastighet"
+	},
+	"player": {
+		"message": "Spiller"
+	},
+	"playerColor": {
+		"message": "Spiller farge"
+	},
+	"playerSize": {
+		"message": "Spiller størrelse"
+	},
+	"playlist": {
+		"message": "Spilleliste"
+	},
+	"playlists": {
+		"message": "Spillelister"
+	},
+	"playPause": {
+		"message": "Spill / Pause"
+	},
+	"popupPlayer": {
+		"message": "Popup-spiller"
+	},
+	"position": {
+		"message": "Posisjon"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Trykk på hvilken som helst tast eller bruk musehjulet."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Trykk på hvilken som helst tast eller bruk musehjulet"
+	},
+	"previousVideo": {
+		"message": "Forrige video"
+	},
+	"primaryColor": {
+		"message": "Hovedfarge"
+	},
+	"purple": {
+		"message": "Lilla"
+	},
+	"rateUs": {
+		"message": "Rangere oss"
+	},
+	"red": {
+		"message": "Rød"
+	},
+	"relatedVideos": {
+		"message": "Relaterte videoer"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Fjern relaterte søkeresultater"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Fjern Shorts-rullen fra søkeresultatene"
+	},
+	"repeat": {
+		"message": "Gjenta"
+	},
+	"reset": {
+		"message": "Tilbakestill"
+	},
+	"resetAllSettings": {
+		"message": "Tilbakestill alle instillinger"
+	},
+	"resetAllShortcuts": {
+		"message": "Tilbakestill alle snarveier"
+	},
+	"reverse": {
+		"message": "Omvendt"
+	},
+	"rotate": {
+		"message": "Roter"
+	},
+	"save": {
+		"message": "Lagre"
+	},
+	"saveAs": {
+		"message": "Lagre som"
+	},
+	"schedule": {
+		"message": "Tidsplan"
+	},
+	"screen": {
+		"message": "Skjerm"
+	},
+	"screenshot": {
+		"message": "Skjermbilde"
+	},
+	"search": {
+		"message": "Søk"
+	},
+	"searchBarOnly": {
+		"message": "Bare søkefelt"
+	},
+	"seekBackward10Seconds": {
+		"message": "Spol 10 sekunder bakover"
+	},
+	"seekForward10Seconds": {
+		"message": "Spol 10 sekunder frem"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Innstillinger"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Innstillinger importert"
+	},
+	"shortcuts": {
+		"message": "Snarveier"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Vis kort på musepekeren"
+	},
+	"showChannelVideosCount": {
+		"message": "Vis antall kanaler"
+	},
+	"shuffle": {
+		"message": "Tilfeldig rekkefølge"
+	},
+	"spacebar": {
+		"message": "Mellomrom"
+	},
+	"squaredUserImages": {
+		"message": "Kvadratiske brukerbilder"
+	},
+	"static": {
+		"message": "Statisk"
+	},
+	"step": {
+		"message": "Steg"
+	},
+	"stop": {
+		"message": "Stopp"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stiler"
+	},
+	"subscriptions": {
+		"message": "Abonnementer"
+	},
+	"subtitles": {
+		"message": "Undertekster"
+	},
+	"sunset": {
+		"message": "Solnedgang"
+	},
+	"sunsetToSunrise": {
+		"message": "Solnedgang til soloppgang"
+	},
+	"systemPeferenceDark": {
+		"message": "Systeminnstillinger: mørk"
+	},
+	"systemPeferenceLight": {
+		"message": "Systeminnstillinger: lys"
+	},
+	"teal": {
+		"message": "Blågrønn"
+	},
+	"textColor": {
+		"message": "Tekstfarge"
+	},
+	"themes": {
+		"message": "Temaer"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Dette vil fjerne alle informasjonskapsler."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Dette vil fjerne alle YouTube-informasjonskapsler"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Dette vil tilbakestille alle innstillinger."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Dette vil tilbakestille alle snarveier"
+	},
+	"thumbnails": {
+		"message": "miniatyrbilder"
+	},
+	"timeFrom": {
+		"message": "Tid fra"
+	},
+	"timeTo": {
+		"message": "Tid til"
+	},
+	"todayAt": {
+		"message": "I dag kl"
+	},
+	"topChat": {
+		"message": "Hoved chat"
+	},
+	"trailerAutoplay": {
+		"message": "Trailer autospilling"
+	},
+	"translations": {
+		"message": "Oversettelser"
+	},
+	"transparentBackground": {
+		"message": "Gjennomsiktig bakgrunn"
+	},
+	"trending": {
+		"message": "Trender"
+	},
+	"tryToReloadThePage": {
+		"message": "Forsøk å laste inn siden på nytt"
+	},
+	"upNextAutoplay": {
+		"message": "Opp neste autospilling"
+	},
+	"use24HourFormat": {
+		"message": "Bruk 24-timers format"
+	},
+	"version": {
+		"message": "Versjon"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Videobeskrivelsen vil bli utvidet for å få navnet på kategorien"
+	},
+	"videoFormats": {
+		"message": "Video formater"
+	},
+	"videos": {
+		"message": "Videoer"
+	},
+	"watchLater": {
+		"message": "Se senere"
+	},
+	"watchTime": {
+		"message": "Tid sett"
+	},
+	"whenTabIsChanged": {
+		"message": "Når fanen endres"
+	},
+	"white": {
+		"message": "Hvit"
+	},
+	"yellow": {
+		"message": "Gul"
+	},
+	"youTubeButtons": {
+		"message": "YouTube knapper"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube Header (til venstre)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube Header (til høyre)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube startside"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube språk"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube begrenser videokvaliteten til 1080p for h.264-kodeken"
+	}
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1,998 +1,998 @@
 {
-    "about": {
-        "message": "Informacje"
-    },
-    "accept": {
-        "message": "Akceptuj"
-    },
-    "activate": {
-        "message": "Aktywuj"
-    },
-    "activateCaptions": {
-        "message": "Aktywuj napisy"
-    },
-    "activated": {
-        "message": "Aktywowane"
-    },
-    "activatedFeatures": {
-        "message": "Aktywowane funkcje"
-    },
-    "activateFullscreen": {
-        "message": "Aktywuj tryb pełnoekranowy"
-    },
-    "activeFeatures": {
-        "message": "Aktywne funkcje"
-    },
-    "addScrollToTop": {
-        "message": "Dodaj «Przewiń do góry»"
-    },
-    "ads": {
-        "message": "Reklamy"
-    },
-    "all": {
-        "message": "Wszystkie"
-    },
-    "allow": {
-        "message": "Zezwól"
-    },
-    "always": {
-        "message": "Zawsze"
-    },
-    "alwaysActive": {
-        "message": "Zawsze aktywne"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Zawsze pokazuj pasek postępu"
-    },
-    "amber": {
-        "message": "Bursztynowy"
-    },
-    "analyzer": {
-        "message": "Analizator"
-    },
-    "appearance": {
-        "message": "Wygląd"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Jesteś pewien że chcesz wyeksportować dane?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Jesteś pewien że chcesz zaimportować dane?"
-    },
-    "audioFormats": {
-        "message": "Formaty audio"
-    },
-    "autoFullscreen": {
-        "message": "Automatyczny tryb pełnoekranowy"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Automatyczna pauza przy zmianie kart"
-    },
-    "autoplay": {
-        "message": "Autoodtwarzanie"
-    },
-    "avoidAv1": {
-        "message": "Unikaj AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Unikaj AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Unikaj AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Unikaj renderowania CPU gdy tylko możliwe"
-    },
-    "backgroundColor": {
-        "message": "Kolor tła"
-    },
-    "backgroundOpacity": {
-        "message": "Przezroczystość tła"
-    },
-    "backupAndReset": {
-        "message": "Kopia zapasowa i reset"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Bazuj na systemowym schemacie kolorów"
-    },
-    "belowPlayer": {
-        "message": "Pod odtwarzaczem"
-    },
-    "black": {
-        "message": "Czarny"
-    },
-    "blockAll": {
-        "message": "Blokuj wszystkie"
-    },
-    "blockAv1": {
-        "message": "Blokuj AV1"
-    },
-    "blockH264": {
-        "message": "Blokuj H.264"
-    },
-    "blocklist": {
-        "message": "Czarna lista"
-    },
-    "blockMusic": {
-        "message": "Blokuj muzykę"
-    },
-    "blockVp8": {
-        "message": "Blokuj VP8"
-    },
-    "blockVp9": {
-        "message": "Blokuj VP9"
-    },
-    "blue": {
-        "message": "Niebieski"
-    },
-    "blueGray": {
-        "message": "Szaroniebieski"
-    },
-    "bluelight": {
-        "message": "Niebieskie światło"
-    },
-    "brown": {
-        "message": "Brązowy"
-    },
-    "browser": {
-        "message": "Przeglądarka"
-    },
-    "browserVersion": {
-        "message": "Wersja przeglądarki"
-    },
-    "bubbles": {
-        "message": "Dymki"
-    },
-    "buttons": {
-        "message": "Przyciski"
-    },
-    "cancel": {
-        "message": "Anuluj"
-    },
-    "categories": {
-        "message": "Kategorie"
-    },
-    "channel": {
-        "message": "Kanał"
-    },
-    "channels": {
-        "message": "Kanały"
-    },
-    "characterEdgeStyle": {
-        "message": "Styl krawędzi znaków"
-    },
-    "clipboard": {
-        "message": "Schowek"
-    },
-    "codecH264": {
-        "message": "Kodek h.264"
-    },
-    "codecs": {
-        "message": "Kodeki"
-    },
-    "collapsed": {
-        "message": "Zwinięte"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Zwinięcie sekcji subskrypcji"
-    },
-    "comments": {
-        "message": "Komentarze"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Potwierdzenie przy zamknięciu"
-    },
-    "cookies": {
-        "message": "Ciasteczka"
-    },
-    "cores": {
-        "message": "Rdzenie"
-    },
-    "cropChapterTitles": {
-        "message": "Przycinaj tytuły rozdziałów"
-    },
-    "custom": {
-        "message": "Niestandardowy"
-    },
-    "customCss": {
-        "message": "Niestandardowy CSS"
-    },
-    "customJs": {
-        "message": "Niestandardowy JS"
-    },
-    "customMiniPlayer": {
-        "message": "Niestandardowy Mini-Odtwarzacz"
-    },
-    "cyan": {
-        "message": "Cyjan"
-    },
-    "dark": {
-        "message": "Ciemny"
-    },
-    "darkTheme": {
-        "message": "Ciemny motyw"
-    },
-    "dateAndTime": {
-        "message": "Data i godzina"
-    },
-    "dawn": {
-        "message": "Świt"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Zmniejsz prędkość odtwarzania"
-    },
-    "decreaseVolume": {
-        "message": "Zmniejsz głośność"
-    },
-    "deepOrange": {
-        "message": "Głęboki pomarańczowy"
-    },
-    "deepPurple": {
-        "message": "Głęboki fioletowy"
-    },
-    "default": {
-        "message": "Domyślna"
-    },
-    "defaultChannelTab": {
-        "message": "Domyślna zakładka na kanałach"
-    },
-    "defaultContentCountry": {
-        "message": "Domyślny kraj zawartości"
-    },
-    "deleteWatchedVideos": {
-        "message": "Usuń obejrzane wideo"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Usuń ciasteczka YouTube"
-    },
-    "depressed": {
-        "message": "Wklęsłe"
-    },
-    "description": {
-        "message": "Opis"
-    },
-    "description_ext": {
-        "message": "Spraw, aby YouTube był uporządkowany i inteligentny! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
-    },
-    "desert": {
-        "message": "Pustynia"
-    },
-    "details": {
-        "message": "Szczegóły"
-    },
-    "developerOptions": {
-        "message": "Ustawienia deweloperskie"
-    },
-    "device": {
-        "message": "Urządzenie"
-    },
-    "dim": {
-        "message": "Przyciemnij"
-    },
-    "disabled": {
-        "message": "Wyłączony"
-    },
-    "dislike": {
-        "message": "Nie podoba mi się"
-    },
-    "donate": {
-        "message": "Dotacja"
-    },
-    "doNotChange": {
-        "message": "Nie zmieniaj"
-    },
-    "draggable": {
-        "message": "Przeciągalne"
-    },
-    "dropShadow": {
-        "message": "Cień"
-    },
-    "empty": {
-        "message": "Pusty"
-    },
-    "enabled": {
-        "message": "Włączony"
-    },
-    "enabledForced": {
-        "message": "Włączony (wymuszony)"
-    },
-    "expanded": {
-        "message": "Rozwinięty"
-    },
-    "exportSettings": {
-        "message": "Eksport ustawień"
-    },
-    "extension": {
-        "message": "Rozszerzenie"
-    },
-    "file": {
-        "message": "Plik"
-    },
-    "filters": {
-        "message": "Filtry"
-    },
-    "fitToWindow": {
-        "message": "Dopasuj do okna"
-    },
-    "flash": {
-        "message": "Błysk"
-    },
-    "font": {
-        "message": "Czcionka"
-    },
-    "fontColor": {
-        "message": "Kolor czcionki"
-    },
-    "fontFamily": {
-        "message": "Rodzaj czcionki"
-    },
-    "fontOpacity": {
-        "message": "Przezroczystość czcionki"
-    },
-    "fontSize": {
-        "message": "Rozmiar czcionki"
-    },
-    "footer": {
-        "message": "Stopka"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Wymuś prędkość odtwarzania"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Wymuś odtwarzanie wideo od początku"
-    },
-    "forcedTheaterMode": {
-        "message": "Wymuś tryb kinowy"
-    },
-    "forcedVolume": {
-        "message": "Wymuś poziom głośności"
-    },
-    "forceSDR": {
-        "message": "Wymuś SDR"
-    },
-    "foundABug": {
-        "message": "Znalazłeś błąd?"
-    },
-    "fullWindow": {
-        "message": "Pełne okno"
-    },
-    "general": {
-        "message": "Ogólne"
-    },
-    "geoPreference": {
-        "message": "Geo preferencja"
-    },
-    "googleApiKey": {
-        "message": "Klucz Google API"
-    },
-    "goToSearchBox": {
-        "message": "Idź do paska wyszukiwania"
-    },
-    "green": {
-        "message": "Zielony"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura HD"
-    },
-    "header": {
-        "message": "Nagłówek"
-    },
-    "hidden": {
-        "message": "Ukryty"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Ukryty na stronie z wideo"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Ukryj animowane miniatury"
-    },
-    "hideAnnotations": {
-        "message": "Ukryj adnotacje"
-    },
-    "hideCards": {
-        "message": "Ukryj karty"
-    },
-    "hideCountryCode": {
-        "message": "Ukryj kod kraju"
-    },
-    "hideDate": {
-        "message": "Ukryj datę"
-    },
-    "hideDetailButton": {
-        "message": "Ukryj przycisk Szczegóły"
-    },
-    "hideDetails": {
-        "message": "Ukryj szczegóły"
-    },
-    "hideEndscreen": {
-        "message": "Ukryj ekran końcowy"
-    },
-    "hideFeaturedContent": {
-        "message": "Ukryj wyróżnioną zawartość"
-    },
-    "hideFooter": {
-        "message": "Ukryj stopkę"
-    },
-    "hideGradientBottom": {
-        "message": "Ukryj cień dookoła paska odtwarzania"
-    },
-    "hideHomePageShorts": {
-        "message": "Usuń Shorts z głównej strony"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ukryj pasek sterowania odtwarzaczem"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ukryj przyciski paska sterowania odtwarzaczem"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ukryj przyciski paska sterowania odtwarzaczem - ustawienia"
-    },
-    "hidePlaylist": {
-        "message": "Ukryj playliste"
-    },
-    "hideRightButtons": {
-        "message": "Ukryj przyciski po prawej"
-    },
-    "hideScrollForDetails": {
-        "message": "Ukryj «Przewiń do szczegółów»"
-    },
-    "hideSkipOverlay": {
-        "message": "Ukryj nakładkę pomijania"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ukryj przyciski na miniaturach"
-    },
-    "hideThumbnails": {
-        "message": "Ukryj miniatury"
-    },
-    "hideViewsCount": {
-        "message": "Ukryj ilość wyświetleń"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ukryj przycisk wyszukiwania głosowego"
-    },
-    "high": {
-        "message": "Wysoka"
-    },
-    "history": {
-        "message": "Historia"
-    },
-    "home": {
-        "message": "Strona główna"
-    },
-    "hover": {
-        "message": "Najedź"
-    },
-    "hoverOnVideoPage": {
-        "message": "Najedź na stronie wideo"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Jak dawno wideo zostało przesłane"
-    },
-    "icons": {
-        "message": "Ikony"
-    },
-    "iconsOnly": {
-        "message": "Tylko ikony"
-    },
-    "importSettings": {
-        "message": "Import ustawień"
-    },
-    "improvedtubeButtons": {
-        "message": "Przyciski ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ikona ImprovedTube na YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Język ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Wersja ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Ulepsz logo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Zwiększ prędkość odtwarzania"
-    },
-    "increaseVolume": {
-        "message": "Zwiększ głośność"
-    },
-    "indigo": {
-        "message": "Indygo"
-    },
-    "items": {
-        "message": "Przedmioty"
-    },
-    "language": {
-        "message": "Język"
-    },
-    "languages": {
-        "message": "Języki"
-    },
-    "legacyYoutube": {
-        "message": "Stara wersja YouTube"
-    },
-    "library": {
-        "message": "Biblioteka"
-    },
-    "light": {
-        "message": "Jasny"
-    },
-    "lightBlue": {
-        "message": "Jasnoniebieski"
-    },
-    "lightGreen": {
-        "message": "Jasnozielony"
-    },
-    "like": {
-        "message": "Polub"
-    },
-    "liked": {
-        "message": "Polubione"
-    },
-    "lime": {
-        "message": "Limonkowy"
-    },
-    "limitPageWidth": {
-        "message": "Ogranicz szerokość strony"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Czat na żywo"
-    },
-    "liveChatType": {
-        "message": "Rodzaj czatu na żywo"
-    },
-    "location": {
-        "message": "Położenie"
-    },
-    "loop": {
-        "message": "Pętla"
-    },
-    "loudnessNormalization": {
-        "message": "Normalizacja głośności"
-    },
-    "low": {
-        "message": "Niska"
-    },
-    "markWatchedVideos": {
-        "message": "Oznacz obejrzane wideo"
-    },
-    "medium": {
-        "message": "Średnia"
-    },
-    "mixer": {
-        "message": "Mikser"
-    },
-    "moveSidebarLeft": {
-        "message": "Przenieś panel boczny na lewo"
-    },
-    "moveThumbnailsRight": {
-        "message": "Przenieś miniatury na prawo"
-    },
-    "myColors": {
-        "message": "Moje kolory"
-    },
-    "name": {
-        "message": "Nazwa"
-    },
-    "nativeMiniPlayer": {
-        "message": "Natywny mini-odtwarzacz"
-    },
-    "new": {
-        "message": "Nowe"
-    },
-    "nextVideo": {
-        "message": "Następne wideo"
-    },
-    "night": {
-        "message": "Noc"
-    },
-    "noActiveFeatures": {
-        "message": "Brak aktywnych funkcji"
-    },
-    "none": {
-        "message": "Brak"
-    },
-    "noOpenVideoTabs": {
-        "message": "Brak otwartych kart wideo"
-    },
-    "normal": {
-        "message": "Normalny"
-    },
-    "off": {
-        "message": "Wyłączone"
-    },
-    "old": {
-        "message": "Stary"
-    },
-    "onAllVideos": {
-        "message": "Na wszystkich wideo"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Aktywny tylko na YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Odtwarzanie tylko w jednej instancji odtwarzacza"
-    },
-    "onSubscribedChannels": {
-        "message": "Na subskrybowanych kanałach"
-    },
-    "openPopupPlayer": {
-        "message": "Otwórz wideo/playliste w nowym oknie"
-    },
-    "orange": {
-        "message": "Pomarańczowy"
-    },
-    "other": {
-        "message": "Inne"
-    },
-    "outline": {
-        "message": "Kontur"
-    },
-    "overlay": {
-        "message": "Nakładka"
-    },
-    "permissions": {
-        "message": "Uprawnienia"
-    },
-    "pictureInPicture": {
-        "message": "Obraz w Obrazie"
-    },
-    "pink": {
-        "message": "Różowy"
-    },
-    "plain": {
-        "message": "Zwykły"
-    },
-    "platform": {
-        "message": "Platforma"
-    },
-    "playAllButton": {
-        "message": "Przycisk \"Odtwórz wszystko\""
-    },
-    "playbackSpeed": {
-        "message": "Prędkość odtwarzania"
-    },
-    "player": {
-        "message": "Odtwarzacz"
-    },
-    "playerColor": {
-        "message": "Kolor odtwarzacza"
-    },
-    "playerSize": {
-        "message": "Rozmiar odtwarzacza"
-    },
-    "playlist": {
-        "message": "Lista odtwarzania"
-    },
-    "playlists": {
-        "message": "Listy odtwarzania"
-    },
-    "playPause": {
-        "message": "Odtwarzanie / Pauza"
-    },
-    "popupPlayer": {
-        "message": "Odtwarzacz popout"
-    },
-    "position": {
-        "message": "Pozycja"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Wciśnij dowolny przycisk lub użyj kółka myszy."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Wciśnij dowolny przycisk lub użyj kółka myszy"
-    },
-    "previousVideo": {
-        "message": "Poprzednie wideo"
-    },
-    "primaryColor": {
-        "message": "Kolor główny"
-    },
-    "purple": {
-        "message": "Fioletowy"
-    },
-    "quality": {
-        "message": "Jakość"
-    },
-    "qualityWithoutFocus": {
-        "message": "Jakość bez ostrości"
-    },
-    "raised": {
-        "message": "Podniesione"
-    },
-    "rateMe": {
-        "message": "Oceń mnie"
-    },
-    "rateUs": {
-        "message": "Oceń nas"
-    },
-    "red": {
-        "message": "Czerwony"
-    },
-    "redDislikeButton": {
-        "message": "Koloruj przycisk 'Nie lubię' na czerwono"
-    },
-    "relatedVideos": {
-        "message": "Powiązane filmy"
-    },
-    "remote": {
-        "message": "Odtwarzaj na telewizorze"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Usuń powiązane wyniki wyszukiwania"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Usuń karuzelę Shorts z wyników wyszukiwania"
-    },
-    "repeat": {
-        "message": "Powtarzaj"
-    },
-    "resetAllSettings": {
-        "message": "Resetuj wszystkie ustawienia"
-    },
-    "resetAllShortcuts": {
-        "message": "Resetuj wszystkie skróty"
-    },
-    "reverse": {
-        "message": "Odwróć"
-    },
-    "rotate": {
-        "message": "Obróć"
-    },
-    "save": {
-        "message": "Zapisz"
-    },
-    "saveAs": {
-        "message": "Zapisz jako"
-    },
-    "schedule": {
-        "message": "Harmonogram"
-    },
-    "screen": {
-        "message": "Ekran"
-    },
-    "screenshot": {
-        "message": "Zrzut ekranu"
-    },
-    "scrollBar": {
-        "message": "Pasek przewijania"
-    },
-    "search": {
-        "message": "Wyszukaj"
-    },
-    "searchBarOnly": {
-        "message": "Tylko pasek wyszukiwania"
-    },
-    "seekBackward10Seconds": {
-        "message": "Przewiń 10 sekund do tyłu"
-    },
-    "seekForward10Seconds": {
-        "message": "Przewiń 10 sekund do przodu"
-    },
-    "seekNextChapter": {
-        "message": "Przewiń do następnego rozdziału"
-    },
-    "seekPreviousChapter": {
-        "message": "Przewiń do poprzedniego rozdziału"
-    },
-    "settings": {
-        "message": "Ustawienia"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Ustawienia pomyślnie zaimportowane"
-    },
-    "share": {
-        "message": "Udostępnij"
-    },
-    "shortcuts": {
-        "message": "Skróty"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Pokaż karty po najechaniu myszą"
-    },
-    "showChannelVideosCount": {
-        "message": "Pokaż ilość wideo na kanale"
-    },
-    "showLess": {
-        "message": "Pokaż mniej"
-    },
-    "showMore": {
-        "message": "Pokaż więcej"
-    },
-    "showRemainingDuration": {
-        "message": "Pokaż pozostały czas trwania filmu"
-    },
-    "shuffle": {
-        "message": "Losowo"
-    },
-    "sidebar": {
-        "message": "Panel boczny"
-    },
-    "spacebar": {
-        "message": "Spacja"
-    },
-    "squaredUserImages": {
-        "message": "Kwadratowe avatary użytkowników"
-    },
-    "static": {
-        "message": "Statyczne"
-    },
-    "statsForNerds": {
-        "message": "Statystyki dla nerdów"
-    },
-    "step": {
-        "message": "Stopień"
-    },
-    "style": {
-        "message": "Styl"
-    },
-    "styles": {
-        "message": "Style"
-    },
-    "subscribe": {
-        "message": "Subskrybuj"
-    },
-    "subscriptions": {
-        "message": "Subskrypcje"
-    },
-    "subtitles": {
-        "message": "Napisy"
-    },
-    "sunset": {
-        "message": "Zachód"
-    },
-    "sunsetToSunrise": {
-        "message": "Od zachodu do wschodu słońca"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferencja systemowa: ciemne"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferencja systemowa: jasne"
-    },
-    "teal": {
-        "message": "Morski"
-    },
-    "textColor": {
-        "message": "Kolor tekstu"
-    },
-    "themes": {
-        "message": "Motywy"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "To usunie wszystkie ciasteczka."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "To usunie wszystkie obejrzane wideo."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "To usunie wszystkie ciasteczka YouTube."
-    },
-    "thisWillResetAllSettings": {
-        "message": "To zresetuje wszystkie ustawienia."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "To zresetuje wszystkie skróty"
-    },
-    "thumbnails": {
-        "message": "Miniatury"
-    },
-    "thumbnailsQuality": {
-        "message": "Jakość miniatur"
-    },
-    "timeFrom": {
-        "message": "Od"
-    },
-    "timeTo": {
-        "message": "Do"
-    },
-    "todayAt": {
-        "message": "Dzisiaj o"
-    },
-    "toggleAutoplay": {
-        "message": "Przełącz autoodtwarzanie"
-    },
-    "toggleCards": {
-        "message": "Przełącz karty"
-    },
-    "toggleControls": {
-        "message": "Przełącz widoczność sterowania odtwarzaczew"
-    },
-    "topChat": {
-        "message": "Czat na górze"
-    },
-    "trackWatchedVideos": {
-        "message": "Śledź obejrzane wideo"
-    },
-    "trailerAutoplay": {
-        "message": "Autoodtwarzanie zwiastunów"
-    },
-    "translations": {
-        "message": "Tłumaczenia"
-    },
-    "transparentBackground": {
-        "message": "Przezroczyste tło"
-    },
-    "trending": {
-        "message": "Na czasie"
-    },
-    "tryToReloadThePage": {
-        "message": "Spróbuj odświeżyć stronę"
-    },
-    "type": {
-        "message": "Typ"
-    },
-    "upNextAutoplay": {
-        "message": "Autoodwarzanie następnego wideo"
-    },
-    "use24HourFormat": {
-        "message": "Używaj 24-godzinnego formatu czasu"
-    },
-    "version": {
-        "message": "Wersja"
-    },
-    "video": {
-        "message": "Wideo"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Opis wideo zostanie rozwinięty aby pozyskać nazwę kategorii"
-    },
-    "videoFormats": {
-        "message": "Formaty wideo"
-    },
-    "videos": {
-        "message": "Wideo"
-    },
-    "viewMode": {
-        "message": "Tryb widoku"
-    },
-    "volume": {
-        "message": "Głośność"
-    },
-    "watchLater": {
-        "message": "Obejrzyj później"
-    },
-    "watchTime": {
-        "message": "Czas oglądania"
-    },
-    "whenPaused": {
-        "message": "Kiedy wideo jest zatrzymane"
-    },
-    "whenTabIsChanged": {
-        "message": "Kiedy zostaje zmieniona karta"
-    },
-    "white": {
-        "message": "Biały"
-    },
-    "windowColor": {
-        "message": "Kolor okna"
-    },
-    "windowOpacity": {
-        "message": "Przezroczystość okna"
-    },
-    "yellow": {
-        "message": "Żółty"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Nagłówek YouTube (lewy)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Nagłówek YouTube (prawy)"
-    },
-    "youtubeHomePage": {
-        "message": "Strona główna YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Język YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube ogranicza jakość wideo do 1080p przy kodeku h.264"
-    }
+	"about": {
+		"message": "Informacje"
+	},
+	"accept": {
+		"message": "Akceptuj"
+	},
+	"activate": {
+		"message": "Aktywuj"
+	},
+	"activateCaptions": {
+		"message": "Aktywuj napisy"
+	},
+	"activated": {
+		"message": "Aktywowane"
+	},
+	"activatedFeatures": {
+		"message": "Aktywowane funkcje"
+	},
+	"activateFullscreen": {
+		"message": "Aktywuj tryb pełnoekranowy"
+	},
+	"activeFeatures": {
+		"message": "Aktywne funkcje"
+	},
+	"addScrollToTop": {
+		"message": "Dodaj «Przewiń do góry»"
+	},
+	"ads": {
+		"message": "Reklamy"
+	},
+	"all": {
+		"message": "Wszystkie"
+	},
+	"allow": {
+		"message": "Zezwól"
+	},
+	"always": {
+		"message": "Zawsze"
+	},
+	"alwaysActive": {
+		"message": "Zawsze aktywne"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Zawsze pokazuj pasek postępu"
+	},
+	"amber": {
+		"message": "Bursztynowy"
+	},
+	"analyzer": {
+		"message": "Analizator"
+	},
+	"appearance": {
+		"message": "Wygląd"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Jesteś pewien że chcesz wyeksportować dane?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Jesteś pewien że chcesz zaimportować dane?"
+	},
+	"audioFormats": {
+		"message": "Formaty audio"
+	},
+	"autoFullscreen": {
+		"message": "Automatyczny tryb pełnoekranowy"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Automatyczna pauza przy zmianie kart"
+	},
+	"autoplay": {
+		"message": "Autoodtwarzanie"
+	},
+	"avoidAv1": {
+		"message": "Unikaj AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Unikaj AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Unikaj AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Unikaj renderowania CPU gdy tylko możliwe"
+	},
+	"backgroundColor": {
+		"message": "Kolor tła"
+	},
+	"backgroundOpacity": {
+		"message": "Przezroczystość tła"
+	},
+	"backupAndReset": {
+		"message": "Kopia zapasowa i reset"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Bazuj na systemowym schemacie kolorów"
+	},
+	"belowPlayer": {
+		"message": "Pod odtwarzaczem"
+	},
+	"black": {
+		"message": "Czarny"
+	},
+	"blockAll": {
+		"message": "Blokuj wszystkie"
+	},
+	"blockAv1": {
+		"message": "Blokuj AV1"
+	},
+	"blockH264": {
+		"message": "Blokuj H.264"
+	},
+	"blocklist": {
+		"message": "Czarna lista"
+	},
+	"blockMusic": {
+		"message": "Blokuj muzykę"
+	},
+	"blockVp8": {
+		"message": "Blokuj VP8"
+	},
+	"blockVp9": {
+		"message": "Blokuj VP9"
+	},
+	"blue": {
+		"message": "Niebieski"
+	},
+	"blueGray": {
+		"message": "Szaroniebieski"
+	},
+	"bluelight": {
+		"message": "Niebieskie światło"
+	},
+	"brown": {
+		"message": "Brązowy"
+	},
+	"browser": {
+		"message": "Przeglądarka"
+	},
+	"browserVersion": {
+		"message": "Wersja przeglądarki"
+	},
+	"bubbles": {
+		"message": "Dymki"
+	},
+	"buttons": {
+		"message": "Przyciski"
+	},
+	"cancel": {
+		"message": "Anuluj"
+	},
+	"categories": {
+		"message": "Kategorie"
+	},
+	"channel": {
+		"message": "Kanał"
+	},
+	"channels": {
+		"message": "Kanały"
+	},
+	"characterEdgeStyle": {
+		"message": "Styl krawędzi znaków"
+	},
+	"clipboard": {
+		"message": "Schowek"
+	},
+	"codecH264": {
+		"message": "Kodek h.264"
+	},
+	"codecs": {
+		"message": "Kodeki"
+	},
+	"collapsed": {
+		"message": "Zwinięte"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Zwinięcie sekcji subskrypcji"
+	},
+	"comments": {
+		"message": "Komentarze"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Potwierdzenie przy zamknięciu"
+	},
+	"cookies": {
+		"message": "Ciasteczka"
+	},
+	"cores": {
+		"message": "Rdzenie"
+	},
+	"cropChapterTitles": {
+		"message": "Przycinaj tytuły rozdziałów"
+	},
+	"custom": {
+		"message": "Niestandardowy"
+	},
+	"customCss": {
+		"message": "Niestandardowy CSS"
+	},
+	"customJs": {
+		"message": "Niestandardowy JS"
+	},
+	"customMiniPlayer": {
+		"message": "Niestandardowy Mini-Odtwarzacz"
+	},
+	"cyan": {
+		"message": "Cyjan"
+	},
+	"dark": {
+		"message": "Ciemny"
+	},
+	"darkTheme": {
+		"message": "Ciemny motyw"
+	},
+	"dateAndTime": {
+		"message": "Data i godzina"
+	},
+	"dawn": {
+		"message": "Świt"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Zmniejsz prędkość odtwarzania"
+	},
+	"decreaseVolume": {
+		"message": "Zmniejsz głośność"
+	},
+	"deepOrange": {
+		"message": "Głęboki pomarańczowy"
+	},
+	"deepPurple": {
+		"message": "Głęboki fioletowy"
+	},
+	"default": {
+		"message": "Domyślna"
+	},
+	"defaultChannelTab": {
+		"message": "Domyślna zakładka na kanałach"
+	},
+	"defaultContentCountry": {
+		"message": "Domyślny kraj zawartości"
+	},
+	"deleteWatchedVideos": {
+		"message": "Usuń obejrzane wideo"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Usuń ciasteczka YouTube"
+	},
+	"depressed": {
+		"message": "Wklęsłe"
+	},
+	"description": {
+		"message": "Opis"
+	},
+	"description_ext": {
+		"message": "Spraw, aby YouTube był uporządkowany i inteligentny! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+	},
+	"desert": {
+		"message": "Pustynia"
+	},
+	"details": {
+		"message": "Szczegóły"
+	},
+	"developerOptions": {
+		"message": "Ustawienia deweloperskie"
+	},
+	"device": {
+		"message": "Urządzenie"
+	},
+	"dim": {
+		"message": "Przyciemnij"
+	},
+	"disabled": {
+		"message": "Wyłączony"
+	},
+	"dislike": {
+		"message": "Nie podoba mi się"
+	},
+	"donate": {
+		"message": "Dotacja"
+	},
+	"doNotChange": {
+		"message": "Nie zmieniaj"
+	},
+	"draggable": {
+		"message": "Przeciągalne"
+	},
+	"dropShadow": {
+		"message": "Cień"
+	},
+	"empty": {
+		"message": "Pusty"
+	},
+	"enabled": {
+		"message": "Włączony"
+	},
+	"enabledForced": {
+		"message": "Włączony (wymuszony)"
+	},
+	"expanded": {
+		"message": "Rozwinięty"
+	},
+	"exportSettings": {
+		"message": "Eksport ustawień"
+	},
+	"extension": {
+		"message": "Rozszerzenie"
+	},
+	"file": {
+		"message": "Plik"
+	},
+	"filters": {
+		"message": "Filtry"
+	},
+	"fitToWindow": {
+		"message": "Dopasuj do okna"
+	},
+	"flash": {
+		"message": "Błysk"
+	},
+	"font": {
+		"message": "Czcionka"
+	},
+	"fontColor": {
+		"message": "Kolor czcionki"
+	},
+	"fontFamily": {
+		"message": "Rodzaj czcionki"
+	},
+	"fontOpacity": {
+		"message": "Przezroczystość czcionki"
+	},
+	"fontSize": {
+		"message": "Rozmiar czcionki"
+	},
+	"footer": {
+		"message": "Stopka"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Wymuś prędkość odtwarzania"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Wymuś odtwarzanie wideo od początku"
+	},
+	"forcedTheaterMode": {
+		"message": "Wymuś tryb kinowy"
+	},
+	"forcedVolume": {
+		"message": "Wymuś poziom głośności"
+	},
+	"forceSDR": {
+		"message": "Wymuś SDR"
+	},
+	"foundABug": {
+		"message": "Znalazłeś błąd?"
+	},
+	"fullWindow": {
+		"message": "Pełne okno"
+	},
+	"general": {
+		"message": "Ogólne"
+	},
+	"geoPreference": {
+		"message": "Geo preferencja"
+	},
+	"googleApiKey": {
+		"message": "Klucz Google API"
+	},
+	"goToSearchBox": {
+		"message": "Idź do paska wyszukiwania"
+	},
+	"green": {
+		"message": "Zielony"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura HD"
+	},
+	"header": {
+		"message": "Nagłówek"
+	},
+	"hidden": {
+		"message": "Ukryty"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Ukryty na stronie z wideo"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Ukryj animowane miniatury"
+	},
+	"hideAnnotations": {
+		"message": "Ukryj adnotacje"
+	},
+	"hideCards": {
+		"message": "Ukryj karty"
+	},
+	"hideCountryCode": {
+		"message": "Ukryj kod kraju"
+	},
+	"hideDate": {
+		"message": "Ukryj datę"
+	},
+	"hideDetailButton": {
+		"message": "Ukryj przycisk Szczegóły"
+	},
+	"hideDetails": {
+		"message": "Ukryj szczegóły"
+	},
+	"hideEndscreen": {
+		"message": "Ukryj ekran końcowy"
+	},
+	"hideFeaturedContent": {
+		"message": "Ukryj wyróżnioną zawartość"
+	},
+	"hideFooter": {
+		"message": "Ukryj stopkę"
+	},
+	"hideGradientBottom": {
+		"message": "Ukryj cień dookoła paska odtwarzania"
+	},
+	"hideHomePageShorts": {
+		"message": "Usuń Shorts z głównej strony"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ukryj pasek sterowania odtwarzaczem"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ukryj przyciski paska sterowania odtwarzaczem"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ukryj przyciski paska sterowania odtwarzaczem - ustawienia"
+	},
+	"hidePlaylist": {
+		"message": "Ukryj playliste"
+	},
+	"hideRightButtons": {
+		"message": "Ukryj przyciski po prawej"
+	},
+	"hideScrollForDetails": {
+		"message": "Ukryj «Przewiń do szczegółów»"
+	},
+	"hideSkipOverlay": {
+		"message": "Ukryj nakładkę pomijania"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ukryj przyciski na miniaturach"
+	},
+	"hideThumbnails": {
+		"message": "Ukryj miniatury"
+	},
+	"hideViewsCount": {
+		"message": "Ukryj ilość wyświetleń"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ukryj przycisk wyszukiwania głosowego"
+	},
+	"high": {
+		"message": "Wysoka"
+	},
+	"history": {
+		"message": "Historia"
+	},
+	"home": {
+		"message": "Strona główna"
+	},
+	"hover": {
+		"message": "Najedź"
+	},
+	"hoverOnVideoPage": {
+		"message": "Najedź na stronie wideo"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Jak dawno wideo zostało przesłane"
+	},
+	"icons": {
+		"message": "Ikony"
+	},
+	"iconsOnly": {
+		"message": "Tylko ikony"
+	},
+	"importSettings": {
+		"message": "Import ustawień"
+	},
+	"improvedtubeButtons": {
+		"message": "Przyciski ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ikona ImprovedTube na YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Język ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Wersja ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Ulepsz logo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Zwiększ prędkość odtwarzania"
+	},
+	"increaseVolume": {
+		"message": "Zwiększ głośność"
+	},
+	"indigo": {
+		"message": "Indygo"
+	},
+	"items": {
+		"message": "Przedmioty"
+	},
+	"language": {
+		"message": "Język"
+	},
+	"languages": {
+		"message": "Języki"
+	},
+	"legacyYoutube": {
+		"message": "Stara wersja YouTube"
+	},
+	"library": {
+		"message": "Biblioteka"
+	},
+	"light": {
+		"message": "Jasny"
+	},
+	"lightBlue": {
+		"message": "Jasnoniebieski"
+	},
+	"lightGreen": {
+		"message": "Jasnozielony"
+	},
+	"like": {
+		"message": "Polub"
+	},
+	"liked": {
+		"message": "Polubione"
+	},
+	"lime": {
+		"message": "Limonkowy"
+	},
+	"limitPageWidth": {
+		"message": "Ogranicz szerokość strony"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Czat na żywo"
+	},
+	"liveChatType": {
+		"message": "Rodzaj czatu na żywo"
+	},
+	"location": {
+		"message": "Położenie"
+	},
+	"loop": {
+		"message": "Pętla"
+	},
+	"loudnessNormalization": {
+		"message": "Normalizacja głośności"
+	},
+	"low": {
+		"message": "Niska"
+	},
+	"markWatchedVideos": {
+		"message": "Oznacz obejrzane wideo"
+	},
+	"medium": {
+		"message": "Średnia"
+	},
+	"mixer": {
+		"message": "Mikser"
+	},
+	"moveSidebarLeft": {
+		"message": "Przenieś panel boczny na lewo"
+	},
+	"moveThumbnailsRight": {
+		"message": "Przenieś miniatury na prawo"
+	},
+	"myColors": {
+		"message": "Moje kolory"
+	},
+	"name": {
+		"message": "Nazwa"
+	},
+	"nativeMiniPlayer": {
+		"message": "Natywny mini-odtwarzacz"
+	},
+	"new": {
+		"message": "Nowe"
+	},
+	"nextVideo": {
+		"message": "Następne wideo"
+	},
+	"night": {
+		"message": "Noc"
+	},
+	"noActiveFeatures": {
+		"message": "Brak aktywnych funkcji"
+	},
+	"none": {
+		"message": "Brak"
+	},
+	"noOpenVideoTabs": {
+		"message": "Brak otwartych kart wideo"
+	},
+	"normal": {
+		"message": "Normalny"
+	},
+	"off": {
+		"message": "Wyłączone"
+	},
+	"old": {
+		"message": "Stary"
+	},
+	"onAllVideos": {
+		"message": "Na wszystkich wideo"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Aktywny tylko na YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Odtwarzanie tylko w jednej instancji odtwarzacza"
+	},
+	"onSubscribedChannels": {
+		"message": "Na subskrybowanych kanałach"
+	},
+	"openPopupPlayer": {
+		"message": "Otwórz wideo/playliste w nowym oknie"
+	},
+	"orange": {
+		"message": "Pomarańczowy"
+	},
+	"other": {
+		"message": "Inne"
+	},
+	"outline": {
+		"message": "Kontur"
+	},
+	"overlay": {
+		"message": "Nakładka"
+	},
+	"permissions": {
+		"message": "Uprawnienia"
+	},
+	"pictureInPicture": {
+		"message": "Obraz w Obrazie"
+	},
+	"pink": {
+		"message": "Różowy"
+	},
+	"plain": {
+		"message": "Zwykły"
+	},
+	"platform": {
+		"message": "Platforma"
+	},
+	"playAllButton": {
+		"message": "Przycisk \"Odtwórz wszystko\""
+	},
+	"playbackSpeed": {
+		"message": "Prędkość odtwarzania"
+	},
+	"player": {
+		"message": "Odtwarzacz"
+	},
+	"playerColor": {
+		"message": "Kolor odtwarzacza"
+	},
+	"playerSize": {
+		"message": "Rozmiar odtwarzacza"
+	},
+	"playlist": {
+		"message": "Lista odtwarzania"
+	},
+	"playlists": {
+		"message": "Listy odtwarzania"
+	},
+	"playPause": {
+		"message": "Odtwarzanie / Pauza"
+	},
+	"popupPlayer": {
+		"message": "Odtwarzacz popout"
+	},
+	"position": {
+		"message": "Pozycja"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Wciśnij dowolny przycisk lub użyj kółka myszy."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Wciśnij dowolny przycisk lub użyj kółka myszy"
+	},
+	"previousVideo": {
+		"message": "Poprzednie wideo"
+	},
+	"primaryColor": {
+		"message": "Kolor główny"
+	},
+	"purple": {
+		"message": "Fioletowy"
+	},
+	"quality": {
+		"message": "Jakość"
+	},
+	"qualityWithoutFocus": {
+		"message": "Jakość bez ostrości"
+	},
+	"raised": {
+		"message": "Podniesione"
+	},
+	"rateMe": {
+		"message": "Oceń mnie"
+	},
+	"rateUs": {
+		"message": "Oceń nas"
+	},
+	"red": {
+		"message": "Czerwony"
+	},
+	"redDislikeButton": {
+		"message": "Koloruj przycisk 'Nie lubię' na czerwono"
+	},
+	"relatedVideos": {
+		"message": "Powiązane filmy"
+	},
+	"remote": {
+		"message": "Odtwarzaj na telewizorze"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Usuń powiązane wyniki wyszukiwania"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Usuń karuzelę Shorts z wyników wyszukiwania"
+	},
+	"repeat": {
+		"message": "Powtarzaj"
+	},
+	"resetAllSettings": {
+		"message": "Resetuj wszystkie ustawienia"
+	},
+	"resetAllShortcuts": {
+		"message": "Resetuj wszystkie skróty"
+	},
+	"reverse": {
+		"message": "Odwróć"
+	},
+	"rotate": {
+		"message": "Obróć"
+	},
+	"save": {
+		"message": "Zapisz"
+	},
+	"saveAs": {
+		"message": "Zapisz jako"
+	},
+	"schedule": {
+		"message": "Harmonogram"
+	},
+	"screen": {
+		"message": "Ekran"
+	},
+	"screenshot": {
+		"message": "Zrzut ekranu"
+	},
+	"scrollBar": {
+		"message": "Pasek przewijania"
+	},
+	"search": {
+		"message": "Wyszukaj"
+	},
+	"searchBarOnly": {
+		"message": "Tylko pasek wyszukiwania"
+	},
+	"seekBackward10Seconds": {
+		"message": "Przewiń 10 sekund do tyłu"
+	},
+	"seekForward10Seconds": {
+		"message": "Przewiń 10 sekund do przodu"
+	},
+	"seekNextChapter": {
+		"message": "Przewiń do następnego rozdziału"
+	},
+	"seekPreviousChapter": {
+		"message": "Przewiń do poprzedniego rozdziału"
+	},
+	"settings": {
+		"message": "Ustawienia"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Ustawienia pomyślnie zaimportowane"
+	},
+	"share": {
+		"message": "Udostępnij"
+	},
+	"shortcuts": {
+		"message": "Skróty"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Pokaż karty po najechaniu myszą"
+	},
+	"showChannelVideosCount": {
+		"message": "Pokaż ilość wideo na kanale"
+	},
+	"showLess": {
+		"message": "Pokaż mniej"
+	},
+	"showMore": {
+		"message": "Pokaż więcej"
+	},
+	"showRemainingDuration": {
+		"message": "Pokaż pozostały czas trwania filmu"
+	},
+	"shuffle": {
+		"message": "Losowo"
+	},
+	"sidebar": {
+		"message": "Panel boczny"
+	},
+	"spacebar": {
+		"message": "Spacja"
+	},
+	"squaredUserImages": {
+		"message": "Kwadratowe avatary użytkowników"
+	},
+	"static": {
+		"message": "Statyczne"
+	},
+	"statsForNerds": {
+		"message": "Statystyki dla nerdów"
+	},
+	"step": {
+		"message": "Stopień"
+	},
+	"style": {
+		"message": "Styl"
+	},
+	"styles": {
+		"message": "Style"
+	},
+	"subscribe": {
+		"message": "Subskrybuj"
+	},
+	"subscriptions": {
+		"message": "Subskrypcje"
+	},
+	"subtitles": {
+		"message": "Napisy"
+	},
+	"sunset": {
+		"message": "Zachód"
+	},
+	"sunsetToSunrise": {
+		"message": "Od zachodu do wschodu słońca"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferencja systemowa: ciemne"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferencja systemowa: jasne"
+	},
+	"teal": {
+		"message": "Morski"
+	},
+	"textColor": {
+		"message": "Kolor tekstu"
+	},
+	"themes": {
+		"message": "Motywy"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "To usunie wszystkie ciasteczka."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "To usunie wszystkie obejrzane wideo."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "To usunie wszystkie ciasteczka YouTube."
+	},
+	"thisWillResetAllSettings": {
+		"message": "To zresetuje wszystkie ustawienia."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "To zresetuje wszystkie skróty"
+	},
+	"thumbnails": {
+		"message": "Miniatury"
+	},
+	"thumbnailsQuality": {
+		"message": "Jakość miniatur"
+	},
+	"timeFrom": {
+		"message": "Od"
+	},
+	"timeTo": {
+		"message": "Do"
+	},
+	"todayAt": {
+		"message": "Dzisiaj o"
+	},
+	"toggleAutoplay": {
+		"message": "Przełącz autoodtwarzanie"
+	},
+	"toggleCards": {
+		"message": "Przełącz karty"
+	},
+	"toggleControls": {
+		"message": "Przełącz widoczność sterowania odtwarzaczew"
+	},
+	"topChat": {
+		"message": "Czat na górze"
+	},
+	"trackWatchedVideos": {
+		"message": "Śledź obejrzane wideo"
+	},
+	"trailerAutoplay": {
+		"message": "Autoodtwarzanie zwiastunów"
+	},
+	"translations": {
+		"message": "Tłumaczenia"
+	},
+	"transparentBackground": {
+		"message": "Przezroczyste tło"
+	},
+	"trending": {
+		"message": "Na czasie"
+	},
+	"tryToReloadThePage": {
+		"message": "Spróbuj odświeżyć stronę"
+	},
+	"type": {
+		"message": "Typ"
+	},
+	"upNextAutoplay": {
+		"message": "Autoodwarzanie następnego wideo"
+	},
+	"use24HourFormat": {
+		"message": "Używaj 24-godzinnego formatu czasu"
+	},
+	"version": {
+		"message": "Wersja"
+	},
+	"video": {
+		"message": "Wideo"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Opis wideo zostanie rozwinięty aby pozyskać nazwę kategorii"
+	},
+	"videoFormats": {
+		"message": "Formaty wideo"
+	},
+	"videos": {
+		"message": "Wideo"
+	},
+	"viewMode": {
+		"message": "Tryb widoku"
+	},
+	"volume": {
+		"message": "Głośność"
+	},
+	"watchLater": {
+		"message": "Obejrzyj później"
+	},
+	"watchTime": {
+		"message": "Czas oglądania"
+	},
+	"whenPaused": {
+		"message": "Kiedy wideo jest zatrzymane"
+	},
+	"whenTabIsChanged": {
+		"message": "Kiedy zostaje zmieniona karta"
+	},
+	"white": {
+		"message": "Biały"
+	},
+	"windowColor": {
+		"message": "Kolor okna"
+	},
+	"windowOpacity": {
+		"message": "Przezroczystość okna"
+	},
+	"yellow": {
+		"message": "Żółty"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Nagłówek YouTube (lewy)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Nagłówek YouTube (prawy)"
+	},
+	"youtubeHomePage": {
+		"message": "Strona główna YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Język YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube ogranicza jakość wideo do 1080p przy kodeku h.264"
+	}
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -1,1316 +1,1247 @@
 {
-    "about": {
-        "message": "Sobre"
-    },
-    "accept": {
-        "message": "Aceitar"
-    },
-    "activate": {
-        "message": "Ativar"
-    },
-    "activateCaptions": {
-        "message": "Ativar legendas"
-    },
-    "activated": {
-        "message": "Ativado"
-    },
-    "activatedFeatures": {
-        "message": "Recursos ativados"
-    },
-    "activateFullscreen": {
-        "message": "Ativar tela cheia"
-    },
-    "activeFeatures": {
-        "message": "Recursos ativos"
-    },
-    "addScrollToTop": {
-        "message": "Adicionar «Voltar ao Topo»"
-    },
-    "ads": {
-        "message": "Anúncios"
-    },
-    "all": {
-        "message": "Todos"
-    },
-    "allow": {
-        "message": "Permitir"
-    },
-    "Allow_auto_generate": {
-        "message": "Permitir geração automática"
-    },
-    "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todas as suas configurações serão apagadas e não poderão ser recuperadas"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todos os seus atalhos serão apagados e não poderão ser recuperados"
-    },
-    "always": {
-        "message": "Sempre"
-    },
-    "alwaysActive": {
-        "message": "Sempre ativo"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Sempre exibir a barra de progresso"
-    },
-    "amber": {
-        "message": "Âmbar"
-    },
-    "analyzer": {
-        "message": "Analisador"
-    },
-    "animations": {
-        "message": "Animações"
-    },
-    "appearance": {
-        "message": "Aparência"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Tem certeza de que deseja exportar os dados?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Tem certeza de que deseja importar os dados?"
-    },
-    "areYouSureYouWantToSyncTheData": {
-        "message": "Tem certeza que deseja sincronizar as configurações atuais?"
-    },
-    "ARROWDOWN": {
-        "message": "⇩"
-    },
-    "ARROWLEFT": {
-        "message": "⇦"
-    },
-    "ARROWRIGHT": {
-        "message": "⇨"
-    },
-    "ARROWUP": {
-        "message": "⇧"
-    },
-    "atHistory": {
-        "message": "em 'Histórico'"
-    },
-    "atSubscriptions": {
-        "message": "Em Inscrições"
-    },
-    "atTrending": {
-        "message": "em 'Tendências'"
-    },
-    "audio": {
-        "message": "Áudio"
-    },
-    "audioFormats": {
-        "message": "Formatos de áudio"
-    },
-    "auto": {
-        "message": "Automático"
-    },
-    "Auto_PiP_picture_in_picture": {
-        "message": "Auto-PiP (Picture in picture)"
-    },
-    "autoFullscreen": {
-        "message": "Tela cheia automática"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausar vídeo automaticamente ao alternar entre abas"
-    },
-    "autoPictureInPicture": {
-        "message": "Auto Picture-In-Picture"
-    },
-    "autoplay": {
-        "message": "Reprodução automática"
-    },
-    "avoidAv1": {
-        "message": "Evitar AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Evitar AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Evitar AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Evite renderização da CPU quando possível"
-    },
-    "backgroundColor": {
-        "message": "Cor de fundo"
-    },
-    "backgroundOpacity": {
-        "message": "Opacidade do fundo"
-    },
-    "backupAndReset": {
-        "message": "Backup & Restauração"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baseado nas cores do sistema"
-    },
-    "belowPlayer": {
-        "message": "Abaixo do player"
-    },
-    "bitness": {
-        "message": "Taxa de bits do Sistema"
-    },
-    "black": {
-        "message": "Preto"
-    },
-    "block_Codec_Alert_h264": {
-        "message": "Você precisa ativar o H.264 ou VP9 para reproduzir vídeos."
-    },
-    "blockAll": {
-        "message": "Bloquear tudo"
-    },
-    "blockAv1": {
-        "message": "Bloquear AV1"
-    },
-    "blockH264": {
-        "message": "Bloquear H.264"
-    },
-    "blocklist": {
-        "message": "Lista Negra"
-    },
-    "blockMusic": {
-        "message": "Pule anúncios nos vídeos musicais"
-    },
-    "blockVp8": {
-        "message": "Bloquear VP8"
-    },
-    "blockVp9": {
-        "message": "Bloquear VP9"
-    },
-    "blue": {
-        "message": "Azul"
-    },
-    "blueGray": {
-        "message": "Cinza azulado"
-    },
-    "bluelight": {
-        "message": "Filtrar luz azul"
-    },
-    "brightness": {
-        "message": "Luminosidade"
-    },
-    "brown": {
-        "message": "Marrom"
-    },
-    "browser": {
-        "message": "Navegador"
-    },
-    "browserAccountSync": {
-        "message": "Sincronização (Conta do Navegador)"
-    },
-    "browserVersion": {
-        "message": "Versão do navegador"
-    },
-    "bubbles": {
-        "message": "Bolhas"
-    },
-    "bug": {
-        "message": "Erro"
-    },
-    "buttons": {
-        "message": "Botões"
-    },
-    "cancel": {
-        "message": "Cancelar"
-    },
-    "categories": {
-        "message": "Categorias"
-    },
-    "channel": {
-        "message": "Canal"
-    },
-    "channels": {
-        "message": "Canais"
-    },
-    "chapters": {
-        "message": "Capítulos"
-    },
-    "characterEdgeStyle": {
-        "message": "Estilo da borda"
-    },
-    "clip": {
-        "message": "Clip"
-    },
-    "clipboard": {
-        "message": "Àrea de transferência"
-    },
-    "codecH264": {
-        "message": "Codec h.264"
-    },
-    "codecs": {
-        "message": "Codecs"
-    },
-    "collapsed": {
-        "message": "Recolhido"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Recolher seções de assinatura"
-    },
-    "columns": {
-        "message": "Coluna da barra lateral extra (sem mover os vídeos relacionados, se a janela for larga o suficiente)"
-    },
-    "comments": {
-        "message": "Comentários"
-    },
-    "compact_spacing": {
-        "message": "Espaçamento compacto"
-    },
-    "compactTheme": {
-        "message": "Tema compacto"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Habilitar alerta para casos de fechamento acidental?"
-    },
-    "cookies": {
-        "message": "Cookies"
-    },
-    "cores": {
-        "message": "Núcleos"
-    },
-    "cropChapterTitles": {
-        "message": "Recortar títulos do capítulos"
-    },
-    "Currently_requiring_a_YouTube_API_key": {
-        "message": "(Necessário uma chave do YouTube-API: )"
-    },
-    "custom": {
-        "message": "Personalizar"
-    },
-    "customCss": {
-        "message": "Personalizar CSS"
-    },
-    "customJs": {
-        "message": "Personalizar JS"
-    },
-    "customMiniPlayer": {
-        "message": "Personalizar Mini-Player"
-    },
-    "cyan": {
-        "message": "Ciano"
-    },
-    "dark": {
-        "message": "Escuro"
-    },
-    "darkTheme": {
-        "message": "Tema Escuro"
-    },
-    "dateAndTime": {
-        "message": "Data & Hora"
-    },
-    "dawn": {
-        "message": "Alvorecer"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Diminuir velocidade"
-    },
-    "decreaseVolume": {
-        "message": "Diminuir volume"
-    },
-    "deepOrange": {
-        "message": "Laranja Escuro"
-    },
-    "deepPurple": {
-        "message": "Roxo Escuro"
-    },
-    "default": {
-        "message": "Padrão"
-    },
-    "default_CC": {
-        "message": "Padrão"
-    },
-    "default_theme": {
-        "message": "Tema padrão"
-    },
-    "defaultChannelTab": {
-        "message": "Aba padrão do canal "
-    },
-    "defaultContentCountry": {
-        "message": "Conteúdo padrão do país "
-    },
-    "defaultPlaybackSpeed": {
-        "message": "Velocidade padrão de reprodução"
-    },
-    "deleteWatchedVideos": {
-        "message": "Excluir vídeos assistidos"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Apagar cookies do YouTube"
-    },
-    "depressed": {
-        "message": "Comprimido"
-    },
-    "description": {
-        "message": "Descrição"
-    },
-    "description_ext": {
-        "message": "Torne o YouTube organizado e inteligente! Pular Anúncio, colorir YouTube, volume, velocidade, canal, ferramenta, estilo, HD, adblock, adblocker, tags, playlist ,palavras-chave"
-    },
-    "desert": {
-        "message": "Deserto"
-    },
-    "details": {
-        "message": "Detalhes"
-    },
-    "developerOptions": {
-        "message": "Opções do Desenvolvedor"
-    },
-    "device": {
-        "message": "Dispositivo"
-    },
-    "dim": {
-        "message": "Escurecer"
-    },
-    "disabled": {
-        "message": "Desativado"
-    },
-    "disableThumbnailPlayback": {
-        "message": "Desativar reprodução de vídeo ao passar o mouse"
-    },
-    "dislike": {
-        "message": "Não Gostei."
-    },
-    "displayDayOfTheWeak": {
-        "message": "Mostrar dia da Semana"
-    },
-    "donate": {
-        "message": "Doar"
-    },
-    "doNotChange": {
-        "message": "Não Alterar"
-    },
-    "download": {
-        "message": "Download"
-    },
-    "draggable": {
-        "message": "Arrastável"
-    },
-    "dropShadow": {
-        "message": "Sombra projetada"
-    },
-    "durationWithSpeed": {
-        "message": "Mostrar tempo restante com referência a velocidade de reprodução"
-    },
-    "email": {
-        "message": "Email"
-    },
-    "embedded_Hide_Share": {
-        "message": "Ocultar compartilhamento do video incorporado"
-    },
-    "Embedded_YouTube": {
-        "message": "Vídeos Incorporados"
-    },
-    "empty": {
-        "message": "Vazio"
-    },
-    "enabled": {
-        "message": "Ativado"
-    },
-    "enabledForced": {
-        "message": "Ativado (forçado)"
-    },
-    "expanded": {
-        "message": "Expandido"
-    },
-    "exportSettings": {
-        "message": "Exportar configurações"
-    },
-    "extension": {
-        "message": "Extensão"
-    },
-    "ExtraButtons": {
-        "message": "Botões extras"
-    },
-    "extraButtonsBelowThePlayer": {
-        "message": "Botões extras abaixo do player"
-    },
-    "Feature_not_yet_available": {
-        "message": "Recurso não está presente no momento"
-    },
-    "file": {
-        "message": "Arquivo"
-    },
-    "filters": {
-        "message": "Filtros"
-    },
-    "fitToWindow": {
-        "message": "Ajustar à janela"
-    },
-    "flash": {
-        "message": "Instantâneo"
-    },
-    "font": {
-        "message": "Fonte"
-    },
-    "fontColor": {
-        "message": "Cor da fonte"
-    },
-    "fontFamily": {
-        "message": "Família da fonte"
-    },
-    "fontOpacity": {
-        "message": "Opacidade da fonte"
-    },
-    "fontSize": {
-        "message": "Tamanho da fonte"
-    },
-    "footer": {
-        "message": "Rodapé"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Velocidade do reprodução forçado"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Forçar velocidade de reprodução mesmo para música?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Reprodução do vídeo desde o início forçado"
-    },
-    "forcedTheaterMode": {
-        "message": "Modo teatro forçado"
-    },
-    "forcedVolume": {
-        "message": "Volume forçado"
-    },
-    "forceSDR": {
-        "message": "Forçar SDR"
-    },
-    "foundABug": {
-        "message": "Encontrou um Bug?"
-    },
-    "fullWindow": {
-        "message": "Tela Cheia"
-    },
-    "general": {
-        "message": "Geral"
-    },
-    "geoPreference": {
-        "message": "Preferência Geográfica"
-    },
-    "github": {
-        "message": "GitHub"
-    },
-    "googleApiKey": {
-        "message": "Chave da API do Google"
-    },
-    "goToSearchBox": {
-        "message": "Selecionar barra de pesquisa"
-    },
-    "gpu": {
-        "message": "GPU"
-    },
-    "GPUnotindatabase": {
-        "message": "Não tenho sua GPU nos meus Dados :¬("
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "grey": {
-        "message": "Cinza"
-    },
-    "halfTransparent": {
-        "message": "Meio Transparente"
-    },
-    "Hamburger_Menu": {
-        "message": "Menu hamburguer"
-    },
-    "hardwareInformation": {
-        "message": "Informações do hardware"
-    },
-    "hd": {
-        "message": "HD"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura em HD"
-    },
-    "header": {
-        "message": "Cabeçalho"
-    },
-    "hidden": {
-        "message": "Oculto"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Oculto na página do vídeo"
-    },
-    "hide_author_avatars": {
-        "message": "Ocultar avatares de autores"
-    },
-    "hide_labels": {
-        "message": "Ocultar nomes"
-    },
-    "Hide_Pause_Overlay": {
-        "message": "Ocultar Sobreposição de pausa"
-    },
-    "Hide_Shorts_remixing_this_video": {
-        "message": "Ocultar Shorts remixando alguns videos"
-    },
-    "Hide_sidebar": {
-        "message": "Ocultar barra lateral de recomendações "
-    },
-    "Hide_the_tabs_only": {
-        "message": "Ocultar somente as abas"
-    },
-    "Hide_YouTube_Logo": {
-        "message": "Ocultar Logo do YouTube"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Desativar miniaturas animadas"
-    },
-    "hideAnnotations": {
-        "message": "Ocultar anotações"
-    },
-    "hideCards": {
-        "message": "Ocultar cards"
-    },
-    "hideCategories": {
-        "message": "Ocultar categorias"
-    },
-    "hideCommentsCount": {
-        "message": "Ocultar contagens de Comentários"
-    },
-    "hideCountryCode": {
-        "message": "Ocultar código do país"
-    },
-    "hideDate": {
-        "message": "Ocultar data"
-    },
-    "hideDetailButton": {
-        "message": "Ocultar botão de detalhs"
-    },
-    "hideDetails": {
-        "message": "Ocultar detalhes"
-    },
-    "hideEndscreen": {
-        "message": "Ocultar tela final"
-    },
-    "hideFeaturedContent": {
-        "message": "Ocultar conteúdo em destaque"
-    },
-    "hideFooter": {
-        "message": "Ocultar rodapé"
-    },
-    "hideGradientBottom": {
-        "message": "Ocultar sombra ao redor da barra do player"
-    },
-    "hideHomePageShorts": {
-        "message": "Remover Shorts da página inicial"
-    },
-    "hideMore": {
-        "message": "Ocultar Ver mais (...) "
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ocultar a barra de controles do player"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ocultar os botões da barra de controles do player"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ocultar opções de controles do player"
-    },
-    "hidePlaylist": {
-        "message": "Ocultar playlist"
-    },
-    "hideReport": {
-        "message": "Ocultar report"
-    },
-    "hideRightButtons": {
-        "message": "Ocultar botões à direita"
-    },
-    "hideScrollForDetails": {
-        "message": "Ocultar «Rolar para ver detalhes»"
-    },
-    "hideSkipOverlay": {
-        "message": "Esconder animação de salto de 5 segundos"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ocultar botões nas miniaturas"
-    },
-    "hideThumbnails": {
-        "message": "Ocultar miniaturas"
-    },
-    "hideVideoTitleFullScreen": {
-        "message": "Ocultar o título do vídeo em tela cheia"
-    },
-    "hideViewsCount": {
-        "message": "Ocultar visualizações"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ocultar botão pesquisa de voz"
-    },
-    "high": {
-        "message": "Alta"
-    },
-    "history": {
-        "message": "Histórico"
-    },
-    "home": {
-        "message": "Início"
-    },
-    "homeScreen": {
-        "message": "Tela inicial"
-    },
-    "hover": {
-        "message": "Passar o Ponteiro"
-    },
-    "hoverOnVideoPage": {
-        "message": "Passe o mouse na página do vídeo"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Há quanto tempo o vídeo foi enviado"
-    },
-    "icons": {
-        "message": "Ícones"
-    },
-    "iconsOnly": {
-        "message": "Apenas ícones"
-    },
-    "importSettings": {
-        "message": "Importar configurações"
-    },
-    "ImprovedTube": {
-        "message": "ImprovedTube"
-    },
-    "improvedtubeButtons": {
-        "message": "Botões do ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ícone do ImprovedTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Idioma do ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Versão do ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Logo do ImproveTube"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Aumentar velocidade"
-    },
-    "increaseVolume": {
-        "message": "Diminuir volume"
-    },
-    "indigo": {
-        "message": "Indigo"
-    },
-    "items": {
-        "message": "Itens"
-    },
-    "language": {
-        "message": "Idioma"
-    },
-    "language_closed_caption": {
-        "message": "Padrão de Idioma - Legendas de Idioma"
-    },
-    "languages": {
-        "message": "Idiomas"
-    },
-    "layerAnimationScale": {
-        "message": "Escala de animação"
-    },
-    "layout": {
-        "message": "Aparência"
-    },
-    "legacyYoutube": {
-        "message": "YouTube Antigo"
-    },
-    "library": {
-        "message": "Biblioteca"
-    },
-    "light": {
-        "message": "Claro"
-    },
-    "lightBlue": {
-        "message": "Azul Claro"
-    },
-    "lightGreen": {
-        "message": "Verde Claro"
-    },
-    "like": {
-        "message": "Avaliar!"
-    },
-    "liked": {
-        "message": "Avaliado"
-    },
-    "likes": {
-        "message": "Curtidas"
-    },
-    "lime": {
-        "message": "Verde Limão"
-    },
-    "limitPageWidth": {
-        "message": "Limite de largura da página"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Chat Ao vivo"
-    },
-    "liveChatType": {
-        "message": "Tipo chat Ao vivo"
-    },
-    "location": {
-        "message": "Localização"
-    },
-    "loop": {
-        "message": "Loop"
-    },
-    "loudnessNormalization": {
-        "message": "Normalização de volume"
-    },
-    "low": {
-        "message": "Baixa"
-    },
-    "markWatchedVideos": {
-        "message": "Marca vídeos assistido"
-    },
-    "medium": {
-        "message": "Média"
-    },
-    "mixer": {
-        "message": "Mixer"
-    },
-    "more": {
-        "message": "Mais"
-    },
-    "mostViewedChannels": {
-        "message": "Canais mais vistos"
-    },
-    "moveSidebarLeft": {
-        "message": "Mover barra lateral para esquerda"
-    },
-    "moveThumbnailsRight": {
-        "message": "Mover miniaturas para direita"
-    },
-    "My_specs": {
-        "message": "Minhas especificações"
-    },
-    "myColors": {
-        "message": "Minhas cores"
-    },
-    "name": {
-        "message": "Nome"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini Player nativo"
-    },
-    "new": {
-        "message": "Novo"
-    },
-    "nextVideo": {
-        "message": "Próximo vídeo"
-    },
-    "night": {
-        "message": "Noite"
-    },
-    "nightMode": {
-        "message": "Modo noturno"
-    },
-    "noActiveFeatures": {
-        "message": "Sem recursos ativos"
-    },
-    "none": {
-        "message": "Nenhum"
-    },
-    "noOpenVideoTabs": {
-        "message": "Nenhuma aba de vídeo aberta"
-    },
-    "normal": {
-        "message": "Normal"
-    },
-    "Not_optimal": {
-        "message": "Sem otimização"
-    },
-    "off": {
-        "message": "Desativado"
-    },
-    "ok": {
-        "message": "OK"
-    },
-    "old": {
-        "message": "Antigo"
-    },
-    "onAllVideos": {
-        "message": "Em todos os vídeos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Ativo apenas no YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Pausa enquanto assisto a um segundo vídeo"
-    },
-    "onSmallCreators": {
-        "message": "Desligado, exceto para canais pequenos"
-    },
-    "onSubscribedChannels": {
-        "message": "Apenas em inscrições"
-    },
-    "openNewTab": {
-        "message": "Abrir em uma nova aba"
-    },
-    "openPopupPlayer": {
-        "message": "Abra vídeos/playlist em uma nova janela"
-    },
-    "optimizeCodecForHardwareAcceleration": {
-        "message": "Otimizar o Codec para aceleração de hardware"
-    },
-    "orange": {
-        "message": "Laranja"
-    },
-    "os": {
-        "message": "Sistema Operacional"
-    },
-    "other": {
-        "message": "Outros"
-    },
-    "outline": {
-        "message": "Contorno"
-    },
-    "overlay": {
-        "message": "Sobreposição"
-    },
-    "permissions": {
-        "message": "Permissões"
-    },
-    "pictureInPicture": {
-        "message": "Janela em janela"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Planície"
-    },
-    "platform": {
-        "message": "Plataforma"
-    },
-    "playAllButton": {
-        "message": "Botão \"Reproduzir Tudo\""
-    },
-    "playbackSpeed": {
-        "message": "Velocidade de reprodução"
-    },
-    "player": {
-        "message": "Player"
-    },
-    "player_dont_speed_education": {
-        "message": "Não acelere na categoria (Rara): Educação"
-    },
-    "player_fit_to_win_button": {
-        "message": "Proporção 4x3: *Velha tela Quadrada \nou ganho de área de visualização quando estiver em modo Teatro"
-    },
-    "player_rotate_button": {
-        "message": "Botão pra girar em 90º graus"
-    },
-    "playerColor": {
-        "message": "Cor do player"
-    },
-    "playerSize": {
-        "message": "Tamanho do player"
-    },
-    "playlist": {
-        "message": "Lista de reprodução"
-    },
-    "playlists": {
-        "message": "Listas de reprodução"
-    },
-    "playPause": {
-        "message": "Reproduzir / Pausar"
-    },
-    "popupPlayer": {
-        "message": "Player externo"
-    },
-    "popupWindowButtons": {
-        "message": "Adicione um botão Popup-player para cada miniatura"
-    },
-    "position": {
-        "message": "Posição"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Pressione qualquer tecla ou use a roda do mouse"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Pressione qualquer tecla ou use a roda do mouse"
-    },
-    "previousVideo": {
-        "message": "Vídeo Anterior"
-    },
-    "primaryColor": {
-        "message": "Cor primária"
-    },
-    "pullSyncSettings": {
-        "message": "Pegar"
-    },
-    "purple": {
-        "message": "Roxo"
-    },
-    "pushSyncSettings": {
-        "message": "Pressione"
-    },
-    "quality": {
-        "message": "Qualidade"
-    },
-    "raised": {
-        "message": "Levantado"
-    },
-    "ram": {
-        "message": "RAM"
-    },
-    "rateMe": {
-        "message": "Avalie-me"
-    },
-    "rateUs": {
-        "message": "Avalie-nos!"
-    },
-    "red": {
-        "message": "Vermelho"
-    },
-    "redDislikeButton": {
-        "message": "Mostrar botão não gostei na cor vermelha"
-    },
-    "relatedVideos": {
-        "message": "Vídeos relacionados"
-    },
-    "remote": {
-        "message": "Assistir na TV"
-    },
-    "Remove": {
-        "message": "Remover"
-    },
-    "removeIcons": {
-        "message": "Remover ícones"
-    },
-    "removeName": {
-        "message": "Remover nome"
-    },
-    "removeNames": {
-        "message": "Remover nomes"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Remover os respectivos resultados de pesquisa"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Remover fileiras de Shorts dos resultados de pesquisa"
-    },
-    "repeat": {
-        "message": "Repetir"
-    },
-    "report": {
-        "message": "Reportar"
-    },
-    "reset": {
-        "message": "Restaurar"
-    },
-    "resetAllSettings": {
-        "message": "Restaurar todas as configurações"
-    },
-    "resetAllShortcuts": {
-        "message": "Resetar todos os atalhos"
-    },
-    "reverse": {
-        "message": "Inverter"
-    },
-    "rotate": {
-        "message": "Girar"
-    },
-    "save": {
-        "message": "Salvar"
-    },
-    "saveAs": {
-        "message": "Salvar como"
-    },
-    "schedule": {
-        "message": "Programação"
-    },
-    "screen": {
-        "message": "Tela"
-    },
-    "screenshot": {
-        "message": "Captura de tela"
-    },
-    "scrollBar": {
-        "message": "Barra De rolagem"
-    },
-    "sd": {
-        "message": "SD"
-    },
-    "search": {
-        "message": "Pesquisar"
-    },
-    "searchBarOnly": {
-        "message": "Apenas barra de pesquisa"
-    },
-    "seekBackward10Seconds": {
-        "message": "Voltar 10 segundos"
-    },
-    "seekForward10Seconds": {
-        "message": "Avançar 10 segundos"
-    },
-    "seekNextChapter": {
-        "message": "Buscar próximo capítulo"
-    },
-    "seekPreviousChapter": {
-        "message": "Buscar capítulo anterior"
-    },
-    "settings": {
-        "message": "Configurações"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Configurações importadas com sucesso"
-    },
-    "share": {
-        "message": "Compartilhar"
-    },
-    "shortcut_chapters": {
-        "message": "Mostrar barra lateral de capítulos"
-    },
-    "shortcut_screenshot": {
-        "message": "Captura de tela"
-    },
-    "shortcuts": {
-        "message": "Atalhos"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Mostrar cards ao passar o mouse"
-    },
-    "showChannelVideosCount": {
-        "message": "Número de vídeos do canal"
-    },
-    "showLess": {
-        "message": "Mostre menos"
-    },
-    "showMore": {
-        "message": "Mostre mais"
-    },
-    "showRemainingDuration": {
-        "message": "Mostrar duração restante do vídeo"
-    },
-    "showVersion": {
-        "message": "Mostrar versão"
-    },
-    "shuffle": {
-        "message": "Aleatório"
-    },
-    "sidebar": {
-        "message": "Painel Lateral"
-    },
-    "Sidebar_simple_alternative": {
-        "message": "Barra lateral (alternativa simples)"
-    },
-    "softwareInformation": {
-        "message": "Informação do hardware"
-    },
-    "spacebar": {
-        "message": "Espaço"
-    },
-    "squaredUserImages": {
-        "message": "Imagens do usuário quadrada"
-    },
-    "static": {
-        "message": "Estático"
-    },
-    "statsForNerds": {
-        "message": "Mostrar Estatísticas para Nerds"
-    },
-    "step": {
-        "message": "Avançar"
-    },
-    "stop": {
-        "message": "Parar"
-    },
-    "style": {
-        "message": "Estilo"
-    },
-    "styles": {
-        "message": "Estilos"
-    },
-    "subscribe": {
-        "message": "Inscreva-Se"
-    },
-    "subscriptions": {
-        "message": "Inscrições"
-    },
-    "Subtitle_Capture_including_the_current_words": {
-        "message": "Legenda (Captura incluindo as palavras atuais)"
-    },
-    "subtitles": {
-        "message": "Legendas"
-    },
-    "sunset": {
-        "message": "Entardecer"
-    },
-    "sunsetToSunrise": {
-        "message": "Entardecer ao amanhecer"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferência do sistema: escuro"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferência do sistema: claro"
-    },
-    "teal": {
-        "message": "Verde Azulado"
-    },
-    "textColor": {
-        "message": "Cor do texto"
-    },
-    "thanks": {
-        "message": "Valeu Demais"
-    },
-    "themes": {
-        "message": "Temas"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Todos os cookies serão removidos."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Isto irá remover todos os vídeos assistidos."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Todos os cookies do YouTube serão removidos"
-    },
-    "thisWillResetAllSettings": {
-        "message": "As configurações padrão serão restauradas."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Isso irá redefinir todos os atalhos"
-    },
-    "thumbnails": {
-        "message": "Miniaturas"
-    },
-    "thumbnailsQuality": {
-        "message": "Qualidade das Miniaturas"
-    },
-    "timeFrom": {
-        "message": "Horário inicial"
-    },
-    "timeTo": {
-        "message": "Horário final"
-    },
-    "To_the_side_No_page_margin": {
-        "message": "Ao lado! (Sem margem de página)"
-    },
-    "todayAt": {
-        "message": "Hoje às"
-    },
-    "toggleAutoplay": {
-        "message": "Alternar reprodução automática"
-    },
-    "toggleCards": {
-        "message": "Alternar cards"
-    },
-    "toggleControls": {
-        "message": "Alternar controles"
-    },
-    "topChat": {
-        "message": "Chat no topo"
-    },
-    "trackWatchedVideos": {
-        "message": "Rastrear vídeos assistidos"
-    },
-    "trailerAutoplay": {
-        "message": "Reproduzir trailer"
-    },
-    "Transcript": {
-        "message": "Transcrição"
-    },
-    "translations": {
-        "message": "Traduções"
-    },
-    "transparentBackground": {
-        "message": "Fundo transparente"
-    },
-    "transparentColor": {
-        "message": "Transparente"
-    },
-    "trending": {
-        "message": "Em Alta"
-    },
-    "tryToReloadThePage": {
-        "message": "Recarregue página"
-    },
-    "type": {
-        "message": "Tipo"
-    },
-    "upNextAutoplay": {
-        "message": "Reproduzir vídeo em seguida"
-    },
-    "use24HourFormat": {
-        "message": "Usar formato de 24 horas"
-    },
-    "version": {
-        "message": "Versão"
-    },
-    "video": {
-        "message": "Vídeo"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "A descrição se expandirá para acessar a categoria do vídeo"
-    },
-    "videoFormats": {
-        "message": "Formatos de vídeo"
-    },
-    "videos": {
-        "message": "Vídeos"
-    },
-    "viewMode": {
-        "message": "Modo de visualização"
-    },
-    "volume": {
-        "message": "Volume"
-    },
-    "watchedVideos": {
-        "message": "Vídeos assistidos"
-    },
-    "watchLater": {
-        "message": "Assistir Mais Tarde"
-    },
-    "watchTime": {
-        "message": "Tempo de exibição"
-    },
-    "whenPaused": {
-        "message": "Quando pausado"
-    },
-    "whenTabIsChanged": {
-        "message": "Quando a aba é alterada"
-    },
-    "white": {
-        "message": "Branco"
-    },
-    "windowColor": {
-        "message": "Cor da janela"
-    },
-    "windowOpacity": {
-        "message": "Opacidade da janela"
-    },
-    "with_scrollbars": {
-        "message": "Com barras de rolagem?"
-    },
-    "yellow": {
-        "message": "Amarelo"
-    },
-    "Youtube_Search": {
-        "message": "Pesquisar do Youtube"
-    },
-    "youTubeButtons": {
-        "message": "Botões do YouTube"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Cabeçalho do YouTube (à esquerda)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Cabeçalho do YouTube (à direita)"
-    },
-    "youtubeHomePage": {
-        "message": "Página Inicial do YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Idioma do YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "O YouTube limita o codec h.264 à resolução de 1080p"
-    },
-    "youtubesDark": {
-        "message": "YouTube escuro"
-    }
+	"about": {
+		"message": "Sobre"
+	},
+	"accept": {
+		"message": "Aceitar"
+	},
+	"activate": {
+		"message": "Ativar"
+	},
+	"activateCaptions": {
+		"message": "Ativar legendas"
+	},
+	"activated": {
+		"message": "Ativado"
+	},
+	"activatedFeatures": {
+		"message": "Recursos ativados"
+	},
+	"activateFullscreen": {
+		"message": "Ativar tela cheia"
+	},
+	"activeFeatures": {
+		"message": "Recursos ativos"
+	},
+	"addScrollToTop": {
+		"message": "Adicionar «Voltar ao Topo»"
+	},
+	"ads": {
+		"message": "Anúncios"
+	},
+	"all": {
+		"message": "Todos"
+	},
+	"allow": {
+		"message": "Permitir"
+	},
+	"Allow_auto_generate": {
+		"message": "Permitir geração automática"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todas as suas configurações serão apagadas e não poderão ser recuperadas"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todos os seus atalhos serão apagados e não poderão ser recuperados"
+	},
+	"always": {
+		"message": "Sempre"
+	},
+	"alwaysActive": {
+		"message": "Sempre ativo"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Sempre exibir a barra de progresso"
+	},
+	"amber": {
+		"message": "Âmbar"
+	},
+	"analyzer": {
+		"message": "Analisador"
+	},
+	"animations": {
+		"message": "Animações"
+	},
+	"appearance": {
+		"message": "Aparência"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Tem certeza de que deseja exportar os dados?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Tem certeza de que deseja importar os dados?"
+	},
+	"areYouSureYouWantToSyncTheData": {
+		"message": "Tem certeza que deseja sincronizar as configurações atuais?"
+	},
+	"atHistory": {
+		"message": "em 'Histórico'"
+	},
+	"atSubscriptions": {
+		"message": "Em Inscrições"
+	},
+	"atTrending": {
+		"message": "em 'Tendências'"
+	},
+	"audio": {
+		"message": "Áudio"
+	},
+	"audioFormats": {
+		"message": "Formatos de áudio"
+	},
+	"auto": {
+		"message": "Automático"
+	},
+	"Auto_PiP_picture_in_picture": {
+		"message": "Auto-PiP (Picture in picture)"
+	},
+	"autoFullscreen": {
+		"message": "Tela cheia automática"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausar vídeo automaticamente ao alternar entre abas"
+	},
+	"autoplay": {
+		"message": "Reprodução automática"
+	},
+	"avoidAv1": {
+		"message": "Evitar AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Evitar AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Evitar AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Evite renderização da CPU quando possível"
+	},
+	"backgroundColor": {
+		"message": "Cor de fundo"
+	},
+	"backgroundOpacity": {
+		"message": "Opacidade do fundo"
+	},
+	"backupAndReset": {
+		"message": "Backup & Restauração"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baseado nas cores do sistema"
+	},
+	"belowPlayer": {
+		"message": "Abaixo do player"
+	},
+	"bitness": {
+		"message": "Taxa de bits do Sistema"
+	},
+	"black": {
+		"message": "Preto"
+	},
+	"block_Codec_Alert_h264": {
+		"message": "Você precisa ativar o H.264 ou VP9 para reproduzir vídeos."
+	},
+	"blockAll": {
+		"message": "Bloquear tudo"
+	},
+	"blockAv1": {
+		"message": "Bloquear AV1"
+	},
+	"blockH264": {
+		"message": "Bloquear H.264"
+	},
+	"blocklist": {
+		"message": "Lista Negra"
+	},
+	"blockMusic": {
+		"message": "Pule anúncios nos vídeos musicais"
+	},
+	"blockVp8": {
+		"message": "Bloquear VP8"
+	},
+	"blockVp9": {
+		"message": "Bloquear VP9"
+	},
+	"blue": {
+		"message": "Azul"
+	},
+	"blueGray": {
+		"message": "Cinza azulado"
+	},
+	"bluelight": {
+		"message": "Filtrar luz azul"
+	},
+	"brightness": {
+		"message": "Luminosidade"
+	},
+	"brown": {
+		"message": "Marrom"
+	},
+	"browser": {
+		"message": "Navegador"
+	},
+	"browserAccountSync": {
+		"message": "Sincronização (Conta do Navegador)"
+	},
+	"browserVersion": {
+		"message": "Versão do navegador"
+	},
+	"bubbles": {
+		"message": "Bolhas"
+	},
+	"bug": {
+		"message": "Erro"
+	},
+	"buttons": {
+		"message": "Botões"
+	},
+	"cancel": {
+		"message": "Cancelar"
+	},
+	"categories": {
+		"message": "Categorias"
+	},
+	"channel": {
+		"message": "Canal"
+	},
+	"channels": {
+		"message": "Canais"
+	},
+	"chapters": {
+		"message": "Capítulos"
+	},
+	"characterEdgeStyle": {
+		"message": "Estilo da borda"
+	},
+	"clipboard": {
+		"message": "Àrea de transferência"
+	},
+	"collapsed": {
+		"message": "Recolhido"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Recolher seções de assinatura"
+	},
+	"columns": {
+		"message": "Coluna da barra lateral extra (sem mover os vídeos relacionados, se a janela for larga o suficiente)"
+	},
+	"comments": {
+		"message": "Comentários"
+	},
+	"compact_spacing": {
+		"message": "Espaçamento compacto"
+	},
+	"compactTheme": {
+		"message": "Tema compacto"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Habilitar alerta para casos de fechamento acidental?"
+	},
+	"cores": {
+		"message": "Núcleos"
+	},
+	"cropChapterTitles": {
+		"message": "Recortar títulos do capítulos"
+	},
+	"Currently_requiring_a_YouTube_API_key": {
+		"message": "(Necessário uma chave do YouTube-API: )"
+	},
+	"custom": {
+		"message": "Personalizar"
+	},
+	"customCss": {
+		"message": "Personalizar CSS"
+	},
+	"customJs": {
+		"message": "Personalizar JS"
+	},
+	"customMiniPlayer": {
+		"message": "Personalizar Mini-Player"
+	},
+	"cyan": {
+		"message": "Ciano"
+	},
+	"dark": {
+		"message": "Escuro"
+	},
+	"darkTheme": {
+		"message": "Tema Escuro"
+	},
+	"dateAndTime": {
+		"message": "Data & Hora"
+	},
+	"dawn": {
+		"message": "Alvorecer"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Diminuir velocidade"
+	},
+	"decreaseVolume": {
+		"message": "Diminuir volume"
+	},
+	"deepOrange": {
+		"message": "Laranja Escuro"
+	},
+	"deepPurple": {
+		"message": "Roxo Escuro"
+	},
+	"default": {
+		"message": "Padrão"
+	},
+	"default_CC": {
+		"message": "Padrão"
+	},
+	"default_theme": {
+		"message": "Tema padrão"
+	},
+	"defaultChannelTab": {
+		"message": "Aba padrão do canal"
+	},
+	"defaultContentCountry": {
+		"message": "Conteúdo padrão do país"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Velocidade padrão de reprodução"
+	},
+	"deleteWatchedVideos": {
+		"message": "Excluir vídeos assistidos"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Apagar cookies do YouTube"
+	},
+	"depressed": {
+		"message": "Comprimido"
+	},
+	"description": {
+		"message": "Descrição"
+	},
+	"description_ext": {
+		"message": "Torne o YouTube organizado e inteligente! Pular Anúncio, colorir YouTube, volume, velocidade, canal, ferramenta, estilo, HD, adblock, adblocker, tags, playlist ,palavras-chave"
+	},
+	"desert": {
+		"message": "Deserto"
+	},
+	"details": {
+		"message": "Detalhes"
+	},
+	"developerOptions": {
+		"message": "Opções do Desenvolvedor"
+	},
+	"device": {
+		"message": "Dispositivo"
+	},
+	"dim": {
+		"message": "Escurecer"
+	},
+	"disabled": {
+		"message": "Desativado"
+	},
+	"disableThumbnailPlayback": {
+		"message": "Desativar reprodução de vídeo ao passar o mouse"
+	},
+	"dislike": {
+		"message": "Não Gostei."
+	},
+	"displayDayOfTheWeak": {
+		"message": "Mostrar dia da Semana"
+	},
+	"donate": {
+		"message": "Doar"
+	},
+	"doNotChange": {
+		"message": "Não Alterar"
+	},
+	"draggable": {
+		"message": "Arrastável"
+	},
+	"dropShadow": {
+		"message": "Sombra projetada"
+	},
+	"durationWithSpeed": {
+		"message": "Mostrar tempo restante com referência a velocidade de reprodução"
+	},
+	"embedded_Hide_Share": {
+		"message": "Ocultar compartilhamento do video incorporado"
+	},
+	"Embedded_YouTube": {
+		"message": "Vídeos Incorporados"
+	},
+	"empty": {
+		"message": "Vazio"
+	},
+	"enabled": {
+		"message": "Ativado"
+	},
+	"enabledForced": {
+		"message": "Ativado (forçado)"
+	},
+	"expanded": {
+		"message": "Expandido"
+	},
+	"exportSettings": {
+		"message": "Exportar configurações"
+	},
+	"extension": {
+		"message": "Extensão"
+	},
+	"ExtraButtons": {
+		"message": "Botões extras"
+	},
+	"extraButtonsBelowThePlayer": {
+		"message": "Botões extras abaixo do player"
+	},
+	"Feature_not_yet_available": {
+		"message": "Recurso não está presente no momento"
+	},
+	"file": {
+		"message": "Arquivo"
+	},
+	"filters": {
+		"message": "Filtros"
+	},
+	"fitToWindow": {
+		"message": "Ajustar à janela"
+	},
+	"flash": {
+		"message": "Instantâneo"
+	},
+	"font": {
+		"message": "Fonte"
+	},
+	"fontColor": {
+		"message": "Cor da fonte"
+	},
+	"fontFamily": {
+		"message": "Família da fonte"
+	},
+	"fontOpacity": {
+		"message": "Opacidade da fonte"
+	},
+	"fontSize": {
+		"message": "Tamanho da fonte"
+	},
+	"footer": {
+		"message": "Rodapé"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Velocidade do reprodução forçado"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(Forçar velocidade de reprodução mesmo para música?)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Reprodução do vídeo desde o início forçado"
+	},
+	"forcedTheaterMode": {
+		"message": "Modo teatro forçado"
+	},
+	"forcedVolume": {
+		"message": "Volume forçado"
+	},
+	"forceSDR": {
+		"message": "Forçar SDR"
+	},
+	"foundABug": {
+		"message": "Encontrou um Bug?"
+	},
+	"fullWindow": {
+		"message": "Tela Cheia"
+	},
+	"general": {
+		"message": "Geral"
+	},
+	"geoPreference": {
+		"message": "Preferência Geográfica"
+	},
+	"googleApiKey": {
+		"message": "Chave da API do Google"
+	},
+	"goToSearchBox": {
+		"message": "Selecionar barra de pesquisa"
+	},
+	"GPUnotindatabase": {
+		"message": "Não tenho sua GPU nos meus Dados :¬("
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"grey": {
+		"message": "Cinza"
+	},
+	"halfTransparent": {
+		"message": "Meio Transparente"
+	},
+	"Hamburger_Menu": {
+		"message": "Menu hamburguer"
+	},
+	"hardwareInformation": {
+		"message": "Informações do hardware"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura em HD"
+	},
+	"header": {
+		"message": "Cabeçalho"
+	},
+	"hidden": {
+		"message": "Oculto"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Oculto na página do vídeo"
+	},
+	"hide_author_avatars": {
+		"message": "Ocultar avatares de autores"
+	},
+	"hide_labels": {
+		"message": "Ocultar nomes"
+	},
+	"Hide_Pause_Overlay": {
+		"message": "Ocultar Sobreposição de pausa"
+	},
+	"Hide_Shorts_remixing_this_video": {
+		"message": "Ocultar Shorts remixando alguns videos"
+	},
+	"Hide_sidebar": {
+		"message": "Ocultar barra lateral de recomendações"
+	},
+	"Hide_the_tabs_only": {
+		"message": "Ocultar somente as abas"
+	},
+	"Hide_YouTube_Logo": {
+		"message": "Ocultar Logo do YouTube"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Desativar miniaturas animadas"
+	},
+	"hideAnnotations": {
+		"message": "Ocultar anotações"
+	},
+	"hideCards": {
+		"message": "Ocultar cards"
+	},
+	"hideCategories": {
+		"message": "Ocultar categorias"
+	},
+	"hideCommentsCount": {
+		"message": "Ocultar contagens de Comentários"
+	},
+	"hideCountryCode": {
+		"message": "Ocultar código do país"
+	},
+	"hideDate": {
+		"message": "Ocultar data"
+	},
+	"hideDetailButton": {
+		"message": "Ocultar botão de detalhs"
+	},
+	"hideDetails": {
+		"message": "Ocultar detalhes"
+	},
+	"hideEndscreen": {
+		"message": "Ocultar tela final"
+	},
+	"hideFeaturedContent": {
+		"message": "Ocultar conteúdo em destaque"
+	},
+	"hideFooter": {
+		"message": "Ocultar rodapé"
+	},
+	"hideGradientBottom": {
+		"message": "Ocultar sombra ao redor da barra do player"
+	},
+	"hideHomePageShorts": {
+		"message": "Remover Shorts da página inicial"
+	},
+	"hideMore": {
+		"message": "Ocultar Ver mais (...)"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ocultar a barra de controles do player"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ocultar os botões da barra de controles do player"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ocultar opções de controles do player"
+	},
+	"hidePlaylist": {
+		"message": "Ocultar playlist"
+	},
+	"hideReport": {
+		"message": "Ocultar report"
+	},
+	"hideRightButtons": {
+		"message": "Ocultar botões à direita"
+	},
+	"hideScrollForDetails": {
+		"message": "Ocultar «Rolar para ver detalhes»"
+	},
+	"hideSkipOverlay": {
+		"message": "Esconder animação de salto de 5 segundos"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ocultar botões nas miniaturas"
+	},
+	"hideThumbnails": {
+		"message": "Ocultar miniaturas"
+	},
+	"hideVideoTitleFullScreen": {
+		"message": "Ocultar o título do vídeo em tela cheia"
+	},
+	"hideViewsCount": {
+		"message": "Ocultar visualizações"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ocultar botão pesquisa de voz"
+	},
+	"high": {
+		"message": "Alta"
+	},
+	"history": {
+		"message": "Histórico"
+	},
+	"home": {
+		"message": "Início"
+	},
+	"homeScreen": {
+		"message": "Tela inicial"
+	},
+	"hover": {
+		"message": "Passar o Ponteiro"
+	},
+	"hoverOnVideoPage": {
+		"message": "Passe o mouse na página do vídeo"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Há quanto tempo o vídeo foi enviado"
+	},
+	"icons": {
+		"message": "Ícones"
+	},
+	"iconsOnly": {
+		"message": "Apenas ícones"
+	},
+	"importSettings": {
+		"message": "Importar configurações"
+	},
+	"improvedtubeButtons": {
+		"message": "Botões do ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ícone do ImprovedTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Idioma do ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Versão do ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Logo do ImproveTube"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Aumentar velocidade"
+	},
+	"increaseVolume": {
+		"message": "Diminuir volume"
+	},
+	"items": {
+		"message": "Itens"
+	},
+	"language": {
+		"message": "Idioma"
+	},
+	"language_closed_caption": {
+		"message": "Padrão de Idioma - Legendas de Idioma"
+	},
+	"languages": {
+		"message": "Idiomas"
+	},
+	"layerAnimationScale": {
+		"message": "Escala de animação"
+	},
+	"layout": {
+		"message": "Aparência"
+	},
+	"legacyYoutube": {
+		"message": "YouTube Antigo"
+	},
+	"library": {
+		"message": "Biblioteca"
+	},
+	"light": {
+		"message": "Claro"
+	},
+	"lightBlue": {
+		"message": "Azul Claro"
+	},
+	"lightGreen": {
+		"message": "Verde Claro"
+	},
+	"like": {
+		"message": "Avaliar!"
+	},
+	"liked": {
+		"message": "Avaliado"
+	},
+	"likes": {
+		"message": "Curtidas"
+	},
+	"lime": {
+		"message": "Verde Limão"
+	},
+	"limitPageWidth": {
+		"message": "Limite de largura da página"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Chat Ao vivo"
+	},
+	"liveChatType": {
+		"message": "Tipo chat Ao vivo"
+	},
+	"location": {
+		"message": "Localização"
+	},
+	"loudnessNormalization": {
+		"message": "Normalização de volume"
+	},
+	"low": {
+		"message": "Baixa"
+	},
+	"markWatchedVideos": {
+		"message": "Marca vídeos assistido"
+	},
+	"medium": {
+		"message": "Média"
+	},
+	"more": {
+		"message": "Mais"
+	},
+	"mostViewedChannels": {
+		"message": "Canais mais vistos"
+	},
+	"moveSidebarLeft": {
+		"message": "Mover barra lateral para esquerda"
+	},
+	"moveThumbnailsRight": {
+		"message": "Mover miniaturas para direita"
+	},
+	"My_specs": {
+		"message": "Minhas especificações"
+	},
+	"myColors": {
+		"message": "Minhas cores"
+	},
+	"name": {
+		"message": "Nome"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini Player nativo"
+	},
+	"new": {
+		"message": "Novo"
+	},
+	"nextVideo": {
+		"message": "Próximo vídeo"
+	},
+	"night": {
+		"message": "Noite"
+	},
+	"nightMode": {
+		"message": "Modo noturno"
+	},
+	"noActiveFeatures": {
+		"message": "Sem recursos ativos"
+	},
+	"none": {
+		"message": "Nenhum"
+	},
+	"noOpenVideoTabs": {
+		"message": "Nenhuma aba de vídeo aberta"
+	},
+	"Not_optimal": {
+		"message": "Sem otimização"
+	},
+	"off": {
+		"message": "Desativado"
+	},
+	"ok": {
+		"message": "OK"
+	},
+	"old": {
+		"message": "Antigo"
+	},
+	"onAllVideos": {
+		"message": "Em todos os vídeos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Ativo apenas no YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Pausa enquanto assisto a um segundo vídeo"
+	},
+	"onSmallCreators": {
+		"message": "Desligado, exceto para canais pequenos"
+	},
+	"onSubscribedChannels": {
+		"message": "Apenas em inscrições"
+	},
+	"openNewTab": {
+		"message": "Abrir em uma nova aba"
+	},
+	"openPopupPlayer": {
+		"message": "Abra vídeos/playlist em uma nova janela"
+	},
+	"optimizeCodecForHardwareAcceleration": {
+		"message": "Otimizar o Codec para aceleração de hardware"
+	},
+	"orange": {
+		"message": "Laranja"
+	},
+	"os": {
+		"message": "Sistema Operacional"
+	},
+	"other": {
+		"message": "Outros"
+	},
+	"outline": {
+		"message": "Contorno"
+	},
+	"overlay": {
+		"message": "Sobreposição"
+	},
+	"permissions": {
+		"message": "Permissões"
+	},
+	"pictureInPicture": {
+		"message": "Janela em janela"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Planície"
+	},
+	"platform": {
+		"message": "Plataforma"
+	},
+	"playAllButton": {
+		"message": "Botão \"Reproduzir Tudo\""
+	},
+	"playbackSpeed": {
+		"message": "Velocidade de reprodução"
+	},
+	"player_dont_speed_education": {
+		"message": "Não acelere na categoria (Rara): Educação"
+	},
+	"player_fit_to_win_button": {
+		"message": "Proporção 4x3: *Velha tela Quadrada \nou ganho de área de visualização quando estiver em modo Teatro"
+	},
+	"player_rotate_button": {
+		"message": "Botão pra girar em 90º graus"
+	},
+	"playerColor": {
+		"message": "Cor do player"
+	},
+	"playerSize": {
+		"message": "Tamanho do player"
+	},
+	"playlist": {
+		"message": "Lista de reprodução"
+	},
+	"playlists": {
+		"message": "Listas de reprodução"
+	},
+	"playPause": {
+		"message": "Reproduzir / Pausar"
+	},
+	"popupPlayer": {
+		"message": "Player externo"
+	},
+	"popupWindowButtons": {
+		"message": "Adicione um botão Popup-player para cada miniatura"
+	},
+	"position": {
+		"message": "Posição"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Pressione qualquer tecla ou use a roda do mouse"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Pressione qualquer tecla ou use a roda do mouse"
+	},
+	"previousVideo": {
+		"message": "Vídeo Anterior"
+	},
+	"primaryColor": {
+		"message": "Cor primária"
+	},
+	"pullSyncSettings": {
+		"message": "Pegar"
+	},
+	"purple": {
+		"message": "Roxo"
+	},
+	"pushSyncSettings": {
+		"message": "Pressione"
+	},
+	"quality": {
+		"message": "Qualidade"
+	},
+	"raised": {
+		"message": "Levantado"
+	},
+	"rateMe": {
+		"message": "Avalie-me"
+	},
+	"rateUs": {
+		"message": "Avalie-nos!"
+	},
+	"red": {
+		"message": "Vermelho"
+	},
+	"redDislikeButton": {
+		"message": "Mostrar botão não gostei na cor vermelha"
+	},
+	"relatedVideos": {
+		"message": "Vídeos relacionados"
+	},
+	"remote": {
+		"message": "Assistir na TV"
+	},
+	"Remove": {
+		"message": "Remover"
+	},
+	"removeIcons": {
+		"message": "Remover ícones"
+	},
+	"removeName": {
+		"message": "Remover nome"
+	},
+	"removeNames": {
+		"message": "Remover nomes"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Remover os respectivos resultados de pesquisa"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Remover fileiras de Shorts dos resultados de pesquisa"
+	},
+	"repeat": {
+		"message": "Repetir"
+	},
+	"report": {
+		"message": "Reportar"
+	},
+	"reset": {
+		"message": "Restaurar"
+	},
+	"resetAllSettings": {
+		"message": "Restaurar todas as configurações"
+	},
+	"resetAllShortcuts": {
+		"message": "Resetar todos os atalhos"
+	},
+	"reverse": {
+		"message": "Inverter"
+	},
+	"rotate": {
+		"message": "Girar"
+	},
+	"save": {
+		"message": "Salvar"
+	},
+	"saveAs": {
+		"message": "Salvar como"
+	},
+	"schedule": {
+		"message": "Programação"
+	},
+	"screen": {
+		"message": "Tela"
+	},
+	"screenshot": {
+		"message": "Captura de tela"
+	},
+	"scrollBar": {
+		"message": "Barra De rolagem"
+	},
+	"search": {
+		"message": "Pesquisar"
+	},
+	"searchBarOnly": {
+		"message": "Apenas barra de pesquisa"
+	},
+	"seekBackward10Seconds": {
+		"message": "Voltar 10 segundos"
+	},
+	"seekForward10Seconds": {
+		"message": "Avançar 10 segundos"
+	},
+	"seekNextChapter": {
+		"message": "Buscar próximo capítulo"
+	},
+	"seekPreviousChapter": {
+		"message": "Buscar capítulo anterior"
+	},
+	"settings": {
+		"message": "Configurações"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Configurações importadas com sucesso"
+	},
+	"share": {
+		"message": "Compartilhar"
+	},
+	"shortcut_chapters": {
+		"message": "Mostrar barra lateral de capítulos"
+	},
+	"shortcut_screenshot": {
+		"message": "Captura de tela"
+	},
+	"shortcuts": {
+		"message": "Atalhos"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Mostrar cards ao passar o mouse"
+	},
+	"showChannelVideosCount": {
+		"message": "Número de vídeos do canal"
+	},
+	"showLess": {
+		"message": "Mostre menos"
+	},
+	"showMore": {
+		"message": "Mostre mais"
+	},
+	"showRemainingDuration": {
+		"message": "Mostrar duração restante do vídeo"
+	},
+	"showVersion": {
+		"message": "Mostrar versão"
+	},
+	"shuffle": {
+		"message": "Aleatório"
+	},
+	"sidebar": {
+		"message": "Painel Lateral"
+	},
+	"Sidebar_simple_alternative": {
+		"message": "Barra lateral (alternativa simples)"
+	},
+	"softwareInformation": {
+		"message": "Informação do hardware"
+	},
+	"spacebar": {
+		"message": "Espaço"
+	},
+	"squaredUserImages": {
+		"message": "Imagens do usuário quadrada"
+	},
+	"static": {
+		"message": "Estático"
+	},
+	"statsForNerds": {
+		"message": "Mostrar Estatísticas para Nerds"
+	},
+	"step": {
+		"message": "Avançar"
+	},
+	"stop": {
+		"message": "Parar"
+	},
+	"style": {
+		"message": "Estilo"
+	},
+	"styles": {
+		"message": "Estilos"
+	},
+	"subscribe": {
+		"message": "Inscreva-Se"
+	},
+	"subscriptions": {
+		"message": "Inscrições"
+	},
+	"Subtitle_Capture_including_the_current_words": {
+		"message": "Legenda (Captura incluindo as palavras atuais)"
+	},
+	"subtitles": {
+		"message": "Legendas"
+	},
+	"sunset": {
+		"message": "Entardecer"
+	},
+	"sunsetToSunrise": {
+		"message": "Entardecer ao amanhecer"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferência do sistema: escuro"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferência do sistema: claro"
+	},
+	"teal": {
+		"message": "Verde Azulado"
+	},
+	"textColor": {
+		"message": "Cor do texto"
+	},
+	"thanks": {
+		"message": "Valeu Demais"
+	},
+	"themes": {
+		"message": "Temas"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Todos os cookies serão removidos."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Isto irá remover todos os vídeos assistidos."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Todos os cookies do YouTube serão removidos"
+	},
+	"thisWillResetAllSettings": {
+		"message": "As configurações padrão serão restauradas."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Isso irá redefinir todos os atalhos"
+	},
+	"thumbnails": {
+		"message": "Miniaturas"
+	},
+	"thumbnailsQuality": {
+		"message": "Qualidade das Miniaturas"
+	},
+	"timeFrom": {
+		"message": "Horário inicial"
+	},
+	"timeTo": {
+		"message": "Horário final"
+	},
+	"To_the_side_No_page_margin": {
+		"message": "Ao lado! (Sem margem de página)"
+	},
+	"todayAt": {
+		"message": "Hoje às"
+	},
+	"toggleAutoplay": {
+		"message": "Alternar reprodução automática"
+	},
+	"toggleCards": {
+		"message": "Alternar cards"
+	},
+	"toggleControls": {
+		"message": "Alternar controles"
+	},
+	"topChat": {
+		"message": "Chat no topo"
+	},
+	"trackWatchedVideos": {
+		"message": "Rastrear vídeos assistidos"
+	},
+	"trailerAutoplay": {
+		"message": "Reproduzir trailer"
+	},
+	"Transcript": {
+		"message": "Transcrição"
+	},
+	"translations": {
+		"message": "Traduções"
+	},
+	"transparentBackground": {
+		"message": "Fundo transparente"
+	},
+	"transparentColor": {
+		"message": "Transparente"
+	},
+	"trending": {
+		"message": "Em Alta"
+	},
+	"tryToReloadThePage": {
+		"message": "Recarregue página"
+	},
+	"type": {
+		"message": "Tipo"
+	},
+	"upNextAutoplay": {
+		"message": "Reproduzir vídeo em seguida"
+	},
+	"use24HourFormat": {
+		"message": "Usar formato de 24 horas"
+	},
+	"version": {
+		"message": "Versão"
+	},
+	"video": {
+		"message": "Vídeo"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "A descrição se expandirá para acessar a categoria do vídeo"
+	},
+	"videoFormats": {
+		"message": "Formatos de vídeo"
+	},
+	"videos": {
+		"message": "Vídeos"
+	},
+	"viewMode": {
+		"message": "Modo de visualização"
+	},
+	"watchedVideos": {
+		"message": "Vídeos assistidos"
+	},
+	"watchLater": {
+		"message": "Assistir Mais Tarde"
+	},
+	"watchTime": {
+		"message": "Tempo de exibição"
+	},
+	"whenPaused": {
+		"message": "Quando pausado"
+	},
+	"whenTabIsChanged": {
+		"message": "Quando a aba é alterada"
+	},
+	"white": {
+		"message": "Branco"
+	},
+	"windowColor": {
+		"message": "Cor da janela"
+	},
+	"windowOpacity": {
+		"message": "Opacidade da janela"
+	},
+	"with_scrollbars": {
+		"message": "Com barras de rolagem?"
+	},
+	"yellow": {
+		"message": "Amarelo"
+	},
+	"Youtube_Search": {
+		"message": "Pesquisar do Youtube"
+	},
+	"youTubeButtons": {
+		"message": "Botões do YouTube"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Cabeçalho do YouTube (à esquerda)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Cabeçalho do YouTube (à direita)"
+	},
+	"youtubeHomePage": {
+		"message": "Página Inicial do YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Idioma do YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "O YouTube limita o codec h.264 à resolução de 1080p"
+	},
+	"youtubesDark": {
+		"message": "YouTube escuro"
+	}
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,1229 +1,1220 @@
 {
-    "about": {
-        "message": "Sobre"
-    },
-    "accept": {
-        "message": "Aceitar"
-    },
-    "activate": {
-        "message": "Ativar"
-    },
-    "activateCaptions": {
-        "message": "Ativar legendas"
-    },
-    "activated": {
-        "message": "Ativado"
-    },
-    "activatedFeatures": {
-        "message": "Recursos ativados"
-    },
-    "activateFullscreen": {
-        "message": "Ativar tela cheia"
-    },
-    "activeFeatures": {
-        "message": "Recursos ativos"
-    },
-    "addScrollToTop": {
-        "message": "Adicionar «Voltar ao Topo»"
-    },
-    "ads": {
-        "message": "Anúncios"
-    },
-    "all": {
-        "message": "Todos"
-    },
-    "allow": {
-        "message": "Permitir"
-    },
-    "Allow_auto_generate": {
-        "message": "Permitir geração automática"
-    },
-    "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todas as suas configurações serão apagadas e não poderão ser recuperadas"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todos os seus atalhos serão apagados e não poderão ser recuperados"
-    },
-    "always": {
-        "message": "Sempre"
-    },
-    "alwaysActive": {
-        "message": "Sempre ativo"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Sempre exibir a barra de progresso"
-    },
-    "amber": {
-        "message": "Âmbar"
-    },
-    "analyzer": {
-        "message": "Analisador"
-    },
-    "animations": {
-        "message": "Animações"
-    },
-    "appearance": {
-        "message": "Aparência"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Tem certeza de que deseja exportar os dados?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Tem certeza de que deseja importar os dados?"
-    },
-    "audio": {
-        "message": "Áudio"
-    },
-    "audioFormats": {
-        "message": "Formatos de áudio"
-    },
-    "auto": {
-        "message": "Automático"
-    },
-    "Auto_PiP_picture_in_picture": {
-        "message": "Auto-PiP (Picture in picture)"
-    },
-    "autoFullscreen": {
-        "message": "Tela cheia automática"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausar vídeo automáticamente ao alternar entre abas"
-    },
-    "autoplay": {
-        "message": "Reprodução automática"
-    },
-    "avoidAv1": {
-        "message": "Evitar AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Evitar AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Evitar AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Evite renderização da CPU quando possível"
-    },
-    "backgroundColor": {
-        "message": "Cor de fundo"
-    },
-    "backgroundOpacity": {
-        "message": "Opacidade do fundo"
-    },
-    "backupAndReset": {
-        "message": "Backup & Restauração"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baseado nas cores do sistema"
-    },
-    "belowPlayer": {
-        "message": "Abaixo do player"
-    },
-    "bitness": {
-        "message": "Taxa de bits do Sistema"
-    },
-    "black": {
-        "message": "Preto"
-    },
-    "block_Codec_h264Alert": {
-        "message": "Você precisa ativar o VP9 ou H.264 para o Youtube funcionar. Desabilitar ambos irá quebrar o Vídeo."
-    },
-    "block_Codec_VP9Alert": {
-        "message": "Você precisa ativar o VP9 ou H.264 para o Youtube funcionar. Desabilitar ambos irá quebrar o Vídeo."
-    },
-    "blockAll": {
-        "message": "Bloquear tudo"
-    },
-    "blockAv1": {
-        "message": "Bloquear AV1"
-    },
-    "blockH264": {
-        "message": "Bloquear H.264"
-    },
-    "blocklist": {
-        "message": "Lista Negra"
-    },
-    "blockMusic": {
-        "message": "Pule anúncios nos vídeos musicais"
-    },
-    "blockVp8": {
-        "message": "Bloquear VP8"
-    },
-    "blockVp9": {
-        "message": "Bloquear VP9"
-    },
-    "blue": {
-        "message": "Azul"
-    },
-    "blueGray": {
-        "message": "Cinza azulado"
-    },
-    "bluelight": {
-        "message": "Filtrar luz azul"
-    },
-    "brightness": {
-        "message": "Luminosidade"
-    },
-    "brown": {
-        "message": "Marrom"
-    },
-    "browser": {
-        "message": "Navegador"
-    },
-    "browserVersion": {
-        "message": "Versão do navegador"
-    },
-    "bubbles": {
-        "message": "Bolhas"
-    },
-    "bug": {
-        "message": "Erro"
-    },
-    "Buttons": {
-        "message": "Botões"
-    },
-    "cancel": {
-        "message": "Cancelar"
-    },
-    "categories": {
-        "message": "Categorias"
-    },
-    "channel": {
-        "message": "Canal"
-    },
-    "channels": {
-        "message": "Canais"
-    },
-    "chapters": {
-        "message": "Capítulos"
-    },
-    "characterEdgeStyle": {
-        "message": "Estilo da borda"
-    },
-    "clipboard": {
-        "message": "Àrea de transferência"
-    },
-    "collapsed": {
-        "message": "Recolhido"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Recolher seções de assinatura"
-    },
-    "comments": {
-        "message": "Comentários"
-    },
-    "compact_spacing": {
-        "message": "Espaçamento compacto"
-    },
-    "compactTheme": {
-        "message": "Tema compacto"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Habilitar alerta para casos de fechamento acidental?"
-    },
-    "cores": {
-        "message": "Núcleos"
-    },
-    "cropChapterTitles": {
-        "message": "Recortar títulos do capítulos"
-    },
-    "Currently_requiring_a_YouTube_API_key": {
-        "message": "(Necessário uma chave do YouTube-API: )"
-    },
-    "custom": {
-        "message": "Personalizar"
-    },
-    "customCss": {
-        "message": "Personalizar CSS"
-    },
-    "customJs": {
-        "message": "Personalizar JS"
-    },
-    "customMiniPlayer": {
-        "message": "Personalizar Mini-Player"
-    },
-    "cyan": {
-        "message": "Ciano"
-    },
-    "dark": {
-        "message": "Escuro"
-    },
-    "darkTheme": {
-        "message": "Tema Escuro"
-    },
-    "dateAndTime": {
-        "message": "Data & Hora"
-    },
-    "dawn": {
-        "message": "Alvorecer"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Diminuir velocidade"
-    },
-    "decreaseVolume": {
-        "message": "Diminuir volume"
-    },
-    "deepOrange": {
-        "message": "Laranja Escuro"
-    },
-    "deepPurple": {
-        "message": "Roxo Escuro"
-    },
-    "default": {
-        "message": "Padrão"
-    },
-    "default_CC": {
-        "message": "Padrão"
-    },
-    "default_theme": {
-        "message": "padrão"
-    },
-    "defaultChannelTab": {
-        "message": "Aba padrão do canal "
-    },
-    "defaultContentCountry": {
-        "message": "Conteúdo padrão do país "
-    },
-    "defaultPlaybackSpeed": {
-        "message": "Velocidade padrão de reprodução"
-    },
-    "deleteWatchedVideos": {
-        "message": "Excluir vídeos assistidos"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Apagar cookies do YouTube"
-    },
-    "depressed": {
-        "message": "Comprimido"
-    },
-    "description": {
-        "message": "Descrição"
-    },
-    "description_ext": {
-        "message": "Torne o YouTube organizado e inteligente! Pular Anúncio, colorir YouTube, volume, velocidade, canal, ferramenta, estilo, HD, adblock, adblocker, tags, playlist ,palavras-chave"
-    },
-    "desert": {
-        "message": "Deserto"
-    },
-    "details": {
-        "message": "Detalhes"
-    },
-    "developerOptions": {
-        "message": "Opções do Desenvolvedor"
-    },
-    "device": {
-        "message": "Dispositivo"
-    },
-    "dim": {
-        "message": "Escurecer"
-    },
-    "disabled": {
-        "message": "Desativado"
-    },
-    "dislike": {
-        "message": "Não Gostei."
-    },
-    "displayDayOfTheWeak": {
-        "message": "Mostrar dia da Semana"
-    },
-    "donate": {
-        "message": "Doar"
-    },
-    "doNotChange": {
-        "message": "Não Alterar"
-    },
-    "draggable": {
-        "message": "Arrastável"
-    },
-    "dropShadow": {
-        "message": "Sombra projetada"
-    },
-    "durationWithSpeed": {
-        "message": "Mostrar tempo restante com referência a velocidade de reprodução"
-    },
-    "embedded_Hide_Share": {
-        "message": "Ocultar compartilhamento do video incorporado"
-    },
-    "Embedded_YouTube": {
-        "message": "Vídeos Incorporados"
-    },
-    "empty": {
-        "message": "Vazio"
-    },
-    "enabled": {
-        "message": "Ativado"
-    },
-    "enabledForced": {
-        "message": "Ativado (forçado)"
-    },
-    "expanded": {
-        "message": "Expandido"
-    },
-    "exportSettings": {
-        "message": "Exportar configurações"
-    },
-    "extension": {
-        "message": "Extensão"
-    },
-    "ExtraButtons": {
-        "message": "Botões extras"
-    },
-    "Feature_not_yet_available": {
-        "message": "Recurso não está presente no momento"
-    },
-    "file": {
-        "message": "Arquivo"
-    },
-    "filters": {
-        "message": "Filtros"
-    },
-    "fitToWindow": {
-        "message": "Ajustar à janela"
-    },
-    "flash": {
-        "message": "Instantâneo"
-    },
-    "font": {
-        "message": "Fonte"
-    },
-    "fontColor": {
-        "message": "Cor da fonte"
-    },
-    "fontFamily": {
-        "message": "Família da fonte"
-    },
-    "fontOpacity": {
-        "message": "Opacidade da fonte"
-    },
-    "fontSize": {
-        "message": "Tamanho da fonte"
-    },
-    "footer": {
-        "message": "Rodapé"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Velocidade do reprodução forçado"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Forçar velocidade de reprodução mesmo para música?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Reprodução do vídeo desde o início forçado"
-    },
-    "forcedTheaterMode": {
-        "message": "Modo teatro forçado"
-    },
-    "forcedVolume": {
-        "message": "Volume forçado"
-    },
-    "forceSDR": {
-        "message": "Forçar SDR"
-    },
-    "foundABug": {
-        "message": "Encontrou um Bug?"
-    },
-    "fullWindow": {
-        "message": "Tela Cheia"
-    },
-    "general": {
-        "message": "Geral"
-    },
-    "geoPreference": {
-        "message": "Preferência Geográfica"
-    },
-    "googleApiKey": {
-        "message": "Chave da API do Google"
-    },
-    "goToSearchBox": {
-        "message": "Selecionar barra de pesquisa"
-    },
-    "GPUnotindatabase": {
-        "message": "Não tenho sua GPU nos meus Dados :¬("
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "grey": {
-        "message": "Cinza"
-    },
-    "Hamburger_Menu": {
-        "message": "Menu hamburguer"
-    },
-    "hardwareInformation": {
-        "message": "Informações do hardware"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura em HD"
-    },
-    "header": {
-        "message": "Cabeçalho"
-    },
-    "hidden": {
-        "message": "Oculto"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Oculto na página do vídeo"
-    },
-    "hide_author_avatars": {
-        "message": "Ocultar avatares de autores"
-    },
-    "hide_labels": {
-        "message": "Ocultar nomes"
-    },
-    "Hide_Pause_Overlay": {
-        "message": "Ocultar Sobreposição de pausa"
-    },
-    "Hide_Shorts_remixing_this_video": {
-        "message": "Ocultar Shorts remixando alguns videos"
-    },
-    "Hide_sidebar": {
-        "message": "Ocultar barra lateral de recomendações "
-    },
-    "Hide_subscriptionsShorts": {
-        "message": "Ocultar Shorts das inscrições"
-    },
-    "Hide_the_tabs_only": {
-        "message": "Ocultar somente as abas"
-    },
-    "Hide_trendingThis_Shorts": {
-        "message": "Ocultar Shorts do Em alta"
-    },
-    "Hide_YouTube_Logo": {
-        "message": "Ocultar Logo do YouTube"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Desativar miniaturas animadas"
-    },
-    "hideAnnotations": {
-        "message": "Ocultar anotações"
-    },
-    "hideCards": {
-        "message": "Ocultar cards"
-    },
-    "hideCategories": {
-        "message": "Ocultar categorias"
-    },
-    "hideCommentsCount": {
-        "message": "Ocultar contagens de Comentários"
-    },
-    "hideCountryCode": {
-        "message": "Ocultar código do país"
-    },
-    "hideDate": {
-        "message": "Ocultar data"
-    },
-    "hideDetailButton": {
-        "message": "Ocultar botão de detalhs"
-    },
-    "hideDetails": {
-        "message": "Ocultar detalhes"
-    },
-    "hideEndscreen": {
-        "message": "Ocultar tela final"
-    },
-    "hideFeaturedContent": {
-        "message": "Ocultar conteúdo em destaque"
-    },
-    "hideFooter": {
-        "message": "Ocultar rodapé"
-    },
-    "hideGradientBottom": {
-        "message": "Ocultar sombra ao redor da barra do player"
-    },
-    "hideMore": {
-        "message": "Ocultar mais"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ocultar a barra de controles do player"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ocultar os botões da barra de controles do player"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ocultar opções de controles do player"
-    },
-    "hidePlaylist": {
-        "message": "Ocultar playlist"
-    },
-    "hideReport": {
-        "message": "Ocultar report"
-    },
-    "hideRightButtons": {
-        "message": "Ocultar botões à direita"
-    },
-    "hideScrollForDetails": {
-        "message": "Ocultar «Rolar para ver detalhes»"
-    },
-    "hideSkipOverlay": {
-        "message": "Esconder animação de salto de 5 segundos"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ocultar botões nas miniaturas"
-    },
-    "hideThumbnails": {
-        "message": "Ocultar miniaturas"
-    },
-    "hideVideoTitleFullScreen": {
-        "message": "Ocultar o título do vídeo em tela cheia"
-    },
-    "hideViewsCount": {
-        "message": "Ocultar visualizações"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ocultar botão pesquisa de voz"
-    },
-    "high": {
-        "message": "Alta"
-    },
-    "history": {
-        "message": "Histórico"
-    },
-    "home": {
-        "message": "Início"
-    },
-    "homeScreen": {
-        "message": "Tela inicial"
-    },
-    "hover": {
-        "message": "Passar o Ponteiro"
-    },
-    "hoverOnVideoPage": {
-        "message": "Passe o mouse na página do vídeo"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Há quanto tempo o vídeo foi enviado"
-    },
-    "icons": {
-        "message": "Ícones"
-    },
-    "iconsOnly": {
-        "message": "Apenas ícones"
-    },
-    "importSettings": {
-        "message": "Importar configurações"
-    },
-    "improvedtubeButtons": {
-        "message": "Botões do ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ícone do ImprovedTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Idioma do ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Versão do ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Logo do ImproveTube"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Aumentar velocidade"
-    },
-    "increaseVolume": {
-        "message": "Diminuir volume"
-    },
-    "items": {
-        "message": "Itens"
-    },
-    "language": {
-        "message": "Idioma"
-    },
-    "language_closed_caption": {
-        "message": "Padrão de Idioma - Legendas de Idioma"
-    },
-    "languages": {
-        "message": "Idiomas"
-    },
-    "layerAnimationScale": {
-        "message": "Escala de animação"
-    },
-    "layout": {
-        "message": "Aparência"
-    },
-    "legacyYoutube": {
-        "message": "YouTube Antigo"
-    },
-    "library": {
-        "message": "Biblioteca"
-    },
-    "light": {
-        "message": "Claro"
-    },
-    "lightBlue": {
-        "message": "Azul Claro"
-    },
-    "lightGreen": {
-        "message": "Verde Claro"
-    },
-    "like": {
-        "message": "Avaliar!"
-    },
-    "liked": {
-        "message": "Avaliado"
-    },
-    "likes": {
-        "message": "Curtidas"
-    },
-    "lime": {
-        "message": "Verde Limão"
-    },
-    "limitPageWidth": {
-        "message": "Limite de largura da página"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Chat Ao vivo"
-    },
-    "liveChatType": {
-        "message": "Tipo chat Ao vivo"
-    },
-    "location": {
-        "message": "Localização"
-    },
-    "loudnessNormalization": {
-        "message": "Normalização de volume"
-    },
-    "low": {
-        "message": "Baixa"
-    },
-    "markWatchedVideos": {
-        "message": "Marca vídeos assistido"
-    },
-    "medium": {
-        "message": "Média"
-    },
-    "more": {
-        "message": "Mais"
-    },
-    "mostViewedChannels": {
-        "message": "Canais mais vistos"
-    },
-    "moveSidebarLeft": {
-        "message": "Mover barra lateral para esquerda"
-    },
-    "moveThumbnailsRight": {
-        "message": "Mover miniaturas para direita"
-    },
-    "My_specs": {
-        "message": "Minhas especificações"
-    },
-    "myColors": {
-        "message": "Minhas cores"
-    },
-    "name": {
-        "message": "Nome"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini Player nativo"
-    },
-    "new": {
-        "message": "Novo"
-    },
-    "nextVideo": {
-        "message": "Próximo vídeo"
-    },
-    "night": {
-        "message": "Noite"
-    },
-    "nightMode": {
-        "message": "Modo noturno"
-    },
-    "noActiveFeatures": {
-        "message": "Sem recursos ativos"
-    },
-    "none": {
-        "message": "Nenhum"
-    },
-    "noOpenVideoTabs": {
-        "message": "Nenhuma aba de vídeo aberta"
-    },
-    "Not_optimal": {
-        "message": "Sem otimização"
-    },
-    "off": {
-        "message": "Desativado"
-    },
-    "ok": {
-        "message": "OK"
-    },
-    "old": {
-        "message": "Antigo"
-    },
-    "onAllVideos": {
-        "message": "Em todos os vídeos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Ativo apenas no YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Pause os videos em outras Abas enquanto assisto a um segundo vídeo"
-    },
-    "onSubscribedChannels": {
-        "message": "Apenas em inscrições"
-    },
-    "openNewTab": {
-        "message": "Abrir em uma nova aba"
-    },
-    "openPopupPlayer": {
-        "message": "Abra vídeos/playlist em uma nova janela"
-    },
-    "optimizeCodecForHardwareAcceleration": {
-        "message": "Otimizar o Codec para aceleração de hardware"
-    },
-    "orange": {
-        "message": "Laranja"
-    },
-    "os": {
-        "message": "Sistema Operacional"
-    },
-    "other": {
-        "message": "Outros"
-    },
-    "outline": {
-        "message": "Contorno"
-    },
-    "overlay": {
-        "message": "Sobreposição"
-    },
-    "permissions": {
-        "message": "Permissões"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Planície"
-    },
-    "platform": {
-        "message": "Plataforma"
-    },
-    "playAllButton": {
-        "message": "Botão \"Reproduzir Tudo\""
-    },
-    "playbackSpeed": {
-        "message": "Velocidade de reprodução"
-    },
-    "player_dont_speed_educatione": {
-        "message": "Não acelere na categoria (Rara): Educação"
-    },
-    "player_fit_to_win_button": {
-        "message": "Proporção 4x3: *Velha tela Quadrada \nou ganho de área de visualização quando estiver em modo Teatro"
-    },
-    "player_rotate_button": {
-        "message": "Botão pra girar em 90º graus"
-    },
-    "playerColor": {
-        "message": "Cor do player"
-    },
-    "playerSize": {
-        "message": "Tamanho do player"
-    },
-    "playlist": {
-        "message": "Lista de reprodução"
-    },
-    "playlists": {
-        "message": "Listas de reprodução"
-    },
-    "playPause": {
-        "message": "Reproduzir / Pausar"
-    },
-    "popupPlayer": {
-        "message": "Player externo"
-    },
-    "popupWindowButtons": {
-        "message": "Adicione um botão Popup-player para cada miniatura"
-    },
-    "position": {
-        "message": "Posição"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Pressione qualquer tecla ou use a roda do mouse"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Pressione qualquer tecla ou use a roda do mouse"
-    },
-    "previousVideo": {
-        "message": "Vídeo Anterior"
-    },
-    "primaryColor": {
-        "message": "Cor primária"
-    },
-    "purple": {
-        "message": "Roxo"
-    },
-    "pushSyncSettings": {
-        "message": "Pressione"
-    },
-    "quality": {
-        "message": "Qualidade"
-    },
-    "raised": {
-        "message": "Levantado"
-    },
-    "ram": {
-        "message": "RAM"
-    },
-    "rateMe": {
-        "message": "Avalie-me"
-    },
-    "rateUs": {
-        "message": "Avalie-nos!"
-    },
-    "red": {
-        "message": "Vermelho"
-    },
-    "redDislikeButton": {
-        "message": "Mostrar botão não gostei na cor vermelha"
-    },
-    "relatedVideos": {
-        "message": "Vídeos relacionados"
-    },
-    "remote": {
-        "message": "Assistir na TV"
-    },
-    "Remove": {
-        "message": "Remover"
-    },
-    "removeHomePageShorts": {
-        "message": "Remover Shorts da página inicial"
-    },
-    "removeIcons": {
-        "message": "Remover ícones"
-    },
-    "removeName": {
-        "message": "Remover nome"
-    },
-    "removeNames": {
-        "message": "Remover nomes"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Remover os respectivos resultados de pesquisa"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Remover fileiras de Shorts dos resultados de pesquisa"
-    },
-    "repeat": {
-        "message": "Repetir"
-    },
-    "report": {
-        "message": "Reportar"
-    },
-    "reset": {
-        "message": "Restaurar"
-    },
-    "resetAllSettings": {
-        "message": "Restaurar todas as configurações"
-    },
-    "resetAllShortcuts": {
-        "message": "Resetar todos os atalhos"
-    },
-    "reverse": {
-        "message": "Inverter"
-    },
-    "rotate": {
-        "message": "Girar"
-    },
-    "save": {
-        "message": "Salvar"
-    },
-    "saveAs": {
-        "message": "Salvar como"
-    },
-    "schedule": {
-        "message": "Programação"
-    },
-    "screen": {
-        "message": "Tela"
-    },
-    "screenshot": {
-        "message": "Captura de tela"
-    },
-    "scrollBar": {
-        "message": "Barra De rolagem"
-    },
-    "sd": {
-        "message": "SD"
-    },
-    "search": {
-        "message": "Pesquisar"
-    },
-    "searchBarOnly": {
-        "message": "Apenas barra de pesquisa"
-    },
-    "seekBackward10Seconds": {
-        "message": "Voltar 10 segundos"
-    },
-    "seekForward10Seconds": {
-        "message": "Avançar 10 segundos"
-    },
-    "seekNextChapter": {
-        "message": "Buscar próximo capítulo"
-    },
-    "seekPreviousChapter": {
-        "message": "Buscar capítulo anterior"
-    },
-    "settings": {
-        "message": "Configurações"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Configurações importadas com sucesso"
-    },
-    "share": {
-        "message": "Compartilhar"
-    },
-    "shortcut_chapters": {
-        "message": "Mostrar barra lateral de capítulos"
-    },
-    "shortcut_screenshot": {
-        "message": "Captura de tela"
-    },
-    "shortcuts": {
-        "message": "Atalhos"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Mostrar cards ao passar o mouse"
-    },
-    "showChannelVideosCount": {
-        "message": "Número de vídeos do canal"
-    },
-    "showLess": {
-        "message": "Mostre menos"
-    },
-    "showMore": {
-        "message": "Mostre mais"
-    },
-    "showRemainingDuration": {
-        "message": "Mostrar duração restante do vídeo"
-    },
-    "showVersion": {
-        "message": "Mostrar versão"
-    },
-    "shuffle": {
-        "message": "Aleatório"
-    },
-    "sidebar": {
-        "message": "Painel Lateral"
-    },
-    "Sidebar_simple_alternative": {
-        "message": "Barra lateral (alternativa simples)"
-    },
-    "softwareInformation": {
-        "message": "Informação do hardware"
-    },
-    "spacebar": {
-        "message": "Espaço"
-    },
-    "squaredUserImages": {
-        "message": "Imagens do usuário quadrada"
-    },
-    "static": {
-        "message": "Estático"
-    },
-    "statsForNerds": {
-        "message": "Mostrar Estatísticas para Nerds"
-    },
-    "step": {
-        "message": "Avançar"
-    },
-    "stop": {
-        "message": "Parar"
-    },
-    "style": {
-        "message": "Estilo"
-    },
-    "styles": {
-        "message": "Estilos"
-    },
-    "subscribe": {
-        "message": "Inscreva-Se"
-    },
-    "subscriptions": {
-        "message": "Inscrições"
-    },
-    "Subtitle_Capture_including_the_current_words": {
-        "message": "Legenda (Captura incluindo as palavras atuais)"
-    },
-    "subtitles": {
-        "message": "Legendas"
-    },
-    "sunset": {
-        "message": "Entardecer"
-    },
-    "sunsetToSunrise": {
-        "message": "Entardecer ao amanhecer"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferência do sistema: escuro"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferência do sistema: claro"
-    },
-    "teal": {
-        "message": "Verde Azulado"
-    },
-    "textColor": {
-        "message": "Cor do texto"
-    },
-    "thanks": {
-        "message": "Valeu Demais"
-    },
-    "themes": {
-        "message": "Temas"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Todos os cookies serão removidos."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Isto irá remover todos os vídeos assistidos."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Todos os cookies do YouTube serão removidos"
-    },
-    "thisWillResetAllSettings": {
-        "message": "As configurações padrão serão restauradas."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Isso irá redefinir todos os atalhos"
-    },
-    "thumbnails": {
-        "message": "Miniaturas"
-    },
-    "thumbnailsQuality": {
-        "message": "Qualidade das Miniaturas"
-    },
-    "timeFrom": {
-        "message": "Horário inicial"
-    },
-    "timeTo": {
-        "message": "Horário final"
-    },
-    "To_the_side_No_page_margin": {
-        "message": "Ao lado! (Sem margem de página)"
-    },
-    "todayAt": {
-        "message": "Hoje às"
-    },
-    "toggleAutoplay": {
-        "message": "Alternar reprodução automática"
-    },
-    "toggleCards": {
-        "message": "Alternar cards"
-    },
-    "toggleControls": {
-        "message": "Alternar controles"
-    },
-    "topChat": {
-        "message": "Chat no topo"
-    },
-    "trackWatchedVideos": {
-        "message": "Rastrear vídeos assistidos"
-    },
-    "trailerAutoplay": {
-        "message": "Reproduzir trailer"
-    },
-    "Transcript": {
-        "message": "Transcrição"
-    },
-    "translations": {
-        "message": "Traduções"
-    },
-    "transparentBackground": {
-        "message": "Fundo transparente"
-    },
-    "transparentColor": {
-        "message": "Transparente"
-    },
-    "trending": {
-        "message": "Em Alta"
-    },
-    "tryToReloadThePage": {
-        "message": "Recarregue página"
-    },
-    "type": {
-        "message": "Tipo"
-    },
-    "upNextAutoplay": {
-        "message": "Reproduzir vídeo em seguida"
-    },
-    "use24HourFormat": {
-        "message": "Usar formato de 24 horas"
-    },
-    "version": {
-        "message": "Versão"
-    },
-    "video": {
-        "message": "Vídeo"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "A descrição se expandirá para acessar a categoria do vídeo"
-    },
-    "videoFormats": {
-        "message": "Formatos de vídeo"
-    },
-    "videos": {
-        "message": "Vídeos"
-    },
-    "viewMode": {
-        "message": "Modo de visualização"
-    },
-    "volume": {
-        "message": "Volume"
-    },
-    "watchedVideos": {
-        "message": "Vídeos assistidos"
-    },
-    "watchLater": {
-        "message": "Assistir Mais Tarde"
-    },
-    "watchTime": {
-        "message": "Tempo de exibição"
-    },
-    "whenPaused": {
-        "message": "Quando pausado"
-    },
-    "whenTabIsChanged": {
-        "message": "Quando a aba é alterada"
-    },
-    "white": {
-        "message": "Branco"
-    },
-    "windowColor": {
-        "message": "Cor da janela"
-    },
-    "windowOpacity": {
-        "message": "Opacidade da janela"
-    },
-    "with_scrollbars": {
-        "message": "Com barras de rolagem?"
-    },
-    "yellow": {
-        "message": "Amarelo"
-    },
-    "YouTube_is_buttons": {
-        "message": "Botões do YouTube"
-    },
-    "Youtube_Is_Search": {
-        "message": "Pesquisar do Youtube"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Cabeçalho do YouTube (à esquerda)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Cabeçalho do YouTube (à direita)"
-    },
-    "youtubeHomePage": {
-        "message": "Página Inicial do YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Idioma do YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "O YouTube limita o codec h.264 à resolução de 1080p"
-    },
-    "youtubesDark": {
-        "message": "YouTube escuro"
-    }
+	"about": {
+		"message": "Sobre"
+	},
+	"accept": {
+		"message": "Aceitar"
+	},
+	"activate": {
+		"message": "Ativar"
+	},
+	"activateCaptions": {
+		"message": "Ativar legendas"
+	},
+	"activated": {
+		"message": "Ativado"
+	},
+	"activatedFeatures": {
+		"message": "Recursos ativados"
+	},
+	"activateFullscreen": {
+		"message": "Ativar tela cheia"
+	},
+	"activeFeatures": {
+		"message": "Recursos ativos"
+	},
+	"addScrollToTop": {
+		"message": "Adicionar «Voltar ao Topo»"
+	},
+	"ads": {
+		"message": "Anúncios"
+	},
+	"all": {
+		"message": "Todos"
+	},
+	"allow": {
+		"message": "Permitir"
+	},
+	"Allow_auto_generate": {
+		"message": "Permitir geração automática"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todas as suas configurações serão apagadas e não poderão ser recuperadas"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todos os seus atalhos serão apagados e não poderão ser recuperados"
+	},
+	"always": {
+		"message": "Sempre"
+	},
+	"alwaysActive": {
+		"message": "Sempre ativo"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Sempre exibir a barra de progresso"
+	},
+	"amber": {
+		"message": "Âmbar"
+	},
+	"analyzer": {
+		"message": "Analisador"
+	},
+	"animations": {
+		"message": "Animações"
+	},
+	"appearance": {
+		"message": "Aparência"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Tem certeza de que deseja exportar os dados?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Tem certeza de que deseja importar os dados?"
+	},
+	"audio": {
+		"message": "Áudio"
+	},
+	"audioFormats": {
+		"message": "Formatos de áudio"
+	},
+	"auto": {
+		"message": "Automático"
+	},
+	"Auto_PiP_picture_in_picture": {
+		"message": "Auto-PiP (Picture in picture)"
+	},
+	"autoFullscreen": {
+		"message": "Tela cheia automática"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausar vídeo automáticamente ao alternar entre abas"
+	},
+	"autoplay": {
+		"message": "Reprodução automática"
+	},
+	"avoidAv1": {
+		"message": "Evitar AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Evitar AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Evitar AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Evite renderização da CPU quando possível"
+	},
+	"backgroundColor": {
+		"message": "Cor de fundo"
+	},
+	"backgroundOpacity": {
+		"message": "Opacidade do fundo"
+	},
+	"backupAndReset": {
+		"message": "Backup & Restauração"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baseado nas cores do sistema"
+	},
+	"belowPlayer": {
+		"message": "Abaixo do player"
+	},
+	"bitness": {
+		"message": "Taxa de bits do Sistema"
+	},
+	"black": {
+		"message": "Preto"
+	},
+	"block_Codec_h264Alert": {
+		"message": "Você precisa ativar o VP9 ou H.264 para o Youtube funcionar. Desabilitar ambos irá quebrar o Vídeo."
+	},
+	"block_Codec_VP9Alert": {
+		"message": "Você precisa ativar o VP9 ou H.264 para o Youtube funcionar. Desabilitar ambos irá quebrar o Vídeo."
+	},
+	"blockAll": {
+		"message": "Bloquear tudo"
+	},
+	"blockAv1": {
+		"message": "Bloquear AV1"
+	},
+	"blockH264": {
+		"message": "Bloquear H.264"
+	},
+	"blocklist": {
+		"message": "Lista Negra"
+	},
+	"blockMusic": {
+		"message": "Pule anúncios nos vídeos musicais"
+	},
+	"blockVp8": {
+		"message": "Bloquear VP8"
+	},
+	"blockVp9": {
+		"message": "Bloquear VP9"
+	},
+	"blue": {
+		"message": "Azul"
+	},
+	"blueGray": {
+		"message": "Cinza azulado"
+	},
+	"bluelight": {
+		"message": "Filtrar luz azul"
+	},
+	"brightness": {
+		"message": "Luminosidade"
+	},
+	"brown": {
+		"message": "Marrom"
+	},
+	"browser": {
+		"message": "Navegador"
+	},
+	"browserVersion": {
+		"message": "Versão do navegador"
+	},
+	"bubbles": {
+		"message": "Bolhas"
+	},
+	"bug": {
+		"message": "Erro"
+	},
+	"Buttons": {
+		"message": "Botões"
+	},
+	"cancel": {
+		"message": "Cancelar"
+	},
+	"categories": {
+		"message": "Categorias"
+	},
+	"channel": {
+		"message": "Canal"
+	},
+	"channels": {
+		"message": "Canais"
+	},
+	"chapters": {
+		"message": "Capítulos"
+	},
+	"characterEdgeStyle": {
+		"message": "Estilo da borda"
+	},
+	"clipboard": {
+		"message": "Àrea de transferência"
+	},
+	"collapsed": {
+		"message": "Recolhido"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Recolher seções de assinatura"
+	},
+	"comments": {
+		"message": "Comentários"
+	},
+	"compact_spacing": {
+		"message": "Espaçamento compacto"
+	},
+	"compactTheme": {
+		"message": "Tema compacto"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Habilitar alerta para casos de fechamento acidental?"
+	},
+	"cores": {
+		"message": "Núcleos"
+	},
+	"cropChapterTitles": {
+		"message": "Recortar títulos do capítulos"
+	},
+	"Currently_requiring_a_YouTube_API_key": {
+		"message": "(Necessário uma chave do YouTube-API: )"
+	},
+	"custom": {
+		"message": "Personalizar"
+	},
+	"customCss": {
+		"message": "Personalizar CSS"
+	},
+	"customJs": {
+		"message": "Personalizar JS"
+	},
+	"customMiniPlayer": {
+		"message": "Personalizar Mini-Player"
+	},
+	"cyan": {
+		"message": "Ciano"
+	},
+	"dark": {
+		"message": "Escuro"
+	},
+	"darkTheme": {
+		"message": "Tema Escuro"
+	},
+	"dateAndTime": {
+		"message": "Data & Hora"
+	},
+	"dawn": {
+		"message": "Alvorecer"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Diminuir velocidade"
+	},
+	"decreaseVolume": {
+		"message": "Diminuir volume"
+	},
+	"deepOrange": {
+		"message": "Laranja Escuro"
+	},
+	"deepPurple": {
+		"message": "Roxo Escuro"
+	},
+	"default": {
+		"message": "Padrão"
+	},
+	"default_CC": {
+		"message": "Padrão"
+	},
+	"default_theme": {
+		"message": "padrão"
+	},
+	"defaultChannelTab": {
+		"message": "Aba padrão do canal"
+	},
+	"defaultContentCountry": {
+		"message": "Conteúdo padrão do país"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Velocidade padrão de reprodução"
+	},
+	"deleteWatchedVideos": {
+		"message": "Excluir vídeos assistidos"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Apagar cookies do YouTube"
+	},
+	"depressed": {
+		"message": "Comprimido"
+	},
+	"description": {
+		"message": "Descrição"
+	},
+	"description_ext": {
+		"message": "Torne o YouTube organizado e inteligente! Pular Anúncio, colorir YouTube, volume, velocidade, canal, ferramenta, estilo, HD, adblock, adblocker, tags, playlist ,palavras-chave"
+	},
+	"desert": {
+		"message": "Deserto"
+	},
+	"details": {
+		"message": "Detalhes"
+	},
+	"developerOptions": {
+		"message": "Opções do Desenvolvedor"
+	},
+	"device": {
+		"message": "Dispositivo"
+	},
+	"dim": {
+		"message": "Escurecer"
+	},
+	"disabled": {
+		"message": "Desativado"
+	},
+	"dislike": {
+		"message": "Não Gostei."
+	},
+	"displayDayOfTheWeak": {
+		"message": "Mostrar dia da Semana"
+	},
+	"donate": {
+		"message": "Doar"
+	},
+	"doNotChange": {
+		"message": "Não Alterar"
+	},
+	"draggable": {
+		"message": "Arrastável"
+	},
+	"dropShadow": {
+		"message": "Sombra projetada"
+	},
+	"durationWithSpeed": {
+		"message": "Mostrar tempo restante com referência a velocidade de reprodução"
+	},
+	"embedded_Hide_Share": {
+		"message": "Ocultar compartilhamento do video incorporado"
+	},
+	"Embedded_YouTube": {
+		"message": "Vídeos Incorporados"
+	},
+	"empty": {
+		"message": "Vazio"
+	},
+	"enabled": {
+		"message": "Ativado"
+	},
+	"enabledForced": {
+		"message": "Ativado (forçado)"
+	},
+	"expanded": {
+		"message": "Expandido"
+	},
+	"exportSettings": {
+		"message": "Exportar configurações"
+	},
+	"extension": {
+		"message": "Extensão"
+	},
+	"ExtraButtons": {
+		"message": "Botões extras"
+	},
+	"Feature_not_yet_available": {
+		"message": "Recurso não está presente no momento"
+	},
+	"file": {
+		"message": "Arquivo"
+	},
+	"filters": {
+		"message": "Filtros"
+	},
+	"fitToWindow": {
+		"message": "Ajustar à janela"
+	},
+	"flash": {
+		"message": "Instantâneo"
+	},
+	"font": {
+		"message": "Fonte"
+	},
+	"fontColor": {
+		"message": "Cor da fonte"
+	},
+	"fontFamily": {
+		"message": "Família da fonte"
+	},
+	"fontOpacity": {
+		"message": "Opacidade da fonte"
+	},
+	"fontSize": {
+		"message": "Tamanho da fonte"
+	},
+	"footer": {
+		"message": "Rodapé"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Velocidade do reprodução forçado"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(Forçar velocidade de reprodução mesmo para música?)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Reprodução do vídeo desde o início forçado"
+	},
+	"forcedTheaterMode": {
+		"message": "Modo teatro forçado"
+	},
+	"forcedVolume": {
+		"message": "Volume forçado"
+	},
+	"forceSDR": {
+		"message": "Forçar SDR"
+	},
+	"foundABug": {
+		"message": "Encontrou um Bug?"
+	},
+	"fullWindow": {
+		"message": "Tela Cheia"
+	},
+	"general": {
+		"message": "Geral"
+	},
+	"geoPreference": {
+		"message": "Preferência Geográfica"
+	},
+	"googleApiKey": {
+		"message": "Chave da API do Google"
+	},
+	"goToSearchBox": {
+		"message": "Selecionar barra de pesquisa"
+	},
+	"GPUnotindatabase": {
+		"message": "Não tenho sua GPU nos meus Dados :¬("
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"grey": {
+		"message": "Cinza"
+	},
+	"Hamburger_Menu": {
+		"message": "Menu hamburguer"
+	},
+	"hardwareInformation": {
+		"message": "Informações do hardware"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura em HD"
+	},
+	"header": {
+		"message": "Cabeçalho"
+	},
+	"hidden": {
+		"message": "Oculto"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Oculto na página do vídeo"
+	},
+	"hide_author_avatars": {
+		"message": "Ocultar avatares de autores"
+	},
+	"hide_labels": {
+		"message": "Ocultar nomes"
+	},
+	"Hide_Pause_Overlay": {
+		"message": "Ocultar Sobreposição de pausa"
+	},
+	"Hide_Shorts_remixing_this_video": {
+		"message": "Ocultar Shorts remixando alguns videos"
+	},
+	"Hide_sidebar": {
+		"message": "Ocultar barra lateral de recomendações"
+	},
+	"Hide_subscriptionsShorts": {
+		"message": "Ocultar Shorts das inscrições"
+	},
+	"Hide_the_tabs_only": {
+		"message": "Ocultar somente as abas"
+	},
+	"Hide_trendingThis_Shorts": {
+		"message": "Ocultar Shorts do Em alta"
+	},
+	"Hide_YouTube_Logo": {
+		"message": "Ocultar Logo do YouTube"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Desativar miniaturas animadas"
+	},
+	"hideAnnotations": {
+		"message": "Ocultar anotações"
+	},
+	"hideCards": {
+		"message": "Ocultar cards"
+	},
+	"hideCategories": {
+		"message": "Ocultar categorias"
+	},
+	"hideCommentsCount": {
+		"message": "Ocultar contagens de Comentários"
+	},
+	"hideCountryCode": {
+		"message": "Ocultar código do país"
+	},
+	"hideDate": {
+		"message": "Ocultar data"
+	},
+	"hideDetailButton": {
+		"message": "Ocultar botão de detalhs"
+	},
+	"hideDetails": {
+		"message": "Ocultar detalhes"
+	},
+	"hideEndscreen": {
+		"message": "Ocultar tela final"
+	},
+	"hideFeaturedContent": {
+		"message": "Ocultar conteúdo em destaque"
+	},
+	"hideFooter": {
+		"message": "Ocultar rodapé"
+	},
+	"hideGradientBottom": {
+		"message": "Ocultar sombra ao redor da barra do player"
+	},
+	"hideMore": {
+		"message": "Ocultar mais"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ocultar a barra de controles do player"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ocultar os botões da barra de controles do player"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ocultar opções de controles do player"
+	},
+	"hidePlaylist": {
+		"message": "Ocultar playlist"
+	},
+	"hideReport": {
+		"message": "Ocultar report"
+	},
+	"hideRightButtons": {
+		"message": "Ocultar botões à direita"
+	},
+	"hideScrollForDetails": {
+		"message": "Ocultar «Rolar para ver detalhes»"
+	},
+	"hideSkipOverlay": {
+		"message": "Esconder animação de salto de 5 segundos"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ocultar botões nas miniaturas"
+	},
+	"hideThumbnails": {
+		"message": "Ocultar miniaturas"
+	},
+	"hideVideoTitleFullScreen": {
+		"message": "Ocultar o título do vídeo em tela cheia"
+	},
+	"hideViewsCount": {
+		"message": "Ocultar visualizações"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ocultar botão pesquisa de voz"
+	},
+	"high": {
+		"message": "Alta"
+	},
+	"history": {
+		"message": "Histórico"
+	},
+	"home": {
+		"message": "Início"
+	},
+	"homeScreen": {
+		"message": "Tela inicial"
+	},
+	"hover": {
+		"message": "Passar o Ponteiro"
+	},
+	"hoverOnVideoPage": {
+		"message": "Passe o mouse na página do vídeo"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Há quanto tempo o vídeo foi enviado"
+	},
+	"icons": {
+		"message": "Ícones"
+	},
+	"iconsOnly": {
+		"message": "Apenas ícones"
+	},
+	"importSettings": {
+		"message": "Importar configurações"
+	},
+	"improvedtubeButtons": {
+		"message": "Botões do ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ícone do ImprovedTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Idioma do ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Versão do ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Logo do ImproveTube"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Aumentar velocidade"
+	},
+	"increaseVolume": {
+		"message": "Diminuir volume"
+	},
+	"items": {
+		"message": "Itens"
+	},
+	"language": {
+		"message": "Idioma"
+	},
+	"language_closed_caption": {
+		"message": "Padrão de Idioma - Legendas de Idioma"
+	},
+	"languages": {
+		"message": "Idiomas"
+	},
+	"layerAnimationScale": {
+		"message": "Escala de animação"
+	},
+	"layout": {
+		"message": "Aparência"
+	},
+	"legacyYoutube": {
+		"message": "YouTube Antigo"
+	},
+	"library": {
+		"message": "Biblioteca"
+	},
+	"light": {
+		"message": "Claro"
+	},
+	"lightBlue": {
+		"message": "Azul Claro"
+	},
+	"lightGreen": {
+		"message": "Verde Claro"
+	},
+	"like": {
+		"message": "Avaliar!"
+	},
+	"liked": {
+		"message": "Avaliado"
+	},
+	"likes": {
+		"message": "Curtidas"
+	},
+	"lime": {
+		"message": "Verde Limão"
+	},
+	"limitPageWidth": {
+		"message": "Limite de largura da página"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Chat Ao vivo"
+	},
+	"liveChatType": {
+		"message": "Tipo chat Ao vivo"
+	},
+	"location": {
+		"message": "Localização"
+	},
+	"loudnessNormalization": {
+		"message": "Normalização de volume"
+	},
+	"low": {
+		"message": "Baixa"
+	},
+	"markWatchedVideos": {
+		"message": "Marca vídeos assistido"
+	},
+	"medium": {
+		"message": "Média"
+	},
+	"more": {
+		"message": "Mais"
+	},
+	"mostViewedChannels": {
+		"message": "Canais mais vistos"
+	},
+	"moveSidebarLeft": {
+		"message": "Mover barra lateral para esquerda"
+	},
+	"moveThumbnailsRight": {
+		"message": "Mover miniaturas para direita"
+	},
+	"My_specs": {
+		"message": "Minhas especificações"
+	},
+	"myColors": {
+		"message": "Minhas cores"
+	},
+	"name": {
+		"message": "Nome"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini Player nativo"
+	},
+	"new": {
+		"message": "Novo"
+	},
+	"nextVideo": {
+		"message": "Próximo vídeo"
+	},
+	"night": {
+		"message": "Noite"
+	},
+	"nightMode": {
+		"message": "Modo noturno"
+	},
+	"noActiveFeatures": {
+		"message": "Sem recursos ativos"
+	},
+	"none": {
+		"message": "Nenhum"
+	},
+	"noOpenVideoTabs": {
+		"message": "Nenhuma aba de vídeo aberta"
+	},
+	"Not_optimal": {
+		"message": "Sem otimização"
+	},
+	"off": {
+		"message": "Desativado"
+	},
+	"ok": {
+		"message": "OK"
+	},
+	"old": {
+		"message": "Antigo"
+	},
+	"onAllVideos": {
+		"message": "Em todos os vídeos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Ativo apenas no YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Pause os videos em outras Abas enquanto assisto a um segundo vídeo"
+	},
+	"onSubscribedChannels": {
+		"message": "Apenas em inscrições"
+	},
+	"openNewTab": {
+		"message": "Abrir em uma nova aba"
+	},
+	"openPopupPlayer": {
+		"message": "Abra vídeos/playlist em uma nova janela"
+	},
+	"optimizeCodecForHardwareAcceleration": {
+		"message": "Otimizar o Codec para aceleração de hardware"
+	},
+	"orange": {
+		"message": "Laranja"
+	},
+	"os": {
+		"message": "Sistema Operacional"
+	},
+	"other": {
+		"message": "Outros"
+	},
+	"outline": {
+		"message": "Contorno"
+	},
+	"overlay": {
+		"message": "Sobreposição"
+	},
+	"permissions": {
+		"message": "Permissões"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Planície"
+	},
+	"platform": {
+		"message": "Plataforma"
+	},
+	"playAllButton": {
+		"message": "Botão \"Reproduzir Tudo\""
+	},
+	"playbackSpeed": {
+		"message": "Velocidade de reprodução"
+	},
+	"player_dont_speed_educatione": {
+		"message": "Não acelere na categoria (Rara): Educação"
+	},
+	"player_fit_to_win_button": {
+		"message": "Proporção 4x3: *Velha tela Quadrada \nou ganho de área de visualização quando estiver em modo Teatro"
+	},
+	"player_rotate_button": {
+		"message": "Botão pra girar em 90º graus"
+	},
+	"playerColor": {
+		"message": "Cor do player"
+	},
+	"playerSize": {
+		"message": "Tamanho do player"
+	},
+	"playlist": {
+		"message": "Lista de reprodução"
+	},
+	"playlists": {
+		"message": "Listas de reprodução"
+	},
+	"playPause": {
+		"message": "Reproduzir / Pausar"
+	},
+	"popupPlayer": {
+		"message": "Player externo"
+	},
+	"popupWindowButtons": {
+		"message": "Adicione um botão Popup-player para cada miniatura"
+	},
+	"position": {
+		"message": "Posição"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Pressione qualquer tecla ou use a roda do mouse"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Pressione qualquer tecla ou use a roda do mouse"
+	},
+	"previousVideo": {
+		"message": "Vídeo Anterior"
+	},
+	"primaryColor": {
+		"message": "Cor primária"
+	},
+	"purple": {
+		"message": "Roxo"
+	},
+	"pushSyncSettings": {
+		"message": "Pressione"
+	},
+	"quality": {
+		"message": "Qualidade"
+	},
+	"raised": {
+		"message": "Levantado"
+	},
+	"rateMe": {
+		"message": "Avalie-me"
+	},
+	"rateUs": {
+		"message": "Avalie-nos!"
+	},
+	"red": {
+		"message": "Vermelho"
+	},
+	"redDislikeButton": {
+		"message": "Mostrar botão não gostei na cor vermelha"
+	},
+	"relatedVideos": {
+		"message": "Vídeos relacionados"
+	},
+	"remote": {
+		"message": "Assistir na TV"
+	},
+	"Remove": {
+		"message": "Remover"
+	},
+	"removeHomePageShorts": {
+		"message": "Remover Shorts da página inicial"
+	},
+	"removeIcons": {
+		"message": "Remover ícones"
+	},
+	"removeName": {
+		"message": "Remover nome"
+	},
+	"removeNames": {
+		"message": "Remover nomes"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Remover os respectivos resultados de pesquisa"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Remover fileiras de Shorts dos resultados de pesquisa"
+	},
+	"repeat": {
+		"message": "Repetir"
+	},
+	"report": {
+		"message": "Reportar"
+	},
+	"reset": {
+		"message": "Restaurar"
+	},
+	"resetAllSettings": {
+		"message": "Restaurar todas as configurações"
+	},
+	"resetAllShortcuts": {
+		"message": "Resetar todos os atalhos"
+	},
+	"reverse": {
+		"message": "Inverter"
+	},
+	"rotate": {
+		"message": "Girar"
+	},
+	"save": {
+		"message": "Salvar"
+	},
+	"saveAs": {
+		"message": "Salvar como"
+	},
+	"schedule": {
+		"message": "Programação"
+	},
+	"screen": {
+		"message": "Tela"
+	},
+	"screenshot": {
+		"message": "Captura de tela"
+	},
+	"scrollBar": {
+		"message": "Barra De rolagem"
+	},
+	"search": {
+		"message": "Pesquisar"
+	},
+	"searchBarOnly": {
+		"message": "Apenas barra de pesquisa"
+	},
+	"seekBackward10Seconds": {
+		"message": "Voltar 10 segundos"
+	},
+	"seekForward10Seconds": {
+		"message": "Avançar 10 segundos"
+	},
+	"seekNextChapter": {
+		"message": "Buscar próximo capítulo"
+	},
+	"seekPreviousChapter": {
+		"message": "Buscar capítulo anterior"
+	},
+	"settings": {
+		"message": "Configurações"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Configurações importadas com sucesso"
+	},
+	"share": {
+		"message": "Compartilhar"
+	},
+	"shortcut_chapters": {
+		"message": "Mostrar barra lateral de capítulos"
+	},
+	"shortcut_screenshot": {
+		"message": "Captura de tela"
+	},
+	"shortcuts": {
+		"message": "Atalhos"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Mostrar cards ao passar o mouse"
+	},
+	"showChannelVideosCount": {
+		"message": "Número de vídeos do canal"
+	},
+	"showLess": {
+		"message": "Mostre menos"
+	},
+	"showMore": {
+		"message": "Mostre mais"
+	},
+	"showRemainingDuration": {
+		"message": "Mostrar duração restante do vídeo"
+	},
+	"showVersion": {
+		"message": "Mostrar versão"
+	},
+	"shuffle": {
+		"message": "Aleatório"
+	},
+	"sidebar": {
+		"message": "Painel Lateral"
+	},
+	"Sidebar_simple_alternative": {
+		"message": "Barra lateral (alternativa simples)"
+	},
+	"softwareInformation": {
+		"message": "Informação do hardware"
+	},
+	"spacebar": {
+		"message": "Espaço"
+	},
+	"squaredUserImages": {
+		"message": "Imagens do usuário quadrada"
+	},
+	"static": {
+		"message": "Estático"
+	},
+	"statsForNerds": {
+		"message": "Mostrar Estatísticas para Nerds"
+	},
+	"step": {
+		"message": "Avançar"
+	},
+	"stop": {
+		"message": "Parar"
+	},
+	"style": {
+		"message": "Estilo"
+	},
+	"styles": {
+		"message": "Estilos"
+	},
+	"subscribe": {
+		"message": "Inscreva-Se"
+	},
+	"subscriptions": {
+		"message": "Inscrições"
+	},
+	"Subtitle_Capture_including_the_current_words": {
+		"message": "Legenda (Captura incluindo as palavras atuais)"
+	},
+	"subtitles": {
+		"message": "Legendas"
+	},
+	"sunset": {
+		"message": "Entardecer"
+	},
+	"sunsetToSunrise": {
+		"message": "Entardecer ao amanhecer"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferência do sistema: escuro"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferência do sistema: claro"
+	},
+	"teal": {
+		"message": "Verde Azulado"
+	},
+	"textColor": {
+		"message": "Cor do texto"
+	},
+	"thanks": {
+		"message": "Valeu Demais"
+	},
+	"themes": {
+		"message": "Temas"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Todos os cookies serão removidos."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Isto irá remover todos os vídeos assistidos."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Todos os cookies do YouTube serão removidos"
+	},
+	"thisWillResetAllSettings": {
+		"message": "As configurações padrão serão restauradas."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Isso irá redefinir todos os atalhos"
+	},
+	"thumbnails": {
+		"message": "Miniaturas"
+	},
+	"thumbnailsQuality": {
+		"message": "Qualidade das Miniaturas"
+	},
+	"timeFrom": {
+		"message": "Horário inicial"
+	},
+	"timeTo": {
+		"message": "Horário final"
+	},
+	"To_the_side_No_page_margin": {
+		"message": "Ao lado! (Sem margem de página)"
+	},
+	"todayAt": {
+		"message": "Hoje às"
+	},
+	"toggleAutoplay": {
+		"message": "Alternar reprodução automática"
+	},
+	"toggleCards": {
+		"message": "Alternar cards"
+	},
+	"toggleControls": {
+		"message": "Alternar controles"
+	},
+	"topChat": {
+		"message": "Chat no topo"
+	},
+	"trackWatchedVideos": {
+		"message": "Rastrear vídeos assistidos"
+	},
+	"trailerAutoplay": {
+		"message": "Reproduzir trailer"
+	},
+	"Transcript": {
+		"message": "Transcrição"
+	},
+	"translations": {
+		"message": "Traduções"
+	},
+	"transparentBackground": {
+		"message": "Fundo transparente"
+	},
+	"transparentColor": {
+		"message": "Transparente"
+	},
+	"trending": {
+		"message": "Em Alta"
+	},
+	"tryToReloadThePage": {
+		"message": "Recarregue página"
+	},
+	"type": {
+		"message": "Tipo"
+	},
+	"upNextAutoplay": {
+		"message": "Reproduzir vídeo em seguida"
+	},
+	"use24HourFormat": {
+		"message": "Usar formato de 24 horas"
+	},
+	"version": {
+		"message": "Versão"
+	},
+	"video": {
+		"message": "Vídeo"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "A descrição se expandirá para acessar a categoria do vídeo"
+	},
+	"videoFormats": {
+		"message": "Formatos de vídeo"
+	},
+	"videos": {
+		"message": "Vídeos"
+	},
+	"viewMode": {
+		"message": "Modo de visualização"
+	},
+	"watchedVideos": {
+		"message": "Vídeos assistidos"
+	},
+	"watchLater": {
+		"message": "Assistir Mais Tarde"
+	},
+	"watchTime": {
+		"message": "Tempo de exibição"
+	},
+	"whenPaused": {
+		"message": "Quando pausado"
+	},
+	"whenTabIsChanged": {
+		"message": "Quando a aba é alterada"
+	},
+	"white": {
+		"message": "Branco"
+	},
+	"windowColor": {
+		"message": "Cor da janela"
+	},
+	"windowOpacity": {
+		"message": "Opacidade da janela"
+	},
+	"with_scrollbars": {
+		"message": "Com barras de rolagem?"
+	},
+	"yellow": {
+		"message": "Amarelo"
+	},
+	"YouTube_is_buttons": {
+		"message": "Botões do YouTube"
+	},
+	"Youtube_Is_Search": {
+		"message": "Pesquisar do Youtube"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Cabeçalho do YouTube (à esquerda)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Cabeçalho do YouTube (à direita)"
+	},
+	"youtubeHomePage": {
+		"message": "Página Inicial do YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Idioma do YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "O YouTube limita o codec h.264 à resolução de 1080p"
+	},
+	"youtubesDark": {
+		"message": "YouTube escuro"
+	}
 }

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -1,1145 +1,1136 @@
 {
-    "about": {
-        "message": "Acerca"
-    },
-    "accept": {
-        "message": "Aceitar"
-    },
-    "activate": {
-        "message": "Ativar"
-    },
-    "activateCaptions": {
-        "message": "Ativar legendas"
-    },
-    "activated": {
-        "message": "Ativado"
-    },
-    "activatedFeatures": {
-        "message": "Opções ativadas"
-    },
-    "activateFullscreen": {
-        "message": "Ativar ecrã completo"
-    },
-    "activeFeatures": {
-        "message": "Opções ativas"
-    },
-    "addScrollToTop": {
-        "message": "Adicionar «Ir para o topo»"
-    },
-    "ads": {
-        "message": "Anúncios"
-    },
-    "all": {
-        "message": "Todas"
-    },
-    "allow": {
-        "message": "Permitir"
-    },
-    "Allow_auto_generate": {
-        "message": "Permitir geração automática"
-    },
-    "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todas as suas definições serão eliminadas e não poderão ser recuperadas"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "Todos os seus atalhos serão eliminados e não poderão ser recuperados"
-    },
-    "always": {
-        "message": "Sempre"
-    },
-    "alwaysActive": {
-        "message": "Sempre ativo"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Mostrar sempre a barra de progressos"
-    },
-    "amber": {
-        "message": "Âmbar"
-    },
-    "analyzer": {
-        "message": "Analisador"
-    },
-    "animations": {
-        "message": "Animações"
-    },
-    "appearance": {
-        "message": "Aparência"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Tem certeza de que deseja exportar os dados?"
-    },
-    "audio": {
-        "message": "Áudio"
-    },
-    "audioFormats": {
-        "message": "Formatos de áudio"
-    },
-    "auto": {
-        "message": "Automático"
-    },
-    "Auto_PiP_picture_in_picture": {
-        "message": "Auto-PiP (Picture in picture)"
-    },
-    "autoFullscreen": {
-        "message": "Ecrân completo automático"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausa quando muda de abas"
-    },
-    "autoplay": {
-        "message": "Reprodução automática"
-    },
-    "avoidAv1": {
-        "message": "Evitar AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Evitar AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Evitar AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Evite renderização da CPU quando possível"
-    },
-    "backgroundColor": {
-        "message": "Cor de fundo"
-    },
-    "backgroundOpacity": {
-        "message": "Opacidade do fundo"
-    },
-    "backupAndReset": {
-        "message": "Cópia de segurança e repor"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Baseado no esquema de cores do sistema"
-    },
-    "belowPlayer": {
-        "message": "Reprodutor abaixo"
-    },
-    "bitness": {
-        "message": "Processor Bits"
-    },
-    "black": {
-        "message": "Preto"
-    },
-    "blockAll": {
-        "message": "Bloquear todos"
-    },
-    "blockAv1": {
-        "message": "Bloquear AV1"
-    },
-    "blockH264": {
-        "message": "Bloquear H.264"
-    },
-    "blocklist": {
-        "message": "Lista negra"
-    },
-    "blockMusic": {
-        "message": "Bloquear música"
-    },
-    "blockVp8": {
-        "message": "Bloquear VP8"
-    },
-    "blockVp9": {
-        "message": "Bloquear VP9"
-    },
-    "blue": {
-        "message": "Azul"
-    },
-    "blueGray": {
-        "message": "Azul acizentado"
-    },
-    "bluelight": {
-        "message": "Azul claro"
-    },
-    "brightness": {
-        "message": "Luminosidade"
-    },
-    "brown": {
-        "message": "Castanho"
-    },
-    "browser": {
-        "message": "Navegador"
-    },
-    "browserVersion": {
-        "message": "Versão do navegador"
-    },
-    "bubbles": {
-        "message": "Bolhas"
-    },
-    "bug": {
-        "message": "Erro"
-    },
-    "buttons": {
-        "message": "Botões"
-    },
-    "cancel": {
-        "message": "Cancelar"
-    },
-    "categories": {
-        "message": "Categorias"
-    },
-    "channel": {
-        "message": "Canal"
-    },
-    "channels": {
-        "message": "Canais"
-    },
-    "chapters": {
-        "message": "Capítulos"
-    },
-    "characterEdgeStyle": {
-        "message": "Estilo da borda de personagem"
-    },
-    "clipboard": {
-        "message": "Area de transferência"
-    },
-    "collapsed": {
-        "message": "Extender"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Extender as secções escolhidas"
-    },
-    "comments": {
-        "message": "Comentários"
-    },
-    "compact_spacing": {
-        "message": "Tema compacto"
-    },
-    "compactTheme": {
-        "message": "Tema compacto"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Confirmar antes de encerrar"
-    },
-    "cores": {
-        "message": "Núcleos"
-    },
-    "cropChapterTitles": {
-        "message": "Recortar títulos do capítulos"
-    },
-    "Currently_requiring_a_YouTube_API_key": {
-        "message": "(Necessário uma chave do YouTube-API: )"
-    },
-    "custom": {
-        "message": "Personalizar"
-    },
-    "customCss": {
-        "message": "CSS personalizadas"
-    },
-    "customJs": {
-        "message": "JS personalizadas"
-    },
-    "customMiniPlayer": {
-        "message": "Personalizar Mini-Player"
-    },
-    "cyan": {
-        "message": "Esverdeado"
-    },
-    "dark": {
-        "message": "Escuro"
-    },
-    "darkTheme": {
-        "message": "Tema escuro"
-    },
-    "dateAndTime": {
-        "message": "Data & hora"
-    },
-    "dawn": {
-        "message": "Escurecer"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Diminuir velocidade de leitura"
-    },
-    "decreaseVolume": {
-        "message": "Diminuir volume"
-    },
-    "deepOrange": {
-        "message": "Laranja forte"
-    },
-    "deepPurple": {
-        "message": "Lilás forte"
-    },
-    "default": {
-        "message": "Padrão"
-    },
-    "default_CC": {
-        "message": "Padrão"
-    },
-    "defaultChannelTab": {
-        "message": "Aba padrão do canal"
-    },
-    "defaultContentCountry": {
-        "message": "País (viagem virtual)"
-    },
-    "defaultPlaybackSpeed": {
-        "message": "Velocidade padrão de reprodução"
-    },
-    "deleteWatchedVideos": {
-        "message": "Excluir vídeos assistidos"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Eliminar os cookies do YouTube"
-    },
-    "depressed": {
-        "message": "Comprimido"
-    },
-    "description": {
-        "message": "Descrição"
-    },
-    "description_ext": {
-        "message": "Torne o YouTube organizado e inteligente! Pule Anúncio, colorir YouTube, volume, velocidade, canal, ferramenta, estilo, HD, adblock, adblocker, tags, playlist ,palavras-chave"
-    },
-    "desert": {
-        "message": "Deserto"
-    },
-    "details": {
-        "message": "Detalhes"
-    },
-    "developerOptions": {
-        "message": "Opções de programador"
-    },
-    "device": {
-        "message": "Aparelho"
-    },
-    "dim": {
-        "message": "Escurecer"
-    },
-    "disabled": {
-        "message": "Desabilitado"
-    },
-    "dislike": {
-        "message": "Não gostar"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Mostrar dia da Semana"
-    },
-    "donate": {
-        "message": "Doar"
-    },
-    "doNotChange": {
-        "message": "Não mudes"
-    },
-    "draggable": {
-        "message": "Podes arrastar"
-    },
-    "dropShadow": {
-        "message": "Sombra projetada"
-    },
-    "durationWithSpeed": {
-        "message": "Mostrar tempo restante com referência a velocidade de reprodução"
-    },
-    "email": {
-        "message": "Correio electronico"
-    },
-    "embedded_Hide_Share": {
-        "message": "Ocultar compartilhamento do video incorporado"
-    },
-    "Embedded_YouTube": {
-        "message": "Videos Incorporados do YouTube"
-    },
-    "empty": {
-        "message": "Vazio"
-    },
-    "enabled": {
-        "message": "Ativado"
-    },
-    "enabledForced": {
-        "message": "Ativado (forçado)"
-    },
-    "expanded": {
-        "message": "Expandir"
-    },
-    "exportSettings": {
-        "message": "Exportar definições"
-    },
-    "extension": {
-        "message": "Extenção"
-    },
-    "Feature_not_yet_available": {
-        "message": "Recurso não está presente no momento"
-    },
-    "file": {
-        "message": "Ficheiro"
-    },
-    "filters": {
-        "message": "Filtros"
-    },
-    "fitToWindow": {
-        "message": "Ajustar á janela"
-    },
-    "flash": {
-        "message": "Instantâneo"
-    },
-    "font": {
-        "message": "Tipo de letra"
-    },
-    "fontColor": {
-        "message": "Cor da fonte"
-    },
-    "fontFamily": {
-        "message": "Família da fonte"
-    },
-    "fontOpacity": {
-        "message": "Opacidade da fonte"
-    },
-    "fontSize": {
-        "message": "Tamanho da fonte"
-    },
-    "footer": {
-        "message": "Cabeçalho"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Forçar velocidade de leitura"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Forçar velocidade de reprodução mesmo para música?)"
-    },
-    "forcedTheaterMode": {
-        "message": "Forçar modo de cinema"
-    },
-    "forcedVolume": {
-        "message": "Volume forçado"
-    },
-    "forceSDR": {
-        "message": "Forçar SDR"
-    },
-    "foundABug": {
-        "message": "Encontrou um erro?"
-    },
-    "fullWindow": {
-        "message": "Janela completa"
-    },
-    "general": {
-        "message": "Geral"
-    },
-    "geoPreference": {
-        "message": "Preferência Geográfica"
-    },
-    "googleApiKey": {
-        "message": "Chave da API do Google"
-    },
-    "goToSearchBox": {
-        "message": "Vai à caixa de pesquisa"
-    },
-    "GPUnotindatabase": {
-        "message": "Não tenho sua GPU nos meus Dados :¬("
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "Hamburger_Menu": {
-        "message": "Menu Hamburger"
-    },
-    "hardwareInformation": {
-        "message": "Informações do hardware"
-    },
-    "hdThumbnail": {
-        "message": "Miniatura HD"
-    },
-    "header": {
-        "message": "Cabeçalho"
-    },
-    "hidden": {
-        "message": "Escondido"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Escondido na página do video"
-    },
-    "hide_author_avatars": {
-        "message": "Ocultar avatar de autor"
-    },
-    "Hide_Pause_Overlay": {
-        "message": "Ocultar Sobreposição de pausa"
-    },
-    "Hide_Shorts_remixing_this_video": {
-        "message": "Ocultar Shorts remixando alguns videos"
-    },
-    "Hide_the_tabs_only": {
-        "message": "Ocultar somente as abas"
-    },
-    "Hide_YouTube_Logo": {
-        "message": "Ocultar Logo do YouTube"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Esconder miniaturas animadas"
-    },
-    "hideAnnotations": {
-        "message": "Esconder anotações"
-    },
-    "hideCards": {
-        "message": "Esconder cartas"
-    },
-    "hideCategories": {
-        "message": "Ocultar categorias"
-    },
-    "hideCommentsCount": {
-        "message": "Ocultar contagens de Comentários"
-    },
-    "hideCountryCode": {
-        "message": "Ocultar código do país"
-    },
-    "hideDate": {
-        "message": "Ocultar data"
-    },
-    "hideDetails": {
-        "message": "Esconder detalhes"
-    },
-    "hideEndscreen": {
-        "message": "Esconder ecãn final"
-    },
-    "hideFeaturedContent": {
-        "message": "Esconder conteúdo"
-    },
-    "hideFooter": {
-        "message": "Esconder rodapé"
-    },
-    "hideGradientBottom": {
-        "message": "Hide Gradient Bottom"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ocultar a barra de controles do player"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ocultar opções de controles do player"
-    },
-    "hidePlaylist": {
-        "message": "Esconder lista de reprodução"
-    },
-    "hideRightButtons": {
-        "message": "Esconder botões do lado direito"
-    },
-    "hideScrollForDetails": {
-        "message": "Esconder «Rodar para detalhes»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideThumbnails": {
-        "message": "Ocultar miniaturas"
-    },
-    "hideVideoTitleFullScreen": {
-        "message": "Ocultar o título do vídeo em tela cheia"
-    },
-    "hideViewsCount": {
-        "message": "Esconder número de vistos"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ocultar botão pesquisa de voz"
-    },
-    "high": {
-        "message": "Alta"
-    },
-    "history": {
-        "message": "História"
-    },
-    "home": {
-        "message": "Casa"
-    },
-    "homeScreen": {
-        "message": "Ecrã inicial"
-    },
-    "hover": {
-        "message": "Aponta"
-    },
-    "hoverOnVideoPage": {
-        "message": "Apontar na página do video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "À quanto tempo o video foi enviado"
-    },
-    "icons": {
-        "message": "Ícones"
-    },
-    "iconsOnly": {
-        "message": "Ícones apenas"
-    },
-    "importSettings": {
-        "message": "Importar definições"
-    },
-    "improvedtubeButtons": {
-        "message": "Botões do ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ícon do ImprovedTube no YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Linguagem do ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Versão do ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Melhorar logotipo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Aumentar velocidade de leitura"
-    },
-    "increaseVolume": {
-        "message": "Aumentar o volume"
-    },
-    "items": {
-        "message": "Artigos"
-    },
-    "language": {
-        "message": "Idioma"
-    },
-    "language_closed_caption": {
-        "message": "Padrão de Idioma - Legendas de videos"
-    },
-    "languages": {
-        "message": "Linguagens"
-    },
-    "layerAnimationScale": {
-        "message": "Escala de animação"
-    },
-    "legacyYoutube": {
-        "message": "YouTube antigo"
-    },
-    "library": {
-        "message": "Biblioteca"
-    },
-    "light": {
-        "message": "Claro"
-    },
-    "lightBlue": {
-        "message": "Azul claro"
-    },
-    "lightGreen": {
-        "message": "Verde claro"
-    },
-    "like": {
-        "message": "Gostar"
-    },
-    "liked": {
-        "message": "Avaliado"
-    },
-    "lime": {
-        "message": "Limão"
-    },
-    "limitPageWidth": {
-        "message": "Limite de largura da página"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Conversa do vivo"
-    },
-    "liveChatType": {
-        "message": "Tipo de conversa do vivo"
-    },
-    "location": {
-        "message": "Localização"
-    },
-    "loudnessNormalization": {
-        "message": "Normalização do volume"
-    },
-    "low": {
-        "message": "Baixa"
-    },
-    "markWatchedVideos": {
-        "message": "Marcar os videos como vistos"
-    },
-    "medium": {
-        "message": "Média"
-    },
-    "mixer": {
-        "message": "Mistura"
-    },
-    "mostViewedChannels": {
-        "message": "Canais mais vistos"
-    },
-    "moveSidebarLeft": {
-        "message": "Mover barra lateral para esquerda"
-    },
-    "moveThumbnailsRight": {
-        "message": "Mover miniaturas para direita"
-    },
-    "My_specs": {
-        "message": "Minhas especificações"
-    },
-    "myColors": {
-        "message": "Minhas cores"
-    },
-    "name": {
-        "message": "Nome"
-    },
-    "nativeMiniPlayer": {
-        "message": "Leitor pequeno padrão"
-    },
-    "new": {
-        "message": "Novo"
-    },
-    "nextVideo": {
-        "message": "Próximo video"
-    },
-    "night": {
-        "message": "Noite"
-    },
-    "nightMode": {
-        "message": "Modo noturno"
-    },
-    "noActiveFeatures": {
-        "message": "Sem opções ativas"
-    },
-    "none": {
-        "message": "Nenhuma"
-    },
-    "noOpenVideoTabs": {
-        "message": "Não abrir janelas de video"
-    },
-    "Not_optimal": {
-        "message": "Sem otimização"
-    },
-    "old": {
-        "message": "Velho"
-    },
-    "onAllVideos": {
-        "message": "Em todos os videos"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Ativo apenas no YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Apenas uma instância do leitor de video"
-    },
-    "onSubscribedChannels": {
-        "message": "Nos canais subscritos"
-    },
-    "openNewTab": {
-        "message": "Abrir em uma nova aba"
-    },
-    "openPopupPlayer": {
-        "message": "Abra vídeos/playlist em uma nova janela"
-    },
-    "optimizeCodecForHardwareAcceleration": {
-        "message": "Otimizar o Codec para aceleração de hardware"
-    },
-    "orange": {
-        "message": "Laranja"
-    },
-    "os": {
-        "message": "SO"
-    },
-    "other": {
-        "message": "Outro"
-    },
-    "outline": {
-        "message": "Contorno"
-    },
-    "overlay": {
-        "message": "Sobreposição"
-    },
-    "permissions": {
-        "message": "Permissões"
-    },
-    "pictureInPicture": {
-        "message": "Janela em janela"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Simples"
-    },
-    "platform": {
-        "message": "Plataforma"
-    },
-    "playAllButton": {
-        "message": "Botão \"Reproduzir Tudo\""
-    },
-    "playbackSpeed": {
-        "message": "Velocidade de leitura"
-    },
-    "player": {
-        "message": "Leitor"
-    },
-    "player_fit_to_win_button": {
-        "message": "Botão Ajustar à janela"
-    },
-    "player_rotate_button": {
-        "message": "botão de rotação do jogador"
-    },
-    "playerColor": {
-        "message": "Côr do leitor"
-    },
-    "playerSize": {
-        "message": "Tamanho do leitor"
-    },
-    "playlist": {
-        "message": "Lista de reprodução"
-    },
-    "playlists": {
-        "message": "Listas de reprodução"
-    },
-    "playPause": {
-        "message": "Reproduzir / Pausar"
-    },
-    "popupPlayer": {
-        "message": "Leitor em janela"
-    },
-    "popupWindowButtons": {
-        "message": "Adicione um botão Popup-player para cada miniatura"
-    },
-    "position": {
-        "message": "Posição"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Carrega em qualquer tecla ou usa a roldana do rato"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Carrega em qualquer tecla ou usa a roldana do rato"
-    },
-    "previousVideo": {
-        "message": "Video anterior"
-    },
-    "primaryColor": {
-        "message": "Côr primaria"
-    },
-    "purple": {
-        "message": "Violeta"
-    },
-    "quality": {
-        "message": "Qualidade"
-    },
-    "raised": {
-        "message": "Levantado"
-    },
-    "ram": {
-        "message": "Memoria"
-    },
-    "rateMe": {
-        "message": "Avalie-me"
-    },
-    "rateUs": {
-        "message": "Avalia-nos"
-    },
-    "red": {
-        "message": "Vermelho"
-    },
-    "relatedVideos": {
-        "message": "Videos relacionados"
-    },
-    "remote": {
-        "message": "Assistir na TV"
-    },
-    "removeHomePageShorts": {
-        "message": "Remover Shorts da página inicial"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Remove resultados relacionado com a pesquisa"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Remover o carrossel de Shorts dos resultados de pesquisa"
-    },
-    "repeat": {
-        "message": "Repetir"
-    },
-    "report": {
-        "message": "Reportar"
-    },
-    "reset": {
-        "message": "Valores de origem"
-    },
-    "resetAllSettings": {
-        "message": "Valores de origem em todas as definições"
-    },
-    "resetAllShortcuts": {
-        "message": "Repôr todos os atalhos"
-    },
-    "reverse": {
-        "message": "Recuar"
-    },
-    "rotate": {
-        "message": "Rodar"
-    },
-    "save": {
-        "message": "Gravar"
-    },
-    "saveAs": {
-        "message": "Gravar como"
-    },
-    "schedule": {
-        "message": "Agendar"
-    },
-    "screen": {
-        "message": "Ecrân"
-    },
-    "screenshot": {
-        "message": "Foto do ecrân"
-    },
-    "scrollBar": {
-        "message": "Barra De rolagem"
-    },
-    "search": {
-        "message": "Pesquisa"
-    },
-    "searchBarOnly": {
-        "message": "Apenas barra de pesquisa"
-    },
-    "seekBackward10Seconds": {
-        "message": "Andar para trás 10 segundos"
-    },
-    "seekForward10Seconds": {
-        "message": "Andar para frente 10 segundos"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Definições"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Definições importadas com sucesso"
-    },
-    "share": {
-        "message": "Compartilhar"
-    },
-    "shortcut_chapters": {
-        "message": "Mostrar barra lateral de capítulos"
-    },
-    "shortcut_screenshot": {
-        "message": "Foto do ecrân"
-    },
-    "shortcuts": {
-        "message": "Atalhos"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Mostrar cartas ao passar o rato por cima"
-    },
-    "showChannelVideosCount": {
-        "message": "Mostrar contagem de videos do canal"
-    },
-    "showLess": {
-        "message": "Mostre menos"
-    },
-    "showMore": {
-        "message": "Mostre mais"
-    },
-    "showRemainingDuration": {
-        "message": "Mostrar duração restante do vídeo"
-    },
-    "showVersion": {
-        "message": "Mostrar versão"
-    },
-    "shuffle": {
-        "message": "Misturar"
-    },
-    "sidebar": {
-        "message": "Barra lateral"
-    },
-    "Sidebar_simple_alternative": {
-        "message": "Barra lateral (alternativa simples)"
-    },
-    "softwareInformation": {
-        "message": "Informação do Software"
-    },
-    "spacebar": {
-        "message": "Barra de espaços"
-    },
-    "squaredUserImages": {
-        "message": "Imagens de utilizador enquadradas"
-    },
-    "static": {
-        "message": "Estática"
-    },
-    "statsForNerds": {
-        "message": "Mostrar Estatísticas para Nerds"
-    },
-    "step": {
-        "message": "Passo"
-    },
-    "stop": {
-        "message": "Parar"
-    },
-    "style": {
-        "message": "Estilo"
-    },
-    "styles": {
-        "message": "Estilos"
-    },
-    "subscribe": {
-        "message": "Inscreva-Se"
-    },
-    "subscriptions": {
-        "message": "Subscrições"
-    },
-    "Subtitle_Capture_including_the_current_words": {
-        "message": "Legenda (Captura incluindo as palavras atuais)"
-    },
-    "subtitles": {
-        "message": "Legendas"
-    },
-    "sunset": {
-        "message": "Pôr do sol"
-    },
-    "sunsetToSunrise": {
-        "message": "Pôr do sol até de manhã"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferências do sistema: Escuro"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferências do sistema: Claro"
-    },
-    "teal": {
-        "message": "Azul esverdeado"
-    },
-    "textColor": {
-        "message": "Côr do texto"
-    },
-    "themes": {
-        "message": "Temas"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Isto vai remover todos os cookies."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Isto irá remover todos os vídeos assistidos."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Isto vai remover todos os cookies do YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Isto vai reiniciar todas as definições."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Isto vai reiniciar todos os atalhos"
-    },
-    "thumbnails": {
-        "message": "Miniaturas"
-    },
-    "thumbnailsQuality": {
-        "message": "Qualidade das Miniaturas"
-    },
-    "timeFrom": {
-        "message": "Tempo de"
-    },
-    "timeTo": {
-        "message": "Tempo para"
-    },
-    "To_the_side_No_page_margin": {
-        "message": "Ao lado! (Sem margem de página)"
-    },
-    "todayAt": {
-        "message": "Hoje em"
-    },
-    "toggleAutoplay": {
-        "message": "Alternar reprodução automática"
-    },
-    "toggleCards": {
-        "message": "Alternar cards"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "Conversa principal"
-    },
-    "trackWatchedVideos": {
-        "message": "Rastrear vídeos assistidos"
-    },
-    "trailerAutoplay": {
-        "message": "Trailer toca automaticamente"
-    },
-    "Transcript": {
-        "message": "Transcrição"
-    },
-    "translations": {
-        "message": "Traduções"
-    },
-    "transparentBackground": {
-        "message": "Fundo transparente"
-    },
-    "transparentColor": {
-        "message": "Transparente"
-    },
-    "trending": {
-        "message": "Tendências"
-    },
-    "tryToReloadThePage": {
-        "message": "Tenta carregar a pagina de novo"
-    },
-    "type": {
-        "message": "Escreve"
-    },
-    "upNextAutoplay": {
-        "message": "Arquivo seguinte a tocar"
-    },
-    "use24HourFormat": {
-        "message": "Usar formato de 24-horas"
-    },
-    "version": {
-        "message": "Versão"
-    },
-    "video": {
-        "message": "Vídeo"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "A descrição do video vai ser expandida para ver o nome da categoria"
-    },
-    "videoFormats": {
-        "message": "Formatos de video"
-    },
-    "videos": {
-        "message": "Vídeos"
-    },
-    "viewMode": {
-        "message": "Modo de visualização"
-    },
-    "watchedVideos": {
-        "message": "Vídeos visualizados"
-    },
-    "watchLater": {
-        "message": "Vêr mais tarde"
-    },
-    "watchTime": {
-        "message": "Tempo de visualização"
-    },
-    "whenPaused": {
-        "message": "Quando pausado"
-    },
-    "whenTabIsChanged": {
-        "message": "Quando a janela mudar"
-    },
-    "white": {
-        "message": "Branco"
-    },
-    "windowColor": {
-        "message": "Cor da janela"
-    },
-    "windowOpacity": {
-        "message": "Opacidade da janela"
-    },
-    "with_scrollbars": {
-        "message": "Com barras de rolagem?"
-    },
-    "yellow": {
-        "message": "Amarelo"
-    },
-    "youTubeButtons": {
-        "message": "Botões do YouTube"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Cabeçalho do YouTube (esquerda)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Cabeçalho do YouTube (direita)"
-    },
-    "youtubeHomePage": {
-        "message": "Página principal do YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Linguagem do YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "O YouTube limita a qualidade do video em 1080p para o codec h.264"
-    }
+	"about": {
+		"message": "Acerca"
+	},
+	"accept": {
+		"message": "Aceitar"
+	},
+	"activate": {
+		"message": "Ativar"
+	},
+	"activateCaptions": {
+		"message": "Ativar legendas"
+	},
+	"activated": {
+		"message": "Ativado"
+	},
+	"activatedFeatures": {
+		"message": "Opções ativadas"
+	},
+	"activateFullscreen": {
+		"message": "Ativar ecrã completo"
+	},
+	"activeFeatures": {
+		"message": "Opções ativas"
+	},
+	"addScrollToTop": {
+		"message": "Adicionar «Ir para o topo»"
+	},
+	"ads": {
+		"message": "Anúncios"
+	},
+	"all": {
+		"message": "Todas"
+	},
+	"allow": {
+		"message": "Permitir"
+	},
+	"Allow_auto_generate": {
+		"message": "Permitir geração automática"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todas as suas definições serão eliminadas e não poderão ser recuperadas"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Todos os seus atalhos serão eliminados e não poderão ser recuperados"
+	},
+	"always": {
+		"message": "Sempre"
+	},
+	"alwaysActive": {
+		"message": "Sempre ativo"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Mostrar sempre a barra de progressos"
+	},
+	"amber": {
+		"message": "Âmbar"
+	},
+	"analyzer": {
+		"message": "Analisador"
+	},
+	"animations": {
+		"message": "Animações"
+	},
+	"appearance": {
+		"message": "Aparência"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Tem certeza de que deseja exportar os dados?"
+	},
+	"audio": {
+		"message": "Áudio"
+	},
+	"audioFormats": {
+		"message": "Formatos de áudio"
+	},
+	"auto": {
+		"message": "Automático"
+	},
+	"Auto_PiP_picture_in_picture": {
+		"message": "Auto-PiP (Picture in picture)"
+	},
+	"autoFullscreen": {
+		"message": "Ecrân completo automático"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausa quando muda de abas"
+	},
+	"autoplay": {
+		"message": "Reprodução automática"
+	},
+	"avoidAv1": {
+		"message": "Evitar AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Evitar AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Evitar AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Evite renderização da CPU quando possível"
+	},
+	"backgroundColor": {
+		"message": "Cor de fundo"
+	},
+	"backgroundOpacity": {
+		"message": "Opacidade do fundo"
+	},
+	"backupAndReset": {
+		"message": "Cópia de segurança e repor"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Baseado no esquema de cores do sistema"
+	},
+	"belowPlayer": {
+		"message": "Reprodutor abaixo"
+	},
+	"bitness": {
+		"message": "Processor Bits"
+	},
+	"black": {
+		"message": "Preto"
+	},
+	"blockAll": {
+		"message": "Bloquear todos"
+	},
+	"blockAv1": {
+		"message": "Bloquear AV1"
+	},
+	"blockH264": {
+		"message": "Bloquear H.264"
+	},
+	"blocklist": {
+		"message": "Lista negra"
+	},
+	"blockMusic": {
+		"message": "Bloquear música"
+	},
+	"blockVp8": {
+		"message": "Bloquear VP8"
+	},
+	"blockVp9": {
+		"message": "Bloquear VP9"
+	},
+	"blue": {
+		"message": "Azul"
+	},
+	"blueGray": {
+		"message": "Azul acizentado"
+	},
+	"bluelight": {
+		"message": "Azul claro"
+	},
+	"brightness": {
+		"message": "Luminosidade"
+	},
+	"brown": {
+		"message": "Castanho"
+	},
+	"browser": {
+		"message": "Navegador"
+	},
+	"browserVersion": {
+		"message": "Versão do navegador"
+	},
+	"bubbles": {
+		"message": "Bolhas"
+	},
+	"bug": {
+		"message": "Erro"
+	},
+	"buttons": {
+		"message": "Botões"
+	},
+	"cancel": {
+		"message": "Cancelar"
+	},
+	"categories": {
+		"message": "Categorias"
+	},
+	"channel": {
+		"message": "Canal"
+	},
+	"channels": {
+		"message": "Canais"
+	},
+	"chapters": {
+		"message": "Capítulos"
+	},
+	"characterEdgeStyle": {
+		"message": "Estilo da borda de personagem"
+	},
+	"clipboard": {
+		"message": "Area de transferência"
+	},
+	"collapsed": {
+		"message": "Extender"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Extender as secções escolhidas"
+	},
+	"comments": {
+		"message": "Comentários"
+	},
+	"compact_spacing": {
+		"message": "Tema compacto"
+	},
+	"compactTheme": {
+		"message": "Tema compacto"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Confirmar antes de encerrar"
+	},
+	"cores": {
+		"message": "Núcleos"
+	},
+	"cropChapterTitles": {
+		"message": "Recortar títulos do capítulos"
+	},
+	"Currently_requiring_a_YouTube_API_key": {
+		"message": "(Necessário uma chave do YouTube-API: )"
+	},
+	"custom": {
+		"message": "Personalizar"
+	},
+	"customCss": {
+		"message": "CSS personalizadas"
+	},
+	"customJs": {
+		"message": "JS personalizadas"
+	},
+	"customMiniPlayer": {
+		"message": "Personalizar Mini-Player"
+	},
+	"cyan": {
+		"message": "Esverdeado"
+	},
+	"dark": {
+		"message": "Escuro"
+	},
+	"darkTheme": {
+		"message": "Tema escuro"
+	},
+	"dateAndTime": {
+		"message": "Data & hora"
+	},
+	"dawn": {
+		"message": "Escurecer"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Diminuir velocidade de leitura"
+	},
+	"decreaseVolume": {
+		"message": "Diminuir volume"
+	},
+	"deepOrange": {
+		"message": "Laranja forte"
+	},
+	"deepPurple": {
+		"message": "Lilás forte"
+	},
+	"default": {
+		"message": "Padrão"
+	},
+	"default_CC": {
+		"message": "Padrão"
+	},
+	"defaultChannelTab": {
+		"message": "Aba padrão do canal"
+	},
+	"defaultContentCountry": {
+		"message": "País (viagem virtual)"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Velocidade padrão de reprodução"
+	},
+	"deleteWatchedVideos": {
+		"message": "Excluir vídeos assistidos"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Eliminar os cookies do YouTube"
+	},
+	"depressed": {
+		"message": "Comprimido"
+	},
+	"description": {
+		"message": "Descrição"
+	},
+	"description_ext": {
+		"message": "Torne o YouTube organizado e inteligente! Pule Anúncio, colorir YouTube, volume, velocidade, canal, ferramenta, estilo, HD, adblock, adblocker, tags, playlist ,palavras-chave"
+	},
+	"desert": {
+		"message": "Deserto"
+	},
+	"details": {
+		"message": "Detalhes"
+	},
+	"developerOptions": {
+		"message": "Opções de programador"
+	},
+	"device": {
+		"message": "Aparelho"
+	},
+	"dim": {
+		"message": "Escurecer"
+	},
+	"disabled": {
+		"message": "Desabilitado"
+	},
+	"dislike": {
+		"message": "Não gostar"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Mostrar dia da Semana"
+	},
+	"donate": {
+		"message": "Doar"
+	},
+	"doNotChange": {
+		"message": "Não mudes"
+	},
+	"draggable": {
+		"message": "Podes arrastar"
+	},
+	"dropShadow": {
+		"message": "Sombra projetada"
+	},
+	"durationWithSpeed": {
+		"message": "Mostrar tempo restante com referência a velocidade de reprodução"
+	},
+	"email": {
+		"message": "Correio electronico"
+	},
+	"embedded_Hide_Share": {
+		"message": "Ocultar compartilhamento do video incorporado"
+	},
+	"Embedded_YouTube": {
+		"message": "Videos Incorporados do YouTube"
+	},
+	"empty": {
+		"message": "Vazio"
+	},
+	"enabled": {
+		"message": "Ativado"
+	},
+	"enabledForced": {
+		"message": "Ativado (forçado)"
+	},
+	"expanded": {
+		"message": "Expandir"
+	},
+	"exportSettings": {
+		"message": "Exportar definições"
+	},
+	"extension": {
+		"message": "Extenção"
+	},
+	"Feature_not_yet_available": {
+		"message": "Recurso não está presente no momento"
+	},
+	"file": {
+		"message": "Ficheiro"
+	},
+	"filters": {
+		"message": "Filtros"
+	},
+	"fitToWindow": {
+		"message": "Ajustar á janela"
+	},
+	"flash": {
+		"message": "Instantâneo"
+	},
+	"font": {
+		"message": "Tipo de letra"
+	},
+	"fontColor": {
+		"message": "Cor da fonte"
+	},
+	"fontFamily": {
+		"message": "Família da fonte"
+	},
+	"fontOpacity": {
+		"message": "Opacidade da fonte"
+	},
+	"fontSize": {
+		"message": "Tamanho da fonte"
+	},
+	"footer": {
+		"message": "Cabeçalho"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Forçar velocidade de leitura"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(Forçar velocidade de reprodução mesmo para música?)"
+	},
+	"forcedTheaterMode": {
+		"message": "Forçar modo de cinema"
+	},
+	"forcedVolume": {
+		"message": "Volume forçado"
+	},
+	"forceSDR": {
+		"message": "Forçar SDR"
+	},
+	"foundABug": {
+		"message": "Encontrou um erro?"
+	},
+	"fullWindow": {
+		"message": "Janela completa"
+	},
+	"general": {
+		"message": "Geral"
+	},
+	"geoPreference": {
+		"message": "Preferência Geográfica"
+	},
+	"googleApiKey": {
+		"message": "Chave da API do Google"
+	},
+	"goToSearchBox": {
+		"message": "Vai à caixa de pesquisa"
+	},
+	"GPUnotindatabase": {
+		"message": "Não tenho sua GPU nos meus Dados :¬("
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"Hamburger_Menu": {
+		"message": "Menu Hamburger"
+	},
+	"hardwareInformation": {
+		"message": "Informações do hardware"
+	},
+	"hdThumbnail": {
+		"message": "Miniatura HD"
+	},
+	"header": {
+		"message": "Cabeçalho"
+	},
+	"hidden": {
+		"message": "Escondido"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Escondido na página do video"
+	},
+	"hide_author_avatars": {
+		"message": "Ocultar avatar de autor"
+	},
+	"Hide_Pause_Overlay": {
+		"message": "Ocultar Sobreposição de pausa"
+	},
+	"Hide_Shorts_remixing_this_video": {
+		"message": "Ocultar Shorts remixando alguns videos"
+	},
+	"Hide_the_tabs_only": {
+		"message": "Ocultar somente as abas"
+	},
+	"Hide_YouTube_Logo": {
+		"message": "Ocultar Logo do YouTube"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Esconder miniaturas animadas"
+	},
+	"hideAnnotations": {
+		"message": "Esconder anotações"
+	},
+	"hideCards": {
+		"message": "Esconder cartas"
+	},
+	"hideCategories": {
+		"message": "Ocultar categorias"
+	},
+	"hideCommentsCount": {
+		"message": "Ocultar contagens de Comentários"
+	},
+	"hideCountryCode": {
+		"message": "Ocultar código do país"
+	},
+	"hideDate": {
+		"message": "Ocultar data"
+	},
+	"hideDetails": {
+		"message": "Esconder detalhes"
+	},
+	"hideEndscreen": {
+		"message": "Esconder ecãn final"
+	},
+	"hideFeaturedContent": {
+		"message": "Esconder conteúdo"
+	},
+	"hideFooter": {
+		"message": "Esconder rodapé"
+	},
+	"hideGradientBottom": {
+		"message": "Hide Gradient Bottom"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ocultar a barra de controles do player"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ocultar opções de controles do player"
+	},
+	"hidePlaylist": {
+		"message": "Esconder lista de reprodução"
+	},
+	"hideRightButtons": {
+		"message": "Esconder botões do lado direito"
+	},
+	"hideScrollForDetails": {
+		"message": "Esconder «Rodar para detalhes»"
+	},
+	"hideThumbnails": {
+		"message": "Ocultar miniaturas"
+	},
+	"hideVideoTitleFullScreen": {
+		"message": "Ocultar o título do vídeo em tela cheia"
+	},
+	"hideViewsCount": {
+		"message": "Esconder número de vistos"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ocultar botão pesquisa de voz"
+	},
+	"high": {
+		"message": "Alta"
+	},
+	"history": {
+		"message": "História"
+	},
+	"home": {
+		"message": "Casa"
+	},
+	"homeScreen": {
+		"message": "Ecrã inicial"
+	},
+	"hover": {
+		"message": "Aponta"
+	},
+	"hoverOnVideoPage": {
+		"message": "Apontar na página do video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "À quanto tempo o video foi enviado"
+	},
+	"icons": {
+		"message": "Ícones"
+	},
+	"iconsOnly": {
+		"message": "Ícones apenas"
+	},
+	"importSettings": {
+		"message": "Importar definições"
+	},
+	"improvedtubeButtons": {
+		"message": "Botões do ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ícon do ImprovedTube no YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Linguagem do ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Versão do ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Melhorar logotipo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Aumentar velocidade de leitura"
+	},
+	"increaseVolume": {
+		"message": "Aumentar o volume"
+	},
+	"items": {
+		"message": "Artigos"
+	},
+	"language": {
+		"message": "Idioma"
+	},
+	"language_closed_caption": {
+		"message": "Padrão de Idioma - Legendas de videos"
+	},
+	"languages": {
+		"message": "Linguagens"
+	},
+	"layerAnimationScale": {
+		"message": "Escala de animação"
+	},
+	"legacyYoutube": {
+		"message": "YouTube antigo"
+	},
+	"library": {
+		"message": "Biblioteca"
+	},
+	"light": {
+		"message": "Claro"
+	},
+	"lightBlue": {
+		"message": "Azul claro"
+	},
+	"lightGreen": {
+		"message": "Verde claro"
+	},
+	"like": {
+		"message": "Gostar"
+	},
+	"liked": {
+		"message": "Avaliado"
+	},
+	"lime": {
+		"message": "Limão"
+	},
+	"limitPageWidth": {
+		"message": "Limite de largura da página"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Conversa do vivo"
+	},
+	"liveChatType": {
+		"message": "Tipo de conversa do vivo"
+	},
+	"location": {
+		"message": "Localização"
+	},
+	"loudnessNormalization": {
+		"message": "Normalização do volume"
+	},
+	"low": {
+		"message": "Baixa"
+	},
+	"markWatchedVideos": {
+		"message": "Marcar os videos como vistos"
+	},
+	"medium": {
+		"message": "Média"
+	},
+	"mixer": {
+		"message": "Mistura"
+	},
+	"mostViewedChannels": {
+		"message": "Canais mais vistos"
+	},
+	"moveSidebarLeft": {
+		"message": "Mover barra lateral para esquerda"
+	},
+	"moveThumbnailsRight": {
+		"message": "Mover miniaturas para direita"
+	},
+	"My_specs": {
+		"message": "Minhas especificações"
+	},
+	"myColors": {
+		"message": "Minhas cores"
+	},
+	"name": {
+		"message": "Nome"
+	},
+	"nativeMiniPlayer": {
+		"message": "Leitor pequeno padrão"
+	},
+	"new": {
+		"message": "Novo"
+	},
+	"nextVideo": {
+		"message": "Próximo video"
+	},
+	"night": {
+		"message": "Noite"
+	},
+	"nightMode": {
+		"message": "Modo noturno"
+	},
+	"noActiveFeatures": {
+		"message": "Sem opções ativas"
+	},
+	"none": {
+		"message": "Nenhuma"
+	},
+	"noOpenVideoTabs": {
+		"message": "Não abrir janelas de video"
+	},
+	"Not_optimal": {
+		"message": "Sem otimização"
+	},
+	"old": {
+		"message": "Velho"
+	},
+	"onAllVideos": {
+		"message": "Em todos os videos"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Ativo apenas no YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Apenas uma instância do leitor de video"
+	},
+	"onSubscribedChannels": {
+		"message": "Nos canais subscritos"
+	},
+	"openNewTab": {
+		"message": "Abrir em uma nova aba"
+	},
+	"openPopupPlayer": {
+		"message": "Abra vídeos/playlist em uma nova janela"
+	},
+	"optimizeCodecForHardwareAcceleration": {
+		"message": "Otimizar o Codec para aceleração de hardware"
+	},
+	"orange": {
+		"message": "Laranja"
+	},
+	"os": {
+		"message": "SO"
+	},
+	"other": {
+		"message": "Outro"
+	},
+	"outline": {
+		"message": "Contorno"
+	},
+	"overlay": {
+		"message": "Sobreposição"
+	},
+	"permissions": {
+		"message": "Permissões"
+	},
+	"pictureInPicture": {
+		"message": "Janela em janela"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Simples"
+	},
+	"platform": {
+		"message": "Plataforma"
+	},
+	"playAllButton": {
+		"message": "Botão \"Reproduzir Tudo\""
+	},
+	"playbackSpeed": {
+		"message": "Velocidade de leitura"
+	},
+	"player": {
+		"message": "Leitor"
+	},
+	"player_fit_to_win_button": {
+		"message": "Botão Ajustar à janela"
+	},
+	"player_rotate_button": {
+		"message": "botão de rotação do jogador"
+	},
+	"playerColor": {
+		"message": "Côr do leitor"
+	},
+	"playerSize": {
+		"message": "Tamanho do leitor"
+	},
+	"playlist": {
+		"message": "Lista de reprodução"
+	},
+	"playlists": {
+		"message": "Listas de reprodução"
+	},
+	"playPause": {
+		"message": "Reproduzir / Pausar"
+	},
+	"popupPlayer": {
+		"message": "Leitor em janela"
+	},
+	"popupWindowButtons": {
+		"message": "Adicione um botão Popup-player para cada miniatura"
+	},
+	"position": {
+		"message": "Posição"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Carrega em qualquer tecla ou usa a roldana do rato"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Carrega em qualquer tecla ou usa a roldana do rato"
+	},
+	"previousVideo": {
+		"message": "Video anterior"
+	},
+	"primaryColor": {
+		"message": "Côr primaria"
+	},
+	"purple": {
+		"message": "Violeta"
+	},
+	"quality": {
+		"message": "Qualidade"
+	},
+	"raised": {
+		"message": "Levantado"
+	},
+	"ram": {
+		"message": "Memoria"
+	},
+	"rateMe": {
+		"message": "Avalie-me"
+	},
+	"rateUs": {
+		"message": "Avalia-nos"
+	},
+	"red": {
+		"message": "Vermelho"
+	},
+	"relatedVideos": {
+		"message": "Videos relacionados"
+	},
+	"remote": {
+		"message": "Assistir na TV"
+	},
+	"removeHomePageShorts": {
+		"message": "Remover Shorts da página inicial"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Remove resultados relacionado com a pesquisa"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Remover o carrossel de Shorts dos resultados de pesquisa"
+	},
+	"repeat": {
+		"message": "Repetir"
+	},
+	"report": {
+		"message": "Reportar"
+	},
+	"reset": {
+		"message": "Valores de origem"
+	},
+	"resetAllSettings": {
+		"message": "Valores de origem em todas as definições"
+	},
+	"resetAllShortcuts": {
+		"message": "Repôr todos os atalhos"
+	},
+	"reverse": {
+		"message": "Recuar"
+	},
+	"rotate": {
+		"message": "Rodar"
+	},
+	"save": {
+		"message": "Gravar"
+	},
+	"saveAs": {
+		"message": "Gravar como"
+	},
+	"schedule": {
+		"message": "Agendar"
+	},
+	"screen": {
+		"message": "Ecrân"
+	},
+	"screenshot": {
+		"message": "Foto do ecrân"
+	},
+	"scrollBar": {
+		"message": "Barra De rolagem"
+	},
+	"search": {
+		"message": "Pesquisa"
+	},
+	"searchBarOnly": {
+		"message": "Apenas barra de pesquisa"
+	},
+	"seekBackward10Seconds": {
+		"message": "Andar para trás 10 segundos"
+	},
+	"seekForward10Seconds": {
+		"message": "Andar para frente 10 segundos"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Definições"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Definições importadas com sucesso"
+	},
+	"share": {
+		"message": "Compartilhar"
+	},
+	"shortcut_chapters": {
+		"message": "Mostrar barra lateral de capítulos"
+	},
+	"shortcut_screenshot": {
+		"message": "Foto do ecrân"
+	},
+	"shortcuts": {
+		"message": "Atalhos"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Mostrar cartas ao passar o rato por cima"
+	},
+	"showChannelVideosCount": {
+		"message": "Mostrar contagem de videos do canal"
+	},
+	"showLess": {
+		"message": "Mostre menos"
+	},
+	"showMore": {
+		"message": "Mostre mais"
+	},
+	"showRemainingDuration": {
+		"message": "Mostrar duração restante do vídeo"
+	},
+	"showVersion": {
+		"message": "Mostrar versão"
+	},
+	"shuffle": {
+		"message": "Misturar"
+	},
+	"sidebar": {
+		"message": "Barra lateral"
+	},
+	"Sidebar_simple_alternative": {
+		"message": "Barra lateral (alternativa simples)"
+	},
+	"softwareInformation": {
+		"message": "Informação do Software"
+	},
+	"spacebar": {
+		"message": "Barra de espaços"
+	},
+	"squaredUserImages": {
+		"message": "Imagens de utilizador enquadradas"
+	},
+	"static": {
+		"message": "Estática"
+	},
+	"statsForNerds": {
+		"message": "Mostrar Estatísticas para Nerds"
+	},
+	"step": {
+		"message": "Passo"
+	},
+	"stop": {
+		"message": "Parar"
+	},
+	"style": {
+		"message": "Estilo"
+	},
+	"styles": {
+		"message": "Estilos"
+	},
+	"subscribe": {
+		"message": "Inscreva-Se"
+	},
+	"subscriptions": {
+		"message": "Subscrições"
+	},
+	"Subtitle_Capture_including_the_current_words": {
+		"message": "Legenda (Captura incluindo as palavras atuais)"
+	},
+	"subtitles": {
+		"message": "Legendas"
+	},
+	"sunset": {
+		"message": "Pôr do sol"
+	},
+	"sunsetToSunrise": {
+		"message": "Pôr do sol até de manhã"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferências do sistema: Escuro"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferências do sistema: Claro"
+	},
+	"teal": {
+		"message": "Azul esverdeado"
+	},
+	"textColor": {
+		"message": "Côr do texto"
+	},
+	"themes": {
+		"message": "Temas"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Isto vai remover todos os cookies."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Isto irá remover todos os vídeos assistidos."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Isto vai remover todos os cookies do YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Isto vai reiniciar todas as definições."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Isto vai reiniciar todos os atalhos"
+	},
+	"thumbnails": {
+		"message": "Miniaturas"
+	},
+	"thumbnailsQuality": {
+		"message": "Qualidade das Miniaturas"
+	},
+	"timeFrom": {
+		"message": "Tempo de"
+	},
+	"timeTo": {
+		"message": "Tempo para"
+	},
+	"To_the_side_No_page_margin": {
+		"message": "Ao lado! (Sem margem de página)"
+	},
+	"todayAt": {
+		"message": "Hoje em"
+	},
+	"toggleAutoplay": {
+		"message": "Alternar reprodução automática"
+	},
+	"toggleCards": {
+		"message": "Alternar cards"
+	},
+	"topChat": {
+		"message": "Conversa principal"
+	},
+	"trackWatchedVideos": {
+		"message": "Rastrear vídeos assistidos"
+	},
+	"trailerAutoplay": {
+		"message": "Trailer toca automaticamente"
+	},
+	"Transcript": {
+		"message": "Transcrição"
+	},
+	"translations": {
+		"message": "Traduções"
+	},
+	"transparentBackground": {
+		"message": "Fundo transparente"
+	},
+	"transparentColor": {
+		"message": "Transparente"
+	},
+	"trending": {
+		"message": "Tendências"
+	},
+	"tryToReloadThePage": {
+		"message": "Tenta carregar a pagina de novo"
+	},
+	"type": {
+		"message": "Escreve"
+	},
+	"upNextAutoplay": {
+		"message": "Arquivo seguinte a tocar"
+	},
+	"use24HourFormat": {
+		"message": "Usar formato de 24-horas"
+	},
+	"version": {
+		"message": "Versão"
+	},
+	"video": {
+		"message": "Vídeo"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "A descrição do video vai ser expandida para ver o nome da categoria"
+	},
+	"videoFormats": {
+		"message": "Formatos de video"
+	},
+	"videos": {
+		"message": "Vídeos"
+	},
+	"viewMode": {
+		"message": "Modo de visualização"
+	},
+	"watchedVideos": {
+		"message": "Vídeos visualizados"
+	},
+	"watchLater": {
+		"message": "Vêr mais tarde"
+	},
+	"watchTime": {
+		"message": "Tempo de visualização"
+	},
+	"whenPaused": {
+		"message": "Quando pausado"
+	},
+	"whenTabIsChanged": {
+		"message": "Quando a janela mudar"
+	},
+	"white": {
+		"message": "Branco"
+	},
+	"windowColor": {
+		"message": "Cor da janela"
+	},
+	"windowOpacity": {
+		"message": "Opacidade da janela"
+	},
+	"with_scrollbars": {
+		"message": "Com barras de rolagem?"
+	},
+	"yellow": {
+		"message": "Amarelo"
+	},
+	"youTubeButtons": {
+		"message": "Botões do YouTube"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Cabeçalho do YouTube (esquerda)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Cabeçalho do YouTube (direita)"
+	},
+	"youtubeHomePage": {
+		"message": "Página principal do YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Linguagem do YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "O YouTube limita a qualidade do video em 1080p para o codec h.264"
+	}
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -1,755 +1,746 @@
 {
-    "about": {
-        "message": "Despre"
-    },
-    "accept": {
-        "message": "Acceptă"
-    },
-    "activate": {
-        "message": "Activează"
-    },
-    "activateCaptions": {
-        "message": "Activează subtitrările"
-    },
-    "activated": {
-        "message": "Activat"
-    },
-    "activatedFeatures": {
-        "message": "Caracteristici activate"
-    },
-    "activateFullscreen": {
-        "message": "Activează ecran complet"
-    },
-    "activeFeatures": {
-        "message": "Caracteristici active"
-    },
-    "addScrollToTop": {
-        "message": "Adaugă «Derulează la început»"
-    },
-    "ads": {
-        "message": "Reclame"
-    },
-    "all": {
-        "message": "Tot"
-    },
-    "allow": {
-        "message": "Permite"
-    },
-    "alwaysActive": {
-        "message": "Mereu activ"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Arată mereu bara de progres"
-    },
-    "amber": {
-        "message": "Chihlimbar"
-    },
-    "analyzer": {
-        "message": "Analizator"
-    },
-    "appearance": {
-        "message": "Aparențe"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Sigur doriți să exportați datele?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Sigur doriți să importați datele?"
-    },
-    "audioFormats": {
-        "message": "Formaturi audio"
-    },
-    "autoFullscreen": {
-        "message": "ecran complet automat"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pauzează automat la schimbarea tab-ului"
-    },
-    "autoplay": {
-        "message": "Pornește automat"
-    },
-    "backgroundColor": {
-        "message": "Culoare de fundal"
-    },
-    "backgroundOpacity": {
-        "message": "Opacitatea fundalului"
-    },
-    "backupAndReset": {
-        "message": "Salvează & resetează"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Bazat pe schema de culori a sistemului"
-    },
-    "black": {
-        "message": "Înapoi"
-    },
-    "blockAll": {
-        "message": "Blochează tot"
-    },
-    "blocklist": {
-        "message": "Lista neagră"
-    },
-    "blockMusic": {
-        "message": "Interzice muzica"
-    },
-    "blue": {
-        "message": "Albastru"
-    },
-    "blueGray": {
-        "message": "Gri albastru"
-    },
-    "bluelight": {
-        "message": "Lumină albastră"
-    },
-    "brown": {
-        "message": "Maro"
-    },
-    "browserVersion": {
-        "message": "Versiunea browserului"
-    },
-    "bubbles": {
-        "message": "Bule"
-    },
-    "buttons": {
-        "message": "Butoane"
-    },
-    "cancel": {
-        "message": "Anulează"
-    },
-    "categories": {
-        "message": "Categorii"
-    },
-    "channel": {
-        "message": "Canal"
-    },
-    "channels": {
-        "message": "Canale"
-    },
-    "collapsed": {
-        "message": "Închis"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Închide secțiunea de subscripții"
-    },
-    "comments": {
-        "message": "Comentarii"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Confirmă înainte să închizi"
-    },
-    "cores": {
-        "message": "Nuclee"
-    },
-    "cropChapterTitles": {
-        "message": "Taie titlurile capitolelor"
-    },
-    "custom": {
-        "message": "Personalizat"
-    },
-    "customCss": {
-        "message": "CSS Personalizat"
-    },
-    "customJs": {
-        "message": "JS Personalizat"
-    },
-    "customMiniPlayer": {
-        "message": "Mini-Player Personalizat"
-    },
-    "dark": {
-        "message": "Închis"
-    },
-    "darkTheme": {
-        "message": "Temă închisă"
-    },
-    "dateAndTime": {
-        "message": "Data & timpul"
-    },
-    "dawn": {
-        "message": "Răsărit"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Scade viteza playback-ului"
-    },
-    "decreaseVolume": {
-        "message": "Scade volumul"
-    },
-    "deepOrange": {
-        "message": "Portocaliu închis"
-    },
-    "deepPurple": {
-        "message": "Mov închis"
-    },
-    "defaultChannelTab": {
-        "message": "Tab-ul implicit al canalului"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Șterge cookie-urile YouTube"
-    },
-    "desert": {
-        "message": "Deșert"
-    },
-    "details": {
-        "message": "Detalii"
-    },
-    "developerOptions": {
-        "message": "Opțiunile dezvoltatorului"
-    },
-    "device": {
-        "message": "Dispozitiv"
-    },
-    "dim": {
-        "message": "Întunecă"
-    },
-    "disabled": {
-        "message": "Dezactivat"
-    },
-    "dislike": {
-        "message": "Nu îmi place"
-    },
-    "donate": {
-        "message": "Donează"
-    },
-    "doNotChange": {
-        "message": "Nu schimba"
-    },
-    "draggable": {
-        "message": "Poate fi tras"
-    },
-    "empty": {
-        "message": "Gol"
-    },
-    "enabled": {
-        "message": "Activat"
-    },
-    "enabledForced": {
-        "message": "Activat (forțat)"
-    },
-    "expanded": {
-        "message": "Deschis"
-    },
-    "exportSettings": {
-        "message": "Exportă setările"
-    },
-    "extension": {
-        "message": "Extensie"
-    },
-    "file": {
-        "message": "Fișier"
-    },
-    "filters": {
-        "message": "Filtre"
-    },
-    "fitToWindow": {
-        "message": "Potrivește în fereastră"
-    },
-    "footer": {
-        "message": "Subsol"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Viteză de playback forțată"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Forced play video from the beginning"
-    },
-    "forcedTheaterMode": {
-        "message": "Modul teatru forțat"
-    },
-    "forcedVolume": {
-        "message": "Volum forțat"
-    },
-    "forceSDR": {
-        "message": "Forțează SDR"
-    },
-    "foundABug": {
-        "message": "Ai găsit un bug?"
-    },
-    "fullWindow": {
-        "message": "Ecran complet"
-    },
-    "geoPreference": {
-        "message": "Preferințe Geo"
-    },
-    "goToSearchBox": {
-        "message": "Du-te la casuța de căutare"
-    },
-    "green": {
-        "message": "Verde"
-    },
-    "hdThumbnail": {
-        "message": "Miniatură HD"
-    },
-    "header": {
-        "message": "Antet"
-    },
-    "hidden": {
-        "message": "Ascuns"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Ascuns pe pagina video"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Ascunde miniaturile animate"
-    },
-    "hideAnnotations": {
-        "message": "Ascunde adnotările"
-    },
-    "hideCards": {
-        "message": "Ascunde cardurile"
-    },
-    "hideDetails": {
-        "message": "Ascunde detaliile"
-    },
-    "hideEndscreen": {
-        "message": "Ascunde ecranul de final"
-    },
-    "hideFeaturedContent": {
-        "message": "Ascunde conținutul prezentat"
-    },
-    "hideFooter": {
-        "message": "Ascunde subsolul"
-    },
-    "hideGradientBottom": {
-        "message": "Ascunde Gradient Bottom"
-    },
-    "hideHomePageShorts": {
-        "message": "Eliminați Shorts de pe pagina de start"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ascundeți bara de control al jucătorului"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ascunde butoanele din bara de control al jucătorului"
-    },
-    "hidePlaylist": {
-        "message": "Ascunde playlistul"
-    },
-    "hideRightButtons": {
-        "message": "Ascunde butoanele din dreapta"
-    },
-    "hideScrollForDetails": {
-        "message": "Ascunde «Derulează pentru detalii»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "Ascunde numărul vizualizărilor"
-    },
-    "history": {
-        "message": "Istoric"
-    },
-    "home": {
-        "message": "Acasă"
-    },
-    "hoverOnVideoPage": {
-        "message": "Hover pe pagina video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Acum cât timp a fost încărcat videoclipul"
-    },
-    "icons": {
-        "message": "Iconițe"
-    },
-    "iconsOnly": {
-        "message": "Doar iconițe"
-    },
-    "importSettings": {
-        "message": "Importă setările"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Iconița ImprovedTube pe YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Limba ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Versiunea ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Îmbunătățește sigla"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Crește viteza de playback"
-    },
-    "increaseVolume": {
-        "message": "Crește volumul"
-    },
-    "items": {
-        "message": "Obiecte"
-    },
-    "languages": {
-        "message": "Limbi"
-    },
-    "legacyYoutube": {
-        "message": "YouTube vechi"
-    },
-    "light": {
-        "message": "Deschis"
-    },
-    "lightBlue": {
-        "message": "Albastru deschis"
-    },
-    "lightGreen": {
-        "message": "Verde deschis"
-    },
-    "like": {
-        "message": "Îmi place"
-    },
-    "list": {
-        "message": "Listă"
-    },
-    "liveChat": {
-        "message": "Chat live"
-    },
-    "liveChatType": {
-        "message": "Chat live scrie"
-    },
-    "loudnessNormalization": {
-        "message": "Normalizează zgomotul"
-    },
-    "markWatchedVideos": {
-        "message": "Marchează videoclipurile văzute"
-    },
-    "myColors": {
-        "message": "Culorile mele"
-    },
-    "name": {
-        "message": "Nume"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mini-Player nativ"
-    },
-    "new": {
-        "message": "Nou"
-    },
-    "nextVideo": {
-        "message": "Următorul video"
-    },
-    "night": {
-        "message": "Noapte"
-    },
-    "noActiveFeatures": {
-        "message": "Nici o caracteristică activată"
-    },
-    "none": {
-        "message": "Nimic"
-    },
-    "noOpenVideoTabs": {
-        "message": "Niciun tab video deschis"
-    },
-    "old": {
-        "message": "Vechi"
-    },
-    "onAllVideos": {
-        "message": "Pe toate videoclipurile"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Activ doar pe YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Doar o instanță de player care merge"
-    },
-    "onSubscribedChannels": {
-        "message": "Pe canalele abonate"
-    },
-    "openPopupPlayer": {
-        "message": "Deschide videoclipul/playlistul într-o fereastră nouă"
-    },
-    "orange": {
-        "message": "Portocaliu"
-    },
-    "os": {
-        "message": "SO"
-    },
-    "other": {
-        "message": "Altele"
-    },
-    "permissions": {
-        "message": "Permisiuni"
-    },
-    "pink": {
-        "message": "Roz"
-    },
-    "plain": {
-        "message": "Simplu"
-    },
-    "platform": {
-        "message": "Platformă"
-    },
-    "playbackSpeed": {
-        "message": "Viteza playbackului"
-    },
-    "playerColor": {
-        "message": "Culoare player"
-    },
-    "playerSize": {
-        "message": "Mărime player"
-    },
-    "playlists": {
-        "message": "Playlisturi"
-    },
-    "playPause": {
-        "message": "Redă / Pauză"
-    },
-    "popupPlayer": {
-        "message": "Player popup"
-    },
-    "position": {
-        "message": "Poziție"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Apasă orice buton sau folosește rotița mouseului."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Apasă orice buton sau folosește rotița mouseului"
-    },
-    "previousVideo": {
-        "message": "Videoclipul anterior"
-    },
-    "primaryColor": {
-        "message": "Culoarea primară"
-    },
-    "purple": {
-        "message": "Mov"
-    },
-    "quality": {
-        "message": "Calitate"
-    },
-    "rateUs": {
-        "message": "Dă-ne o notă"
-    },
-    "red": {
-        "message": "Roșu"
-    },
-    "redDislikeButton": {
-        "message": "Arată butonul nu îmi place cu culoare roșie"
-    },
-    "relatedVideos": {
-        "message": "Videoclipuri asemănătoare"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Elimină rezultatele asemănătoare a căutării"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Eliminați roata de Shorts din rezultatele căutării"
-    },
-    "repeat": {
-        "message": "Repetă"
-    },
-    "reset": {
-        "message": "Resetează"
-    },
-    "resetAllSettings": {
-        "message": "Resetează toate setările"
-    },
-    "resetAllShortcuts": {
-        "message": "Resetează toate scurtăturile"
-    },
-    "reverse": {
-        "message": "Invers"
-    },
-    "rotate": {
-        "message": "Rotește"
-    },
-    "save": {
-        "message": "Salvează"
-    },
-    "saveAs": {
-        "message": "Salvează ca"
-    },
-    "schedule": {
-        "message": "Program"
-    },
-    "screen": {
-        "message": "Ecran"
-    },
-    "screenshot": {
-        "message": "Captură de ecran"
-    },
-    "search": {
-        "message": "Caută"
-    },
-    "searchBarOnly": {
-        "message": "Doar bara de căutare"
-    },
-    "seekBackward10Seconds": {
-        "message": "Sari înapoi 10 secunde"
-    },
-    "seekForward10Seconds": {
-        "message": "Sari înainte 10 secunde"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Setări"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Setările au fost importate cu succes"
-    },
-    "shortcuts": {
-        "message": "Scurtături"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Arată cardurile la hover-ul cu mouseul"
-    },
-    "showChannelVideosCount": {
-        "message": "Arată numărul de videoclipuri al canalului"
-    },
-    "shuffle": {
-        "message": "Amestecă"
-    },
-    "sidebar": {
-        "message": "Bara laterală"
-    },
-    "spacebar": {
-        "message": "Bara de spațiu"
-    },
-    "squaredUserImages": {
-        "message": "Avatarele utilizatorului pătrat"
-    },
-    "statsForNerds": {
-        "message": "Arată Statisticile pentru Tocilari"
-    },
-    "step": {
-        "message": "Pas"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stiluri"
-    },
-    "subscriptions": {
-        "message": "Abonamente"
-    },
-    "subtitles": {
-        "message": "Subtitrări"
-    },
-    "sunset": {
-        "message": "Apus"
-    },
-    "sunsetToSunrise": {
-        "message": "De la apus la răsărit"
-    },
-    "systemPeferenceDark": {
-        "message": "Preferința sitemului: închis"
-    },
-    "systemPeferenceLight": {
-        "message": "Preferința sitemului: deschis"
-    },
-    "textColor": {
-        "message": "Culoarea textului"
-    },
-    "themes": {
-        "message": "Teme"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Asta va șterge toate cookie-urile."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Asta va șterge toate cooki-urile YouTube."
-    },
-    "thisWillResetAllSettings": {
-        "message": "Asta va reseta toate setările."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Asta va șterge toate scurtăturile"
-    },
-    "thumbnails": {
-        "message": "Miniaturi"
-    },
-    "timeFrom": {
-        "message": "Timp de la"
-    },
-    "timeTo": {
-        "message": "Timp până la"
-    },
-    "todayAt": {
-        "message": "Azi la"
-    },
-    "toggleCards": {
-        "message": "Comută cardurile"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "trailerAutoplay": {
-        "message": "Auto-redă trailerul"
-    },
-    "translations": {
-        "message": "Traduceri"
-    },
-    "transparentBackground": {
-        "message": "Fundal Transparent"
-    },
-    "trending": {
-        "message": "Tendințe"
-    },
-    "tryToReloadThePage": {
-        "message": "Încearcă să reîmprospătezi pagina"
-    },
-    "type": {
-        "message": "Scrie"
-    },
-    "upNextAutoplay": {
-        "message": "Urmează"
-    },
-    "use24HourFormat": {
-        "message": "Folosește formatul de 24 de ore"
-    },
-    "version": {
-        "message": "Versiune"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Descripția videoclipului va fi extinsă pentru a afla numele categoriei"
-    },
-    "videoFormats": {
-        "message": "Formatul videoclipului"
-    },
-    "videos": {
-        "message": "Videoclipuri"
-    },
-    "volume": {
-        "message": "Volum"
-    },
-    "watchLater": {
-        "message": "Vezi mai târziu"
-    },
-    "watchTime": {
-        "message": "Timp de vizionare"
-    },
-    "whenTabIsChanged": {
-        "message": "Când tabul este schimbat"
-    },
-    "white": {
-        "message": "Alb"
-    },
-    "yellow": {
-        "message": "Galben"
-    },
-    "youTubeButtons": {
-        "message": "Butoane YouTube"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Antetul YouTube (stânga)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Antetul YouTube (dreapta)"
-    },
-    "youtubeHomePage": {
-        "message": "Pagina de pornire YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Limba de afișare YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube limitează calitatea videoclipului la 1080p pentru codecul h.264"
-    }
+	"about": {
+		"message": "Despre"
+	},
+	"accept": {
+		"message": "Acceptă"
+	},
+	"activate": {
+		"message": "Activează"
+	},
+	"activateCaptions": {
+		"message": "Activează subtitrările"
+	},
+	"activated": {
+		"message": "Activat"
+	},
+	"activatedFeatures": {
+		"message": "Caracteristici activate"
+	},
+	"activateFullscreen": {
+		"message": "Activează ecran complet"
+	},
+	"activeFeatures": {
+		"message": "Caracteristici active"
+	},
+	"addScrollToTop": {
+		"message": "Adaugă «Derulează la început»"
+	},
+	"ads": {
+		"message": "Reclame"
+	},
+	"all": {
+		"message": "Tot"
+	},
+	"allow": {
+		"message": "Permite"
+	},
+	"alwaysActive": {
+		"message": "Mereu activ"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Arată mereu bara de progres"
+	},
+	"amber": {
+		"message": "Chihlimbar"
+	},
+	"analyzer": {
+		"message": "Analizator"
+	},
+	"appearance": {
+		"message": "Aparențe"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Sigur doriți să exportați datele?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Sigur doriți să importați datele?"
+	},
+	"audioFormats": {
+		"message": "Formaturi audio"
+	},
+	"autoFullscreen": {
+		"message": "ecran complet automat"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pauzează automat la schimbarea tab-ului"
+	},
+	"autoplay": {
+		"message": "Pornește automat"
+	},
+	"backgroundColor": {
+		"message": "Culoare de fundal"
+	},
+	"backgroundOpacity": {
+		"message": "Opacitatea fundalului"
+	},
+	"backupAndReset": {
+		"message": "Salvează & resetează"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Bazat pe schema de culori a sistemului"
+	},
+	"black": {
+		"message": "Înapoi"
+	},
+	"blockAll": {
+		"message": "Blochează tot"
+	},
+	"blocklist": {
+		"message": "Lista neagră"
+	},
+	"blockMusic": {
+		"message": "Interzice muzica"
+	},
+	"blue": {
+		"message": "Albastru"
+	},
+	"blueGray": {
+		"message": "Gri albastru"
+	},
+	"bluelight": {
+		"message": "Lumină albastră"
+	},
+	"brown": {
+		"message": "Maro"
+	},
+	"browserVersion": {
+		"message": "Versiunea browserului"
+	},
+	"bubbles": {
+		"message": "Bule"
+	},
+	"buttons": {
+		"message": "Butoane"
+	},
+	"cancel": {
+		"message": "Anulează"
+	},
+	"categories": {
+		"message": "Categorii"
+	},
+	"channel": {
+		"message": "Canal"
+	},
+	"channels": {
+		"message": "Canale"
+	},
+	"collapsed": {
+		"message": "Închis"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Închide secțiunea de subscripții"
+	},
+	"comments": {
+		"message": "Comentarii"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Confirmă înainte să închizi"
+	},
+	"cores": {
+		"message": "Nuclee"
+	},
+	"cropChapterTitles": {
+		"message": "Taie titlurile capitolelor"
+	},
+	"custom": {
+		"message": "Personalizat"
+	},
+	"customCss": {
+		"message": "CSS Personalizat"
+	},
+	"customJs": {
+		"message": "JS Personalizat"
+	},
+	"customMiniPlayer": {
+		"message": "Mini-Player Personalizat"
+	},
+	"dark": {
+		"message": "Închis"
+	},
+	"darkTheme": {
+		"message": "Temă închisă"
+	},
+	"dateAndTime": {
+		"message": "Data & timpul"
+	},
+	"dawn": {
+		"message": "Răsărit"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Scade viteza playback-ului"
+	},
+	"decreaseVolume": {
+		"message": "Scade volumul"
+	},
+	"deepOrange": {
+		"message": "Portocaliu închis"
+	},
+	"deepPurple": {
+		"message": "Mov închis"
+	},
+	"defaultChannelTab": {
+		"message": "Tab-ul implicit al canalului"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Șterge cookie-urile YouTube"
+	},
+	"desert": {
+		"message": "Deșert"
+	},
+	"details": {
+		"message": "Detalii"
+	},
+	"developerOptions": {
+		"message": "Opțiunile dezvoltatorului"
+	},
+	"device": {
+		"message": "Dispozitiv"
+	},
+	"dim": {
+		"message": "Întunecă"
+	},
+	"disabled": {
+		"message": "Dezactivat"
+	},
+	"dislike": {
+		"message": "Nu îmi place"
+	},
+	"donate": {
+		"message": "Donează"
+	},
+	"doNotChange": {
+		"message": "Nu schimba"
+	},
+	"draggable": {
+		"message": "Poate fi tras"
+	},
+	"empty": {
+		"message": "Gol"
+	},
+	"enabled": {
+		"message": "Activat"
+	},
+	"enabledForced": {
+		"message": "Activat (forțat)"
+	},
+	"expanded": {
+		"message": "Deschis"
+	},
+	"exportSettings": {
+		"message": "Exportă setările"
+	},
+	"extension": {
+		"message": "Extensie"
+	},
+	"file": {
+		"message": "Fișier"
+	},
+	"filters": {
+		"message": "Filtre"
+	},
+	"fitToWindow": {
+		"message": "Potrivește în fereastră"
+	},
+	"footer": {
+		"message": "Subsol"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Viteză de playback forțată"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Forced play video from the beginning"
+	},
+	"forcedTheaterMode": {
+		"message": "Modul teatru forțat"
+	},
+	"forcedVolume": {
+		"message": "Volum forțat"
+	},
+	"forceSDR": {
+		"message": "Forțează SDR"
+	},
+	"foundABug": {
+		"message": "Ai găsit un bug?"
+	},
+	"fullWindow": {
+		"message": "Ecran complet"
+	},
+	"geoPreference": {
+		"message": "Preferințe Geo"
+	},
+	"goToSearchBox": {
+		"message": "Du-te la casuța de căutare"
+	},
+	"green": {
+		"message": "Verde"
+	},
+	"hdThumbnail": {
+		"message": "Miniatură HD"
+	},
+	"header": {
+		"message": "Antet"
+	},
+	"hidden": {
+		"message": "Ascuns"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Ascuns pe pagina video"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Ascunde miniaturile animate"
+	},
+	"hideAnnotations": {
+		"message": "Ascunde adnotările"
+	},
+	"hideCards": {
+		"message": "Ascunde cardurile"
+	},
+	"hideDetails": {
+		"message": "Ascunde detaliile"
+	},
+	"hideEndscreen": {
+		"message": "Ascunde ecranul de final"
+	},
+	"hideFeaturedContent": {
+		"message": "Ascunde conținutul prezentat"
+	},
+	"hideFooter": {
+		"message": "Ascunde subsolul"
+	},
+	"hideGradientBottom": {
+		"message": "Ascunde Gradient Bottom"
+	},
+	"hideHomePageShorts": {
+		"message": "Eliminați Shorts de pe pagina de start"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ascundeți bara de control al jucătorului"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ascunde butoanele din bara de control al jucătorului"
+	},
+	"hidePlaylist": {
+		"message": "Ascunde playlistul"
+	},
+	"hideRightButtons": {
+		"message": "Ascunde butoanele din dreapta"
+	},
+	"hideScrollForDetails": {
+		"message": "Ascunde «Derulează pentru detalii»"
+	},
+	"hideViewsCount": {
+		"message": "Ascunde numărul vizualizărilor"
+	},
+	"history": {
+		"message": "Istoric"
+	},
+	"home": {
+		"message": "Acasă"
+	},
+	"hoverOnVideoPage": {
+		"message": "Hover pe pagina video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Acum cât timp a fost încărcat videoclipul"
+	},
+	"icons": {
+		"message": "Iconițe"
+	},
+	"iconsOnly": {
+		"message": "Doar iconițe"
+	},
+	"importSettings": {
+		"message": "Importă setările"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Iconița ImprovedTube pe YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Limba ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Versiunea ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Îmbunătățește sigla"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Crește viteza de playback"
+	},
+	"increaseVolume": {
+		"message": "Crește volumul"
+	},
+	"items": {
+		"message": "Obiecte"
+	},
+	"languages": {
+		"message": "Limbi"
+	},
+	"legacyYoutube": {
+		"message": "YouTube vechi"
+	},
+	"light": {
+		"message": "Deschis"
+	},
+	"lightBlue": {
+		"message": "Albastru deschis"
+	},
+	"lightGreen": {
+		"message": "Verde deschis"
+	},
+	"like": {
+		"message": "Îmi place"
+	},
+	"list": {
+		"message": "Listă"
+	},
+	"liveChat": {
+		"message": "Chat live"
+	},
+	"liveChatType": {
+		"message": "Chat live scrie"
+	},
+	"loudnessNormalization": {
+		"message": "Normalizează zgomotul"
+	},
+	"markWatchedVideos": {
+		"message": "Marchează videoclipurile văzute"
+	},
+	"myColors": {
+		"message": "Culorile mele"
+	},
+	"name": {
+		"message": "Nume"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mini-Player nativ"
+	},
+	"new": {
+		"message": "Nou"
+	},
+	"nextVideo": {
+		"message": "Următorul video"
+	},
+	"night": {
+		"message": "Noapte"
+	},
+	"noActiveFeatures": {
+		"message": "Nici o caracteristică activată"
+	},
+	"none": {
+		"message": "Nimic"
+	},
+	"noOpenVideoTabs": {
+		"message": "Niciun tab video deschis"
+	},
+	"old": {
+		"message": "Vechi"
+	},
+	"onAllVideos": {
+		"message": "Pe toate videoclipurile"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Activ doar pe YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Doar o instanță de player care merge"
+	},
+	"onSubscribedChannels": {
+		"message": "Pe canalele abonate"
+	},
+	"openPopupPlayer": {
+		"message": "Deschide videoclipul/playlistul într-o fereastră nouă"
+	},
+	"orange": {
+		"message": "Portocaliu"
+	},
+	"os": {
+		"message": "SO"
+	},
+	"other": {
+		"message": "Altele"
+	},
+	"permissions": {
+		"message": "Permisiuni"
+	},
+	"pink": {
+		"message": "Roz"
+	},
+	"plain": {
+		"message": "Simplu"
+	},
+	"platform": {
+		"message": "Platformă"
+	},
+	"playbackSpeed": {
+		"message": "Viteza playbackului"
+	},
+	"playerColor": {
+		"message": "Culoare player"
+	},
+	"playerSize": {
+		"message": "Mărime player"
+	},
+	"playlists": {
+		"message": "Playlisturi"
+	},
+	"playPause": {
+		"message": "Redă / Pauză"
+	},
+	"popupPlayer": {
+		"message": "Player popup"
+	},
+	"position": {
+		"message": "Poziție"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Apasă orice buton sau folosește rotița mouseului."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Apasă orice buton sau folosește rotița mouseului"
+	},
+	"previousVideo": {
+		"message": "Videoclipul anterior"
+	},
+	"primaryColor": {
+		"message": "Culoarea primară"
+	},
+	"purple": {
+		"message": "Mov"
+	},
+	"quality": {
+		"message": "Calitate"
+	},
+	"rateUs": {
+		"message": "Dă-ne o notă"
+	},
+	"red": {
+		"message": "Roșu"
+	},
+	"redDislikeButton": {
+		"message": "Arată butonul nu îmi place cu culoare roșie"
+	},
+	"relatedVideos": {
+		"message": "Videoclipuri asemănătoare"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Elimină rezultatele asemănătoare a căutării"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Eliminați roata de Shorts din rezultatele căutării"
+	},
+	"repeat": {
+		"message": "Repetă"
+	},
+	"reset": {
+		"message": "Resetează"
+	},
+	"resetAllSettings": {
+		"message": "Resetează toate setările"
+	},
+	"resetAllShortcuts": {
+		"message": "Resetează toate scurtăturile"
+	},
+	"reverse": {
+		"message": "Invers"
+	},
+	"rotate": {
+		"message": "Rotește"
+	},
+	"save": {
+		"message": "Salvează"
+	},
+	"saveAs": {
+		"message": "Salvează ca"
+	},
+	"schedule": {
+		"message": "Program"
+	},
+	"screen": {
+		"message": "Ecran"
+	},
+	"screenshot": {
+		"message": "Captură de ecran"
+	},
+	"search": {
+		"message": "Caută"
+	},
+	"searchBarOnly": {
+		"message": "Doar bara de căutare"
+	},
+	"seekBackward10Seconds": {
+		"message": "Sari înapoi 10 secunde"
+	},
+	"seekForward10Seconds": {
+		"message": "Sari înainte 10 secunde"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Setări"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Setările au fost importate cu succes"
+	},
+	"shortcuts": {
+		"message": "Scurtături"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Arată cardurile la hover-ul cu mouseul"
+	},
+	"showChannelVideosCount": {
+		"message": "Arată numărul de videoclipuri al canalului"
+	},
+	"shuffle": {
+		"message": "Amestecă"
+	},
+	"sidebar": {
+		"message": "Bara laterală"
+	},
+	"spacebar": {
+		"message": "Bara de spațiu"
+	},
+	"squaredUserImages": {
+		"message": "Avatarele utilizatorului pătrat"
+	},
+	"statsForNerds": {
+		"message": "Arată Statisticile pentru Tocilari"
+	},
+	"step": {
+		"message": "Pas"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stiluri"
+	},
+	"subscriptions": {
+		"message": "Abonamente"
+	},
+	"subtitles": {
+		"message": "Subtitrări"
+	},
+	"sunset": {
+		"message": "Apus"
+	},
+	"sunsetToSunrise": {
+		"message": "De la apus la răsărit"
+	},
+	"systemPeferenceDark": {
+		"message": "Preferința sitemului: închis"
+	},
+	"systemPeferenceLight": {
+		"message": "Preferința sitemului: deschis"
+	},
+	"textColor": {
+		"message": "Culoarea textului"
+	},
+	"themes": {
+		"message": "Teme"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Asta va șterge toate cookie-urile."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Asta va șterge toate cooki-urile YouTube."
+	},
+	"thisWillResetAllSettings": {
+		"message": "Asta va reseta toate setările."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Asta va șterge toate scurtăturile"
+	},
+	"thumbnails": {
+		"message": "Miniaturi"
+	},
+	"timeFrom": {
+		"message": "Timp de la"
+	},
+	"timeTo": {
+		"message": "Timp până la"
+	},
+	"todayAt": {
+		"message": "Azi la"
+	},
+	"toggleCards": {
+		"message": "Comută cardurile"
+	},
+	"trailerAutoplay": {
+		"message": "Auto-redă trailerul"
+	},
+	"translations": {
+		"message": "Traduceri"
+	},
+	"transparentBackground": {
+		"message": "Fundal Transparent"
+	},
+	"trending": {
+		"message": "Tendințe"
+	},
+	"tryToReloadThePage": {
+		"message": "Încearcă să reîmprospătezi pagina"
+	},
+	"type": {
+		"message": "Scrie"
+	},
+	"upNextAutoplay": {
+		"message": "Urmează"
+	},
+	"use24HourFormat": {
+		"message": "Folosește formatul de 24 de ore"
+	},
+	"version": {
+		"message": "Versiune"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Descripția videoclipului va fi extinsă pentru a afla numele categoriei"
+	},
+	"videoFormats": {
+		"message": "Formatul videoclipului"
+	},
+	"videos": {
+		"message": "Videoclipuri"
+	},
+	"volume": {
+		"message": "Volum"
+	},
+	"watchLater": {
+		"message": "Vezi mai târziu"
+	},
+	"watchTime": {
+		"message": "Timp de vizionare"
+	},
+	"whenTabIsChanged": {
+		"message": "Când tabul este schimbat"
+	},
+	"white": {
+		"message": "Alb"
+	},
+	"yellow": {
+		"message": "Galben"
+	},
+	"youTubeButtons": {
+		"message": "Butoane YouTube"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Antetul YouTube (stânga)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Antetul YouTube (dreapta)"
+	},
+	"youtubeHomePage": {
+		"message": "Pagina de pornire YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Limba de afișare YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube limitează calitatea videoclipului la 1080p pentru codecul h.264"
+	}
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,1067 +1,1067 @@
 {
-    "about": {
-        "message": "Об ImprovedTube"
-    },
-    "accept": {
-        "message": "Принять"
-    },
-    "activate": {
-        "message": "Включить"
-    },
-    "activateCaptions": {
-        "message": "Включить субтитры"
-    },
-    "activated": {
-        "message": "Включено"
-    },
-    "activatedFeatures": {
-        "message": "Включенные функции"
-    },
-    "activateFullscreen": {
-        "message": "Перейти в полноэкранный режим"
-    },
-    "activeFeatures": {
-        "message": "Активные функции"
-    },
-    "addScrollToTop": {
-        "message": "Добавить кнопку «наверх»"
-    },
-    "ads": {
-        "message": "Реклама"
-    },
-    "all": {
-        "message": "Все"
-    },
-    "allow": {
-        "message": "Разрешить"
-    },
-    "always": {
-        "message": "Всегда"
-    },
-    "alwaysActive": {
-        "message": "Всегда активный"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Всегда показывать полосу прогресса"
-    },
-    "amber": {
-        "message": "Янтарный"
-    },
-    "analyzer": {
-        "message": "Анализатор"
-    },
-    "animations": {
-        "message": "Анимации"
-    },
-    "appearance": {
-        "message": "Внешний вид"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Вы уверены что хотите экспортировать данные?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Вы уверены что хотите импортировать данные?"
-    },
-    "audio": {
-        "message": "Аудио"
-    },
-    "audioFormats": {
-        "message": "Аудиоформаты"
-    },
-    "auto": {
-        "message": "Авто"
-    },
-    "autoFullscreen": {
-        "message": "Автоматический переход в полноэкранный режим"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Автопауза при смене вкладок"
-    },
-    "autoplay": {
-        "message": "Автовоспроизведение"
-    },
-    "avoidAv1": {
-        "message": "Избегать AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Избегать AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Избегать AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "По возможности избегать ЦП рендеринга"
-    },
-    "backgroundColor": {
-        "message": "Цвет фона"
-    },
-    "backgroundOpacity": {
-        "message": "Прозрачность фона"
-    },
-    "backupAndReset": {
-        "message": "Резервное копирование и сброс"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "На основе системной цветовой схемы"
-    },
-    "belowPlayer": {
-        "message": "Снизу плеера"
-    },
-    "black": {
-        "message": "Черный"
-    },
-    "blockAll": {
-        "message": "Блокировать все"
-    },
-    "blockAv1": {
-        "message": "Блокировать AV1"
-    },
-    "blockH264": {
-        "message": "Блокировать H.264"
-    },
-    "blocklist": {
-        "message": "Черный список"
-    },
-    "blockMusic": {
-        "message": "Блокировать музыку"
-    },
-    "blockVp8": {
-        "message": "Блокировать VP8"
-    },
-    "blockVp9": {
-        "message": "Блокировать VP9"
-    },
-    "blue": {
-        "message": "Синий"
-    },
-    "blueGray": {
-        "message": "Серо-голубой"
-    },
-    "bluelight": {
-        "message": "Светло-синий"
-    },
-    "brown": {
-        "message": "Коричневый"
-    },
-    "browser": {
-        "message": "Браузер"
-    },
-    "browserVersion": {
-        "message": "Версия браузера"
-    },
-    "bubbles": {
-        "message": "Пузыри"
-    },
-    "bug": {
-        "message": "Ошибка"
-    },
-    "buttons": {
-        "message": "Кнопки"
-    },
-    "cancel": {
-        "message": "Отмена"
-    },
-    "categories": {
-        "message": "Категории"
-    },
-    "channel": {
-        "message": "Канал"
-    },
-    "channels": {
-        "message": "Каналы"
-    },
-    "characterEdgeStyle": {
-        "message": "Стиль контура символов"
-    },
-    "clip": {
-        "message": "Создать клип"
-    },
-    "clipboard": {
-        "message": "Буфер обмена"
-    },
-    "codecH264": {
-        "message": "Кодек H.264"
-    },
-    "codecs": {
-        "message": "Кодеки"
-    },
-    "collapsed": {
-        "message": "Свернутый"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Свернуть раздел подписок"
-    },
-    "comments": {
-        "message": "Комментарии"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Подтверждать закрытие"
-    },
-    "cookies": {
-        "message": "Куки"
-    },
-    "cores": {
-        "message": "Ядра"
-    },
-    "cropChapterTitles": {
-        "message": "Обрезать заголовки глав"
-    },
-    "custom": {
-        "message": "Пользовательский"
-    },
-    "customCss": {
-        "message": "Пользовательский CSS"
-    },
-    "customJs": {
-        "message": "Пользовательский JS"
-    },
-    "customMiniPlayer": {
-        "message": "Пользовательский мини-плеер"
-    },
-    "cyan": {
-        "message": "Бирюзовый"
-    },
-    "dark": {
-        "message": "Темный"
-    },
-    "darkTheme": {
-        "message": "Темная тема"
-    },
-    "dateAndTime": {
-        "message": "Дата и время"
-    },
-    "dawn": {
-        "message": "Рассвет"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Уменьшить скорость видео"
-    },
-    "decreaseVolume": {
-        "message": "Уменьшить громкость"
-    },
-    "deepOrange": {
-        "message": "Темно-оранжевый"
-    },
-    "deepPurple": {
-        "message": "Темно-фиолетовый"
-    },
-    "default": {
-        "message": "По умолчанию"
-    },
-    "defaultChannelTab": {
-        "message": "Вкладка канала по умолчанию"
-    },
-    "defaultContentCountry": {
-        "message": "Страна по умолчанию"
-    },
-    "deleteWatchedVideos": {
-        "message": "Удалять просмотренные видео"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Удалить куки YouTube"
-    },
-    "depressed": {
-        "message": "Депрессивный"
-    },
-    "description": {
-        "message": "Описание"
-    },
-    "description_ext": {
-        "message": "Сделайте YouTube аккуратным + умным! Цвет видео YouTube пропуск рекламы громкость скорость канала стиль инструмента HD реклама adblock блокировщик рекламы теги список ключевых слов"
-    },
-    "desert": {
-        "message": "Пустыня"
-    },
-    "details": {
-        "message": "Подробнее"
-    },
-    "developerOptions": {
-        "message": "Настройки разработчика"
-    },
-    "device": {
-        "message": "Устройство"
-    },
-    "dim": {
-        "message": "Тусклый"
-    },
-    "disabled": {
-        "message": "Выключен"
-    },
-    "dislike": {
-        "message": "Дизлайк"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Показывать день недели"
-    },
-    "donate": {
-        "message": "Пожертвовать"
-    },
-    "doNotChange": {
-        "message": "Не менять"
-    },
-    "draggable": {
-        "message": "Перетаскиваемый"
-    },
-    "dropShadow": {
-        "message": "Отбрасываемая тень"
-    },
-    "durationWithSpeed": {
-        "message": "Показывать оставшееся время видео с учётом скорости воспроизведения"
-    },
-    "email": {
-        "message": "E-mail"
-    },
-    "empty": {
-        "message": "Пустой"
-    },
-    "enabled": {
-        "message": "Включен"
-    },
-    "enabledForced": {
-        "message": "Включен (принудительно)"
-    },
-    "expanded": {
-        "message": "Развернутый"
-    },
-    "exportSettings": {
-        "message": "Экспорт настроек"
-    },
-    "extension": {
-        "message": "Расширение"
-    },
-    "file": {
-        "message": "Файл"
-    },
-    "filters": {
-        "message": "Фильтры"
-    },
-    "fitToWindow": {
-        "message": "Подогнать под размеры окна"
-    },
-    "font": {
-        "message": "Шрифт"
-    },
-    "fontColor": {
-        "message": "Цвет шрифта"
-    },
-    "fontFamily": {
-        "message": "Семейство шрифта"
-    },
-    "fontOpacity": {
-        "message": "Прозрачность шрифта"
-    },
-    "fontSize": {
-        "message": "Размер шрифта"
-    },
-    "footer": {
-        "message": "Нижний колонтитул"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Принудительная скорость воспроизведения"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Всегда играть видео с начала"
-    },
-    "forcedTheaterMode": {
-        "message": "Принудительно переходить в режим кино"
-    },
-    "forcedVolume": {
-        "message": "Принудительная громкость"
-    },
-    "forceSDR": {
-        "message": "Принудительное SDR"
-    },
-    "foundABug": {
-        "message": "Нашли ошибку?"
-    },
-    "fullWindow": {
-        "message": "Растянуть на все окно"
-    },
-    "general": {
-        "message": "Общий"
-    },
-    "geoPreference": {
-        "message": "Предпочтения локации"
-    },
-    "googleApiKey": {
-        "message": "Ключ Google API"
-    },
-    "goToSearchBox": {
-        "message": "Перейти в окно поиска"
-    },
-    "gpu": {
-        "message": "ГПУ"
-    },
-    "green": {
-        "message": "Зеленый"
-    },
-    "hardwareInformation": {
-        "message": "Информация об оборудовании"
-    },
-    "hdThumbnail": {
-        "message": "HD-превью"
-    },
-    "header": {
-        "message": "Заголовок"
-    },
-    "hidden": {
-        "message": "Скрытый"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Скрывать (только на странице видео)"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Скрывать анимированные превью"
-    },
-    "hideAnnotations": {
-        "message": "Скрывать аннотации"
-    },
-    "hideCards": {
-        "message": "Скрывать карточки"
-    },
-    "hideCountryCode": {
-        "message": "Скрывать код страны"
-    },
-    "hideDate": {
-        "message": "Скрывать дату видео"
-    },
-    "hideDetailButton": {
-        "message": "Скрывать кнопку «Ещё»"
-    },
-    "hideDetails": {
-        "message": "Скрывать подробную информацию"
-    },
-    "hideEndscreen": {
-        "message": "Скрывать экран после видео"
-    },
-    "hideFeaturedContent": {
-        "message": "Скрывать рекомендации"
-    },
-    "hideFooter": {
-        "message": "Скрывать нижний колонтитул"
-    },
-    "hideGradientBottom": {
-        "message": "Скрывать кнопку градиента"
-    },
-    "hideHomePageShorts": {
-        "message": "Удалить Shorts с главной страницы"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Скрывать панель управления плеером"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Скрывать кнопки панели управления плеером"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Скрывать настройки панели управления пЛеера"
-    },
-    "hidePlaylist": {
-        "message": "Скрывать плейлисты"
-    },
-    "hideRightButtons": {
-        "message": "Скрывать кнопки (справа)"
-    },
-    "hideScrollForDetails": {
-        "message": "Скрывать «Прокрутите для подробной информации»"
-    },
-    "hideSkipOverlay": {
-        "message": "Скрывать наложение \"5 секунд\""
-    },
-    "hideThumbnailOverlay": {
-        "message": "Скрывать наложение на превью"
-    },
-    "hideThumbnails": {
-        "message": "Скрывать превью"
-    },
-    "hideViewsCount": {
-        "message": "Скрывать количество просмотров"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Скрывать кнопку голосового поиска"
-    },
-    "high": {
-        "message": "Высокий"
-    },
-    "history": {
-        "message": "История"
-    },
-    "home": {
-        "message": "Домашняя страница"
-    },
-    "hover": {
-        "message": "Показывать при наведении"
-    },
-    "hoverOnVideoPage": {
-        "message": "Показывать при наведении (только на странице видео)"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Показывать дату видео"
-    },
-    "icons": {
-        "message": "Иконки"
-    },
-    "iconsOnly": {
-        "message": "Только иконки"
-    },
-    "importSettings": {
-        "message": "Импорт настроек"
-    },
-    "improvedtubeButtons": {
-        "message": "Кнопки расширения ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Значок ImprovedTube в YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Язык ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Версия ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Улучшить логотип YouTube"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Увеличить скорость видео"
-    },
-    "increaseVolume": {
-        "message": "Увеличить громкость"
-    },
-    "indigo": {
-        "message": "Индиго"
-    },
-    "items": {
-        "message": "Пункты"
-    },
-    "language": {
-        "message": "Язык"
-    },
-    "languages": {
-        "message": "Языки"
-    },
-    "layerAnimationScale": {
-        "message": "Масштаб слоя анимации"
-    },
-    "layout": {
-        "message": "Слой"
-    },
-    "legacyYoutube": {
-        "message": "Старая версия YouTube"
-    },
-    "library": {
-        "message": "Библиотека"
-    },
-    "light": {
-        "message": "Светлый"
-    },
-    "lightBlue": {
-        "message": "Светло-синий"
-    },
-    "lightGreen": {
-        "message": "Светло-зеленый"
-    },
-    "like": {
-        "message": "Лайк"
-    },
-    "liked": {
-        "message": "Понравившиеся"
-    },
-    "likes": {
-        "message": "Лайки"
-    },
-    "lime": {
-        "message": "Лайм"
-    },
-    "limitPageWidth": {
-        "message": "Ограничивать ширину страницы"
-    },
-    "list": {
-        "message": "Список"
-    },
-    "liveChat": {
-        "message": "Live-чат"
-    },
-    "liveChatType": {
-        "message": "Тип live-чата"
-    },
-    "location": {
-        "message": "Местонахождение"
-    },
-    "loop": {
-        "message": "Зациклить"
-    },
-    "loudnessNormalization": {
-        "message": "Нормализировать громкость"
-    },
-    "low": {
-        "message": "Низкий"
-    },
-    "markWatchedVideos": {
-        "message": "Отмечать просмотренные видео"
-    },
-    "medium": {
-        "message": "Средний"
-    },
-    "mixer": {
-        "message": "Миксер"
-    },
-    "mostViewedChannels": {
-        "message": "Самые просматриваемые каналы"
-    },
-    "moveSidebarLeft": {
-        "message": "Сместить боковую панель влево"
-    },
-    "moveThumbnailsRight": {
-        "message": "Сместить превью вправо"
-    },
-    "myColors": {
-        "message": "Мои цвета"
-    },
-    "name": {
-        "message": "Имя"
-    },
-    "nativeMiniPlayer": {
-        "message": "Мини-плеер от YouTube"
-    },
-    "new": {
-        "message": "Новый"
-    },
-    "nextVideo": {
-        "message": "Следующее видео"
-    },
-    "night": {
-        "message": "Ночь"
-    },
-    "nightMode": {
-        "message": "Ночной режим"
-    },
-    "noActiveFeatures": {
-        "message": "Нет активных функций"
-    },
-    "none": {
-        "message": "Пусто"
-    },
-    "noOpenVideoTabs": {
-        "message": "Нет открытых вкладок с видео"
-    },
-    "normal": {
-        "message": "Обычный"
-    },
-    "off": {
-        "message": "Выключить"
-    },
-    "ok": {
-        "message": "Хорошо"
-    },
-    "old": {
-        "message": "Старый"
-    },
-    "onAllVideos": {
-        "message": "На всех видео"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Активен только в YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Только один плеер играет одновременно"
-    },
-    "onSubscribedChannels": {
-        "message": "Только на каналах в подписках"
-    },
-    "openPopupPlayer": {
-        "message": "Открыть видео/плейлист в новом окне"
-    },
-    "orange": {
-        "message": "Оранжевый"
-    },
-    "os": {
-        "message": "ОС"
-    },
-    "other": {
-        "message": "Другое"
-    },
-    "outline": {
-        "message": "Контур"
-    },
-    "overlay": {
-        "message": "Наложение"
-    },
-    "permissions": {
-        "message": "Разрешения"
-    },
-    "pictureInPicture": {
-        "message": "Картинка в картинке"
-    },
-    "pink": {
-        "message": "Розовый"
-    },
-    "plain": {
-        "message": "Равнина"
-    },
-    "platform": {
-        "message": "Платформа"
-    },
-    "playAllButton": {
-        "message": "Кнопка \"Играть все\""
-    },
-    "playbackSpeed": {
-        "message": "Скорость воспроизведения"
-    },
-    "player": {
-        "message": "Плеер"
-    },
-    "playerColor": {
-        "message": "Цвет плеера"
-    },
-    "playerSize": {
-        "message": "Размер плеера"
-    },
-    "playlist": {
-        "message": "Плейлист"
-    },
-    "playlists": {
-        "message": "Плейлисты"
-    },
-    "playPause": {
-        "message": "Играть / Пауза"
-    },
-    "popupPlayer": {
-        "message": "Плеер во всплывающем окне"
-    },
-    "popupWindowButtons": {
-        "message": "Добавить кнопки всплывающего окна"
-    },
-    "position": {
-        "message": "Положение"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Нажмите любую кнопку или колесо мыши"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Нажмите любую кнопку или используйте колесо мыши"
-    },
-    "previousVideo": {
-        "message": "Предыдущее видео"
-    },
-    "primaryColor": {
-        "message": "Основной цвет"
-    },
-    "purple": {
-        "message": "Фиолетовый"
-    },
-    "quality": {
-        "message": "Качество"
-    },
-    "qualityWithoutFocus": {
-        "message": "Качество при неактивном окне"
-    },
-    "raised": {
-        "message": "Поднятый"
-    },
-    "ram": {
-        "message": "ОЗУ"
-    },
-    "rateMe": {
-        "message": "Оставить отзыв"
-    },
-    "rateUs": {
-        "message": "Оцените нас"
-    },
-    "red": {
-        "message": "Красный"
-    },
-    "redDislikeButton": {
-        "message": "Сделать дизлайк красным"
-    },
-    "relatedVideos": {
-        "message": "Похожие видео"
-    },
-    "remote": {
-        "message": "Удаленное воспроизведение"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Удалять связанные результаты поиска"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Удалить карусель Shorts из результатов поиска"
-    },
-    "repeat": {
-        "message": "Повтор"
-    },
-    "report": {
-        "message": "Пожаловаться"
-    },
-    "reset": {
-        "message": "Сбросить"
-    },
-    "resetAllSettings": {
-        "message": "Сбросить все настройки"
-    },
-    "resetAllShortcuts": {
-        "message": "Сбросить все горячие клавиши"
-    },
-    "reverse": {
-        "message": "Обратный порядок"
-    },
-    "rotate": {
-        "message": "Повернуть"
-    },
-    "save": {
-        "message": "Сохранить"
-    },
-    "saveAs": {
-        "message": "Сохранить как"
-    },
-    "schedule": {
-        "message": "График"
-    },
-    "screen": {
-        "message": "Экран"
-    },
-    "screenshot": {
-        "message": "Скриншот"
-    },
-    "scrollBar": {
-        "message": "Полоса прокрутки"
-    },
-    "search": {
-        "message": "Поиск"
-    },
-    "searchBarOnly": {
-        "message": "Только поисковая строка"
-    },
-    "seekBackward10Seconds": {
-        "message": "Перемотать на 10 секунд назад"
-    },
-    "seekForward10Seconds": {
-        "message": "Перемотать на 10 секунд вперед"
-    },
-    "seekNextChapter": {
-        "message": "Следующая глава"
-    },
-    "seekPreviousChapter": {
-        "message": "Предыдущая глава"
-    },
-    "settings": {
-        "message": "Настройки"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Настройки успешно импортированы"
-    },
-    "share": {
-        "message": "Поделиться"
-    },
-    "shortcuts": {
-        "message": "Горячие клавиши"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Показывать карточки при наведении"
-    },
-    "showChannelVideosCount": {
-        "message": "Показывать количество видео на канале"
-    },
-    "showLess": {
-        "message": "Показать меньше"
-    },
-    "showMore": {
-        "message": "Показать больше"
-    },
-    "showRemainingDuration": {
-        "message": "Показать время до конца видео"
-    },
-    "showVersion": {
-        "message": "Показывать версию"
-    },
-    "shuffle": {
-        "message": "Перемешать"
-    },
-    "sidebar": {
-        "message": "Боковая панель"
-    },
-    "softwareInformation": {
-        "message": "Информация о программном обеспечении"
-    },
-    "spacebar": {
-        "message": "Пробел"
-    },
-    "squaredUserImages": {
-        "message": "Квадратные аватарки пользователей"
-    },
-    "static": {
-        "message": "Статичный"
-    },
-    "statsForNerds": {
-        "message": "Показать статистику для ботаников"
-    },
-    "step": {
-        "message": "Шаг"
-    },
-    "stop": {
-        "message": "Стоп"
-    },
-    "style": {
-        "message": "Стиль"
-    },
-    "styles": {
-        "message": "Стили"
-    },
-    "subscribe": {
-        "message": "Подписаться"
-    },
-    "subscriptions": {
-        "message": "Подписки"
-    },
-    "subtitles": {
-        "message": "Субтитры"
-    },
-    "sunset": {
-        "message": "Закат"
-    },
-    "sunsetToSunrise": {
-        "message": "От заката до рассвета"
-    },
-    "systemPeferenceDark": {
-        "message": "Предпочитаемая системой: темная"
-    },
-    "systemPeferenceLight": {
-        "message": "Предпочитаемая системой: светлая"
-    },
-    "teal": {
-        "message": "Бирюзовый"
-    },
-    "textColor": {
-        "message": "Цвет текста"
-    },
-    "themes": {
-        "message": "Темы"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Это удалит все куки"
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Это удалит все просмотренные видео"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Вы действительно хотите удалить все куки YouTube?"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Это сбросит все настройки"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Это сбросит все горячие клавиши"
-    },
-    "thumbnails": {
-        "message": "Превью"
-    },
-    "thumbnailsQuality": {
-        "message": "Качество превью"
-    },
-    "timeFrom": {
-        "message": "Время от"
-    },
-    "timeTo": {
-        "message": "Время до"
-    },
-    "todayAt": {
-        "message": "Сегодня в"
-    },
-    "toggleAutoplay": {
-        "message": "Автовоспроизведение"
-    },
-    "toggleCards": {
-        "message": "Карточки"
-    },
-    "toggleControls": {
-        "message": "Панель управления"
-    },
-    "topChat": {
-        "message": "Лучшее"
-    },
-    "trackWatchedVideos": {
-        "message": "Отслеживать просмотренные видео"
-    },
-    "trailerAutoplay": {
-        "message": "Автовоспроизведение трейлера"
-    },
-    "translations": {
-        "message": "Переводы"
-    },
-    "transparentBackground": {
-        "message": "Прозрачный фон"
-    },
-    "trending": {
-        "message": "В тренде"
-    },
-    "tryToReloadThePage": {
-        "message": "Попробуйте перезагрузить страницу"
-    },
-    "type": {
-        "message": "Тип"
-    },
-    "upNextAutoplay": {
-        "message": "Автовоспроизведение следующего видео"
-    },
-    "use24HourFormat": {
-        "message": "24-часовой формат"
-    },
-    "version": {
-        "message": "Версия"
-    },
-    "video": {
-        "message": "Видео"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Описание видео развернется, чтобы получить название категории"
-    },
-    "videoFormats": {
-        "message": "Форматы видео"
-    },
-    "videos": {
-        "message": "Видео"
-    },
-    "viewMode": {
-        "message": "Режим просмотра"
-    },
-    "volume": {
-        "message": "Громкость"
-    },
-    "watchLater": {
-        "message": "Посмотреть позже"
-    },
-    "watchTime": {
-        "message": "Время просмотра"
-    },
-    "whenPaused": {
-        "message": "При паузе"
-    },
-    "whenTabIsChanged": {
-        "message": "При смене вкладки"
-    },
-    "white": {
-        "message": "Белый"
-    },
-    "windowColor": {
-        "message": "Цвет окна"
-    },
-    "windowOpacity": {
-        "message": "Прозрачность окна"
-    },
-    "yellow": {
-        "message": "Желтый"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Верхняя панель (слева)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Верхняя панель (справа)"
-    },
-    "youtubeHomePage": {
-        "message": "Домашняя страница YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Язык YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube ограничивает качество видео до 1080p для кодека H.264"
-    }
+	"about": {
+		"message": "Об ImprovedTube"
+	},
+	"accept": {
+		"message": "Принять"
+	},
+	"activate": {
+		"message": "Включить"
+	},
+	"activateCaptions": {
+		"message": "Включить субтитры"
+	},
+	"activated": {
+		"message": "Включено"
+	},
+	"activatedFeatures": {
+		"message": "Включенные функции"
+	},
+	"activateFullscreen": {
+		"message": "Перейти в полноэкранный режим"
+	},
+	"activeFeatures": {
+		"message": "Активные функции"
+	},
+	"addScrollToTop": {
+		"message": "Добавить кнопку «наверх»"
+	},
+	"ads": {
+		"message": "Реклама"
+	},
+	"all": {
+		"message": "Все"
+	},
+	"allow": {
+		"message": "Разрешить"
+	},
+	"always": {
+		"message": "Всегда"
+	},
+	"alwaysActive": {
+		"message": "Всегда активный"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Всегда показывать полосу прогресса"
+	},
+	"amber": {
+		"message": "Янтарный"
+	},
+	"analyzer": {
+		"message": "Анализатор"
+	},
+	"animations": {
+		"message": "Анимации"
+	},
+	"appearance": {
+		"message": "Внешний вид"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Вы уверены что хотите экспортировать данные?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Вы уверены что хотите импортировать данные?"
+	},
+	"audio": {
+		"message": "Аудио"
+	},
+	"audioFormats": {
+		"message": "Аудиоформаты"
+	},
+	"auto": {
+		"message": "Авто"
+	},
+	"autoFullscreen": {
+		"message": "Автоматический переход в полноэкранный режим"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Автопауза при смене вкладок"
+	},
+	"autoplay": {
+		"message": "Автовоспроизведение"
+	},
+	"avoidAv1": {
+		"message": "Избегать AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Избегать AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Избегать AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "По возможности избегать ЦП рендеринга"
+	},
+	"backgroundColor": {
+		"message": "Цвет фона"
+	},
+	"backgroundOpacity": {
+		"message": "Прозрачность фона"
+	},
+	"backupAndReset": {
+		"message": "Резервное копирование и сброс"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "На основе системной цветовой схемы"
+	},
+	"belowPlayer": {
+		"message": "Снизу плеера"
+	},
+	"black": {
+		"message": "Черный"
+	},
+	"blockAll": {
+		"message": "Блокировать все"
+	},
+	"blockAv1": {
+		"message": "Блокировать AV1"
+	},
+	"blockH264": {
+		"message": "Блокировать H.264"
+	},
+	"blocklist": {
+		"message": "Черный список"
+	},
+	"blockMusic": {
+		"message": "Блокировать музыку"
+	},
+	"blockVp8": {
+		"message": "Блокировать VP8"
+	},
+	"blockVp9": {
+		"message": "Блокировать VP9"
+	},
+	"blue": {
+		"message": "Синий"
+	},
+	"blueGray": {
+		"message": "Серо-голубой"
+	},
+	"bluelight": {
+		"message": "Светло-синий"
+	},
+	"brown": {
+		"message": "Коричневый"
+	},
+	"browser": {
+		"message": "Браузер"
+	},
+	"browserVersion": {
+		"message": "Версия браузера"
+	},
+	"bubbles": {
+		"message": "Пузыри"
+	},
+	"bug": {
+		"message": "Ошибка"
+	},
+	"buttons": {
+		"message": "Кнопки"
+	},
+	"cancel": {
+		"message": "Отмена"
+	},
+	"categories": {
+		"message": "Категории"
+	},
+	"channel": {
+		"message": "Канал"
+	},
+	"channels": {
+		"message": "Каналы"
+	},
+	"characterEdgeStyle": {
+		"message": "Стиль контура символов"
+	},
+	"clip": {
+		"message": "Создать клип"
+	},
+	"clipboard": {
+		"message": "Буфер обмена"
+	},
+	"codecH264": {
+		"message": "Кодек H.264"
+	},
+	"codecs": {
+		"message": "Кодеки"
+	},
+	"collapsed": {
+		"message": "Свернутый"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Свернуть раздел подписок"
+	},
+	"comments": {
+		"message": "Комментарии"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Подтверждать закрытие"
+	},
+	"cookies": {
+		"message": "Куки"
+	},
+	"cores": {
+		"message": "Ядра"
+	},
+	"cropChapterTitles": {
+		"message": "Обрезать заголовки глав"
+	},
+	"custom": {
+		"message": "Пользовательский"
+	},
+	"customCss": {
+		"message": "Пользовательский CSS"
+	},
+	"customJs": {
+		"message": "Пользовательский JS"
+	},
+	"customMiniPlayer": {
+		"message": "Пользовательский мини-плеер"
+	},
+	"cyan": {
+		"message": "Бирюзовый"
+	},
+	"dark": {
+		"message": "Темный"
+	},
+	"darkTheme": {
+		"message": "Темная тема"
+	},
+	"dateAndTime": {
+		"message": "Дата и время"
+	},
+	"dawn": {
+		"message": "Рассвет"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Уменьшить скорость видео"
+	},
+	"decreaseVolume": {
+		"message": "Уменьшить громкость"
+	},
+	"deepOrange": {
+		"message": "Темно-оранжевый"
+	},
+	"deepPurple": {
+		"message": "Темно-фиолетовый"
+	},
+	"default": {
+		"message": "По умолчанию"
+	},
+	"defaultChannelTab": {
+		"message": "Вкладка канала по умолчанию"
+	},
+	"defaultContentCountry": {
+		"message": "Страна по умолчанию"
+	},
+	"deleteWatchedVideos": {
+		"message": "Удалять просмотренные видео"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Удалить куки YouTube"
+	},
+	"depressed": {
+		"message": "Депрессивный"
+	},
+	"description": {
+		"message": "Описание"
+	},
+	"description_ext": {
+		"message": "Сделайте YouTube аккуратным + умным! Цвет видео YouTube пропуск рекламы громкость скорость канала стиль инструмента HD реклама adblock блокировщик рекламы теги список ключевых слов"
+	},
+	"desert": {
+		"message": "Пустыня"
+	},
+	"details": {
+		"message": "Подробнее"
+	},
+	"developerOptions": {
+		"message": "Настройки разработчика"
+	},
+	"device": {
+		"message": "Устройство"
+	},
+	"dim": {
+		"message": "Тусклый"
+	},
+	"disabled": {
+		"message": "Выключен"
+	},
+	"dislike": {
+		"message": "Дизлайк"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Показывать день недели"
+	},
+	"donate": {
+		"message": "Пожертвовать"
+	},
+	"doNotChange": {
+		"message": "Не менять"
+	},
+	"draggable": {
+		"message": "Перетаскиваемый"
+	},
+	"dropShadow": {
+		"message": "Отбрасываемая тень"
+	},
+	"durationWithSpeed": {
+		"message": "Показывать оставшееся время видео с учётом скорости воспроизведения"
+	},
+	"email": {
+		"message": "E-mail"
+	},
+	"empty": {
+		"message": "Пустой"
+	},
+	"enabled": {
+		"message": "Включен"
+	},
+	"enabledForced": {
+		"message": "Включен (принудительно)"
+	},
+	"expanded": {
+		"message": "Развернутый"
+	},
+	"exportSettings": {
+		"message": "Экспорт настроек"
+	},
+	"extension": {
+		"message": "Расширение"
+	},
+	"file": {
+		"message": "Файл"
+	},
+	"filters": {
+		"message": "Фильтры"
+	},
+	"fitToWindow": {
+		"message": "Подогнать под размеры окна"
+	},
+	"font": {
+		"message": "Шрифт"
+	},
+	"fontColor": {
+		"message": "Цвет шрифта"
+	},
+	"fontFamily": {
+		"message": "Семейство шрифта"
+	},
+	"fontOpacity": {
+		"message": "Прозрачность шрифта"
+	},
+	"fontSize": {
+		"message": "Размер шрифта"
+	},
+	"footer": {
+		"message": "Нижний колонтитул"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Принудительная скорость воспроизведения"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Всегда играть видео с начала"
+	},
+	"forcedTheaterMode": {
+		"message": "Принудительно переходить в режим кино"
+	},
+	"forcedVolume": {
+		"message": "Принудительная громкость"
+	},
+	"forceSDR": {
+		"message": "Принудительное SDR"
+	},
+	"foundABug": {
+		"message": "Нашли ошибку?"
+	},
+	"fullWindow": {
+		"message": "Растянуть на все окно"
+	},
+	"general": {
+		"message": "Общий"
+	},
+	"geoPreference": {
+		"message": "Предпочтения локации"
+	},
+	"googleApiKey": {
+		"message": "Ключ Google API"
+	},
+	"goToSearchBox": {
+		"message": "Перейти в окно поиска"
+	},
+	"gpu": {
+		"message": "ГПУ"
+	},
+	"green": {
+		"message": "Зеленый"
+	},
+	"hardwareInformation": {
+		"message": "Информация об оборудовании"
+	},
+	"hdThumbnail": {
+		"message": "HD-превью"
+	},
+	"header": {
+		"message": "Заголовок"
+	},
+	"hidden": {
+		"message": "Скрытый"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Скрывать (только на странице видео)"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Скрывать анимированные превью"
+	},
+	"hideAnnotations": {
+		"message": "Скрывать аннотации"
+	},
+	"hideCards": {
+		"message": "Скрывать карточки"
+	},
+	"hideCountryCode": {
+		"message": "Скрывать код страны"
+	},
+	"hideDate": {
+		"message": "Скрывать дату видео"
+	},
+	"hideDetailButton": {
+		"message": "Скрывать кнопку «Ещё»"
+	},
+	"hideDetails": {
+		"message": "Скрывать подробную информацию"
+	},
+	"hideEndscreen": {
+		"message": "Скрывать экран после видео"
+	},
+	"hideFeaturedContent": {
+		"message": "Скрывать рекомендации"
+	},
+	"hideFooter": {
+		"message": "Скрывать нижний колонтитул"
+	},
+	"hideGradientBottom": {
+		"message": "Скрывать кнопку градиента"
+	},
+	"hideHomePageShorts": {
+		"message": "Удалить Shorts с главной страницы"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Скрывать панель управления плеером"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Скрывать кнопки панели управления плеером"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Скрывать настройки панели управления пЛеера"
+	},
+	"hidePlaylist": {
+		"message": "Скрывать плейлисты"
+	},
+	"hideRightButtons": {
+		"message": "Скрывать кнопки (справа)"
+	},
+	"hideScrollForDetails": {
+		"message": "Скрывать «Прокрутите для подробной информации»"
+	},
+	"hideSkipOverlay": {
+		"message": "Скрывать наложение \"5 секунд\""
+	},
+	"hideThumbnailOverlay": {
+		"message": "Скрывать наложение на превью"
+	},
+	"hideThumbnails": {
+		"message": "Скрывать превью"
+	},
+	"hideViewsCount": {
+		"message": "Скрывать количество просмотров"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Скрывать кнопку голосового поиска"
+	},
+	"high": {
+		"message": "Высокий"
+	},
+	"history": {
+		"message": "История"
+	},
+	"home": {
+		"message": "Домашняя страница"
+	},
+	"hover": {
+		"message": "Показывать при наведении"
+	},
+	"hoverOnVideoPage": {
+		"message": "Показывать при наведении (только на странице видео)"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Показывать дату видео"
+	},
+	"icons": {
+		"message": "Иконки"
+	},
+	"iconsOnly": {
+		"message": "Только иконки"
+	},
+	"importSettings": {
+		"message": "Импорт настроек"
+	},
+	"improvedtubeButtons": {
+		"message": "Кнопки расширения ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Значок ImprovedTube в YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Язык ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Версия ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Улучшить логотип YouTube"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Увеличить скорость видео"
+	},
+	"increaseVolume": {
+		"message": "Увеличить громкость"
+	},
+	"indigo": {
+		"message": "Индиго"
+	},
+	"items": {
+		"message": "Пункты"
+	},
+	"language": {
+		"message": "Язык"
+	},
+	"languages": {
+		"message": "Языки"
+	},
+	"layerAnimationScale": {
+		"message": "Масштаб слоя анимации"
+	},
+	"layout": {
+		"message": "Слой"
+	},
+	"legacyYoutube": {
+		"message": "Старая версия YouTube"
+	},
+	"library": {
+		"message": "Библиотека"
+	},
+	"light": {
+		"message": "Светлый"
+	},
+	"lightBlue": {
+		"message": "Светло-синий"
+	},
+	"lightGreen": {
+		"message": "Светло-зеленый"
+	},
+	"like": {
+		"message": "Лайк"
+	},
+	"liked": {
+		"message": "Понравившиеся"
+	},
+	"likes": {
+		"message": "Лайки"
+	},
+	"lime": {
+		"message": "Лайм"
+	},
+	"limitPageWidth": {
+		"message": "Ограничивать ширину страницы"
+	},
+	"list": {
+		"message": "Список"
+	},
+	"liveChat": {
+		"message": "Live-чат"
+	},
+	"liveChatType": {
+		"message": "Тип live-чата"
+	},
+	"location": {
+		"message": "Местонахождение"
+	},
+	"loop": {
+		"message": "Зациклить"
+	},
+	"loudnessNormalization": {
+		"message": "Нормализировать громкость"
+	},
+	"low": {
+		"message": "Низкий"
+	},
+	"markWatchedVideos": {
+		"message": "Отмечать просмотренные видео"
+	},
+	"medium": {
+		"message": "Средний"
+	},
+	"mixer": {
+		"message": "Миксер"
+	},
+	"mostViewedChannels": {
+		"message": "Самые просматриваемые каналы"
+	},
+	"moveSidebarLeft": {
+		"message": "Сместить боковую панель влево"
+	},
+	"moveThumbnailsRight": {
+		"message": "Сместить превью вправо"
+	},
+	"myColors": {
+		"message": "Мои цвета"
+	},
+	"name": {
+		"message": "Имя"
+	},
+	"nativeMiniPlayer": {
+		"message": "Мини-плеер от YouTube"
+	},
+	"new": {
+		"message": "Новый"
+	},
+	"nextVideo": {
+		"message": "Следующее видео"
+	},
+	"night": {
+		"message": "Ночь"
+	},
+	"nightMode": {
+		"message": "Ночной режим"
+	},
+	"noActiveFeatures": {
+		"message": "Нет активных функций"
+	},
+	"none": {
+		"message": "Пусто"
+	},
+	"noOpenVideoTabs": {
+		"message": "Нет открытых вкладок с видео"
+	},
+	"normal": {
+		"message": "Обычный"
+	},
+	"off": {
+		"message": "Выключить"
+	},
+	"ok": {
+		"message": "Хорошо"
+	},
+	"old": {
+		"message": "Старый"
+	},
+	"onAllVideos": {
+		"message": "На всех видео"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Активен только в YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Только один плеер играет одновременно"
+	},
+	"onSubscribedChannels": {
+		"message": "Только на каналах в подписках"
+	},
+	"openPopupPlayer": {
+		"message": "Открыть видео/плейлист в новом окне"
+	},
+	"orange": {
+		"message": "Оранжевый"
+	},
+	"os": {
+		"message": "ОС"
+	},
+	"other": {
+		"message": "Другое"
+	},
+	"outline": {
+		"message": "Контур"
+	},
+	"overlay": {
+		"message": "Наложение"
+	},
+	"permissions": {
+		"message": "Разрешения"
+	},
+	"pictureInPicture": {
+		"message": "Картинка в картинке"
+	},
+	"pink": {
+		"message": "Розовый"
+	},
+	"plain": {
+		"message": "Равнина"
+	},
+	"platform": {
+		"message": "Платформа"
+	},
+	"playAllButton": {
+		"message": "Кнопка \"Играть все\""
+	},
+	"playbackSpeed": {
+		"message": "Скорость воспроизведения"
+	},
+	"player": {
+		"message": "Плеер"
+	},
+	"playerColor": {
+		"message": "Цвет плеера"
+	},
+	"playerSize": {
+		"message": "Размер плеера"
+	},
+	"playlist": {
+		"message": "Плейлист"
+	},
+	"playlists": {
+		"message": "Плейлисты"
+	},
+	"playPause": {
+		"message": "Играть / Пауза"
+	},
+	"popupPlayer": {
+		"message": "Плеер во всплывающем окне"
+	},
+	"popupWindowButtons": {
+		"message": "Добавить кнопки всплывающего окна"
+	},
+	"position": {
+		"message": "Положение"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Нажмите любую кнопку или колесо мыши"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Нажмите любую кнопку или используйте колесо мыши"
+	},
+	"previousVideo": {
+		"message": "Предыдущее видео"
+	},
+	"primaryColor": {
+		"message": "Основной цвет"
+	},
+	"purple": {
+		"message": "Фиолетовый"
+	},
+	"quality": {
+		"message": "Качество"
+	},
+	"qualityWithoutFocus": {
+		"message": "Качество при неактивном окне"
+	},
+	"raised": {
+		"message": "Поднятый"
+	},
+	"ram": {
+		"message": "ОЗУ"
+	},
+	"rateMe": {
+		"message": "Оставить отзыв"
+	},
+	"rateUs": {
+		"message": "Оцените нас"
+	},
+	"red": {
+		"message": "Красный"
+	},
+	"redDislikeButton": {
+		"message": "Сделать дизлайк красным"
+	},
+	"relatedVideos": {
+		"message": "Похожие видео"
+	},
+	"remote": {
+		"message": "Удаленное воспроизведение"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Удалять связанные результаты поиска"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Удалить карусель Shorts из результатов поиска"
+	},
+	"repeat": {
+		"message": "Повтор"
+	},
+	"report": {
+		"message": "Пожаловаться"
+	},
+	"reset": {
+		"message": "Сбросить"
+	},
+	"resetAllSettings": {
+		"message": "Сбросить все настройки"
+	},
+	"resetAllShortcuts": {
+		"message": "Сбросить все горячие клавиши"
+	},
+	"reverse": {
+		"message": "Обратный порядок"
+	},
+	"rotate": {
+		"message": "Повернуть"
+	},
+	"save": {
+		"message": "Сохранить"
+	},
+	"saveAs": {
+		"message": "Сохранить как"
+	},
+	"schedule": {
+		"message": "График"
+	},
+	"screen": {
+		"message": "Экран"
+	},
+	"screenshot": {
+		"message": "Скриншот"
+	},
+	"scrollBar": {
+		"message": "Полоса прокрутки"
+	},
+	"search": {
+		"message": "Поиск"
+	},
+	"searchBarOnly": {
+		"message": "Только поисковая строка"
+	},
+	"seekBackward10Seconds": {
+		"message": "Перемотать на 10 секунд назад"
+	},
+	"seekForward10Seconds": {
+		"message": "Перемотать на 10 секунд вперед"
+	},
+	"seekNextChapter": {
+		"message": "Следующая глава"
+	},
+	"seekPreviousChapter": {
+		"message": "Предыдущая глава"
+	},
+	"settings": {
+		"message": "Настройки"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Настройки успешно импортированы"
+	},
+	"share": {
+		"message": "Поделиться"
+	},
+	"shortcuts": {
+		"message": "Горячие клавиши"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Показывать карточки при наведении"
+	},
+	"showChannelVideosCount": {
+		"message": "Показывать количество видео на канале"
+	},
+	"showLess": {
+		"message": "Показать меньше"
+	},
+	"showMore": {
+		"message": "Показать больше"
+	},
+	"showRemainingDuration": {
+		"message": "Показать время до конца видео"
+	},
+	"showVersion": {
+		"message": "Показывать версию"
+	},
+	"shuffle": {
+		"message": "Перемешать"
+	},
+	"sidebar": {
+		"message": "Боковая панель"
+	},
+	"softwareInformation": {
+		"message": "Информация о программном обеспечении"
+	},
+	"spacebar": {
+		"message": "Пробел"
+	},
+	"squaredUserImages": {
+		"message": "Квадратные аватарки пользователей"
+	},
+	"static": {
+		"message": "Статичный"
+	},
+	"statsForNerds": {
+		"message": "Показать статистику для ботаников"
+	},
+	"step": {
+		"message": "Шаг"
+	},
+	"stop": {
+		"message": "Стоп"
+	},
+	"style": {
+		"message": "Стиль"
+	},
+	"styles": {
+		"message": "Стили"
+	},
+	"subscribe": {
+		"message": "Подписаться"
+	},
+	"subscriptions": {
+		"message": "Подписки"
+	},
+	"subtitles": {
+		"message": "Субтитры"
+	},
+	"sunset": {
+		"message": "Закат"
+	},
+	"sunsetToSunrise": {
+		"message": "От заката до рассвета"
+	},
+	"systemPeferenceDark": {
+		"message": "Предпочитаемая системой: темная"
+	},
+	"systemPeferenceLight": {
+		"message": "Предпочитаемая системой: светлая"
+	},
+	"teal": {
+		"message": "Бирюзовый"
+	},
+	"textColor": {
+		"message": "Цвет текста"
+	},
+	"themes": {
+		"message": "Темы"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Это удалит все куки"
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Это удалит все просмотренные видео"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Вы действительно хотите удалить все куки YouTube?"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Это сбросит все настройки"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Это сбросит все горячие клавиши"
+	},
+	"thumbnails": {
+		"message": "Превью"
+	},
+	"thumbnailsQuality": {
+		"message": "Качество превью"
+	},
+	"timeFrom": {
+		"message": "Время от"
+	},
+	"timeTo": {
+		"message": "Время до"
+	},
+	"todayAt": {
+		"message": "Сегодня в"
+	},
+	"toggleAutoplay": {
+		"message": "Автовоспроизведение"
+	},
+	"toggleCards": {
+		"message": "Карточки"
+	},
+	"toggleControls": {
+		"message": "Панель управления"
+	},
+	"topChat": {
+		"message": "Лучшее"
+	},
+	"trackWatchedVideos": {
+		"message": "Отслеживать просмотренные видео"
+	},
+	"trailerAutoplay": {
+		"message": "Автовоспроизведение трейлера"
+	},
+	"translations": {
+		"message": "Переводы"
+	},
+	"transparentBackground": {
+		"message": "Прозрачный фон"
+	},
+	"trending": {
+		"message": "В тренде"
+	},
+	"tryToReloadThePage": {
+		"message": "Попробуйте перезагрузить страницу"
+	},
+	"type": {
+		"message": "Тип"
+	},
+	"upNextAutoplay": {
+		"message": "Автовоспроизведение следующего видео"
+	},
+	"use24HourFormat": {
+		"message": "24-часовой формат"
+	},
+	"version": {
+		"message": "Версия"
+	},
+	"video": {
+		"message": "Видео"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Описание видео развернется, чтобы получить название категории"
+	},
+	"videoFormats": {
+		"message": "Форматы видео"
+	},
+	"videos": {
+		"message": "Видео"
+	},
+	"viewMode": {
+		"message": "Режим просмотра"
+	},
+	"volume": {
+		"message": "Громкость"
+	},
+	"watchLater": {
+		"message": "Посмотреть позже"
+	},
+	"watchTime": {
+		"message": "Время просмотра"
+	},
+	"whenPaused": {
+		"message": "При паузе"
+	},
+	"whenTabIsChanged": {
+		"message": "При смене вкладки"
+	},
+	"white": {
+		"message": "Белый"
+	},
+	"windowColor": {
+		"message": "Цвет окна"
+	},
+	"windowOpacity": {
+		"message": "Прозрачность окна"
+	},
+	"yellow": {
+		"message": "Желтый"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Верхняя панель (слева)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Верхняя панель (справа)"
+	},
+	"youtubeHomePage": {
+		"message": "Домашняя страница YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Язык YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube ограничивает качество видео до 1080p для кодека H.264"
+	}
 }

--- a/_locales/si/messages.json
+++ b/_locales/si/messages.json
@@ -1,668 +1,668 @@
 {
-    "about": {
-        "message": "අපි ගැන"
-    },
-    "accept": {
-        "message": "පිළිගන්නවා"
-    },
-    "activate": {
-        "message": "Activate කරන්න"
-    },
-    "activateCaptions": {
-        "message": "උපසිරැසි Activate කරන්න"
-    },
-    "activated": {
-        "message": "Activate කරනලදී"
-    },
-    "activatedFeatures": {
-        "message": "දැනට ඔන් කරන ලද විශේෂාංග"
-    },
-    "activateFullscreen": {
-        "message": "සම්පූර්ණ තිරය Activate කරන්න"
-    },
-    "activeFeatures": {
-        "message": "දැනට ක්‍රියාත්මක තත්වයේ පවතිය විශේෂාංග"
-    },
-    "addScrollToTop": {
-        "message": "«Scroll to top» බොත්තම ඇඩ් කරන්න"
-    },
-    "ads": {
-        "message": "වෙළද දැන්වීම් (Ads)"
-    },
-    "all": {
-        "message": "සියල්ල"
-    },
-    "allow": {
-        "message": "අවසර දෙන්න"
-    },
-    "alwaysActive": {
-        "message": "සෑම විටම ක්‍රියාත්මක වෙන"
-    },
-    "alwaysShowProgressBar": {
-        "message": "වීඩීයෝ progress bar එක සෑම විටම පෙන්වන්න"
-    },
-    "amber": {
-        "message": "කහපාටට හුරු"
-    },
-    "analyzer": {
-        "message": "විශ්ලේෂක"
-    },
-    "appearance": {
-        "message": "පෙනුම"
-    },
-    "audio": {
-        "message": "ශබ්ද"
-    },
-    "audioFormats": {
-        "message": "ශබ්ද වල ෆෝමැට් එක"
-    },
-    "auto": {
-        "message": "ස්වයංක්‍රීය"
-    },
-    "autoFullscreen": {
-        "message": "ස්වයංක්‍රීය සම්පූර්ණ තිරය"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "ටැබ් අතර මාරුවෙද්දි වීඩීයෝ එක pause වන ලෙස සැකසීම"
-    },
-    "avoidAv1": {
-        "message": "AV1 මගහරින්න"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "AV1, VP8, VP9 මගහරින්න"
-    },
-    "avoidAv1Vp9": {
-        "message": "AV1, VP9 මගහරින්න"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "පුලුවන් විට cpu හරහා render වීම නවත්වන්න"
-    },
-    "backgroundColor": {
-        "message": "පසුබිමේ පාට"
-    },
-    "backgroundOpacity": {
-        "message": "පසුබිමේ opacity එක"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "System colors මත පදනම්ව"
-    },
-    "belowPlayer": {
-        "message": "player එකට යටින්"
-    },
-    "blockAll": {
-        "message": "සියල්ල Block කරන්න"
-    },
-    "blockAv1": {
-        "message": "AV1 බ්ලොක් කරන්න"
-    },
-    "blockH264": {
-        "message": "H.264 බ්ලොක් කරන්න"
-    },
-    "blocklist": {
-        "message": "Blocklist එක"
-    },
-    "blockMusic": {
-        "message": "Music එක බ්ලොක් කරන්න"
-    },
-    "blockVp8": {
-        "message": "VP8 බ්ලොක් කරන්න"
-    },
-    "blockVp9": {
-        "message": "VP9 බ්ලොක් කරන්න"
-    },
-    "blue": {
-        "message": "නිල්"
-    },
-    "brown": {
-        "message": "දුඹුරු"
-    },
-    "browser": {
-        "message": "බ්‍රවුසරය"
-    },
-    "browserVersion": {
-        "message": "වෙබ් බ්‍රවුසරයේ වර්ශන් එක"
-    },
-    "bubbles": {
-        "message": "බුබුලු"
-    },
-    "bug": {
-        "message": "දෝෂය"
-    },
-    "buttons": {
-        "message": "බටන්"
-    },
-    "categories": {
-        "message": "වර්ග"
-    },
-    "channel": {
-        "message": "චැනල් එක"
-    },
-    "channels": {
-        "message": "චැනල්"
-    },
-    "clipboard": {
-        "message": "Clipboard එක"
-    },
-    "collapsed": {
-        "message": "හකුලන ලදී"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Subscribe කරන කොටස හකුලන්න"
-    },
-    "confirmationBeforeClosing": {
-        "message": "වසා දැමීමට පෙර confirm කිරීම"
-    },
-    "custom": {
-        "message": "තමන්ට කැමති විදිහට"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "playback ස්පීඩ් එක අඩුකරන්න"
-    },
-    "decreaseVolume": {
-        "message": "volume එක අඩුකරන්න"
-    },
-    "deepOrange": {
-        "message": "තද තැඹිලි පාට"
-    },
-    "deepPurple": {
-        "message": "තද දම් පාට"
-    },
-    "default": {
-        "message": "සාමාන්‍ය"
-    },
-    "defaultChannelTab": {
-        "message": "සාමාන්‍ය චැනල් tab එක"
-    },
-    "defaultContentCountry": {
-        "message": "සාමාන්‍ය content country එක"
-    },
-    "deleteWatchedVideos": {
-        "message": "බලපු වීඩියෝ delete කරන්න"
-    },
-    "deleteYoutubeCookies": {
-        "message": "YouTube cookies delete කරන්න"
-    },
-    "depressed": {
-        "message": "මානසික අවපීඩනය"
-    },
-    "description": {
-        "message": "Description එක"
-    },
-    "desert": {
-        "message": "අතුරුපස"
-    },
-    "details": {
-        "message": "විස්තර"
-    },
-    "device": {
-        "message": "Device එක"
-    },
-    "dim": {
-        "message": "කිසිවක් නැත"
-    },
-    "donate": {
-        "message": "Donate කරන්න"
-    },
-    "doNotChange": {
-        "message": "වෙනස් කරන්න එපා"
-    },
-    "draggable": {
-        "message": "Drag කළ හැකි"
-    },
-    "dropShadow": {
-        "message": "හෙවනැල්ල"
-    },
-    "email": {
-        "message": "Email එක"
-    },
-    "empty": {
-        "message": "හිස්"
-    },
-    "enabledForced": {
-        "message": "Enabled (බලහත්කාරයෙන්)"
-    },
-    "expanded": {
-        "message": "පුළුල් කර ඇත"
-    },
-    "exportSettings": {
-        "message": "Settings Export කරන්න"
-    },
-    "font": {
-        "message": "ෆොන්ට් එක"
-    },
-    "fontColor": {
-        "message": "ෆොන්ට් එකේ පාට"
-    },
-    "fontOpacity": {
-        "message": "Font එකේ opacity (විනිවිද පෙනෙන බව) එක "
-    },
-    "fontSize": {
-        "message": "Font එකේ size එක"
-    },
-    "footer": {
-        "message": "Footer එක"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "වීඩියෝව මුල සිට බලහත්කාරයෙන් play කරන්න"
-    },
-    "foundABug": {
-        "message": "දෝෂයක් හම්බුනාද ඔයාට?"
-    },
-    "general": {
-        "message": "සාමාන්‍ය"
-    },
-    "github": {
-        "message": "ගිට්හබ්"
-    },
-    "googleApiKey": {
-        "message": "Google API key එක"
-    },
-    "goToSearchBox": {
-        "message": "Search box එකට යන්න"
-    },
-    "gpu": {
-        "message": "GPU එක"
-    },
-    "green": {
-        "message": "කොළ"
-    },
-    "header": {
-        "message": "Header එක"
-    },
-    "hidden": {
-        "message": "සැඟවුණු"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Animate කරපු thumbnail සඟවන්න"
-    },
-    "hideAnnotations": {
-        "message": "Annotations සඟවන්න"
-    },
-    "hideCards": {
-        "message": "Cards සඟවන්න"
-    },
-    "hideCountryCode": {
-        "message": "Country code එක හංගන්න"
-    },
-    "hideDate": {
-        "message": "Date එක හංගන්න"
-    },
-    "hideDetails": {
-        "message": "Details හංගන්න"
-    },
-    "hideEndscreen": {
-        "message": "Endscreen එක හංගන්න"
-    },
-    "hideFeaturedContent": {
-        "message": "Featured content හංගන්න"
-    },
-    "hideFooter": {
-        "message": "Footer එක හංගන්න"
-    },
-    "hideGradientBottom": {
-        "message": "Player-bar එක වටේ තියෙන shadow එක සගවන්න"
-    },
-    "hideHomePageShorts": {
-        "message": "මුල් පිටුවේ ෂෝට් ඉවත් කරනවා"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Player controls bar එක සඟවන්න"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Player controls bar එකේ තියෙන button සඟවන්න"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Player controls options සඟවන්න"
-    },
-    "hidePlaylist": {
-        "message": "Playlist සඟවන්න"
-    },
-    "hideRightButtons": {
-        "message": "දකුණු පැත්තෙ තියෙන button සඟවන්න"
-    },
-    "hideScrollForDetails": {
-        "message": "«Scroll for details» සඟවන්න"
-    },
-    "hideSkipOverlay": {
-        "message": "5 seconds skip animation එක සඟවන්න"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Thumbnail මත තිබෙන button සඟවන්න"
-    },
-    "hideThumbnails": {
-        "message": "Thumbnail සඟවන්න"
-    },
-    "hideViewsCount": {
-        "message": "Views count එක සඟවන්න"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Voice search button එක සඟවන්න"
-    },
-    "hover": {
-        "message": "Hover (මවුස් පොයින්ටරය තබාගෙන සිටින විට)"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "වීඩියෝ එක අප්ලෝඩ් කරල කොච්චර කල් වෙනවද"
-    },
-    "iconsOnly": {
-        "message": "Icons පමණයි"
-    },
-    "importSettings": {
-        "message": "Backup කරපු settings import කරන්න"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Playback speed එක අඩුකරන්න."
-    },
-    "increaseVolume": {
-        "message": "සද්දෙ අඩුකරන්න"
-    },
-    "indigo": {
-        "message": "ඉන්ඩිගෝ"
-    },
-    "language": {
-        "message": "භාෂාව"
-    },
-    "languages": {
-        "message": "භාෂාවන්"
-    },
-    "limitPageWidth": {
-        "message": "Page එකේ පළල සීමා කරන්න"
-    },
-    "list": {
-        "message": "List එක"
-    },
-    "liveChat": {
-        "message": "Live chat එක"
-    },
-    "liveChatType": {
-        "message": "Live chat type එක තෝරන්න"
-    },
-    "location": {
-        "message": "Location එක"
-    },
-    "loop": {
-        "message": "Loop (නැවත නැවත play වෙන ලෙස සැකසීම)"
-    },
-    "loudnessNormalization": {
-        "message": "Loudness සාමාන්‍යකරණය"
-    },
-    "markWatchedVideos": {
-        "message": "කලින් බලපු වීඩියෝ Mark කරන්න"
-    },
-    "mixer": {
-        "message": "Mixer එක"
-    },
-    "moveSidebarLeft": {
-        "message": "Sidebar එක වම් පැත්තට යවන්න"
-    },
-    "moveThumbnailsRight": {
-        "message": "Thumbnail දකුණු පැත්තට කරන්න"
-    },
-    "name": {
-        "message": "නම"
-    },
-    "nativeMiniPlayer": {
-        "message": "යූටූබ් වලටම ආවේණික mini player එක"
-    },
-    "nextVideo": {
-        "message": "මීළඟ video එක"
-    },
-    "noActiveFeatures": {
-        "message": "ක්‍රියාකාරීව තිබෙන Features නොමැත"
-    },
-    "none": {
-        "message": "None (කිසිවක් නැහැ)"
-    },
-    "noOpenVideoTabs": {
-        "message": "Open කරපු වීඩියෝ ටැබ් නැත"
-    },
-    "normal": {
-        "message": "සාමාන්‍ය"
-    },
-    "old": {
-        "message": "පරණ"
-    },
-    "onAllVideos": {
-        "message": "සියලුම වීඩියෝ මත"
-    },
-    "onSubscribedChannels": {
-        "message": "Subscribe කරපු චැනල් මත"
-    },
-    "openPopupPlayer": {
-        "message": "video හෝ playlist new window එකකින් open කරන්න"
-    },
-    "orange": {
-        "message": "තැඹිලි පාට"
-    },
-    "os": {
-        "message": "OS එක (මෙහෙයුම් පද්ධතිය)"
-    },
-    "other": {
-        "message": "අනෙකුත්"
-    },
-    "outline": {
-        "message": "Outline එක"
-    },
-    "permissions": {
-        "message": "අවසරයන්"
-    },
-    "pink": {
-        "message": "රෝස පාට"
-    },
-    "platform": {
-        "message": "Platform එක"
-    },
-    "playbackSpeed": {
-        "message": "Playback speed එක"
-    },
-    "player": {
-        "message": "Player එක"
-    },
-    "playerColor": {
-        "message": "Player එකේ පැහැය"
-    },
-    "playerSize": {
-        "message": "Player එකේ ප්‍රමාණය"
-    },
-    "playlist": {
-        "message": "Playlist එක"
-    },
-    "playPause": {
-        "message": "Play කරන්න / Pause කරන්න"
-    },
-    "position": {
-        "message": "Position එක"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "ඕනෑම key එකක් හෝ mouse wheel එක යොදාගන්න."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "ඕනෑම key එකක් හෝ mouse wheel එක යොදාගන්න"
-    },
-    "previousVideo": {
-        "message": "කලින් video එක"
-    },
-    "primaryColor": {
-        "message": "Primary color එක"
-    },
-    "purple": {
-        "message": "දම් පාට"
-    },
-    "quality": {
-        "message": "Quality එක"
-    },
-    "ram": {
-        "message": "RAM එක"
-    },
-    "rateMe": {
-        "message": "මාව Rate කරන්න"
-    },
-    "rateUs": {
-        "message": "අපිව Rate කරන්න"
-    },
-    "redDislikeButton": {
-        "message": "Dislike button එක රතුපාටින් පෙන්වන්න."
-    },
-    "removeRelatedSearchResults": {
-        "message": "Related search results කොටස ඉවත් කරන්න"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "සෙවා ප්‍රතිඵල සෙයානක් ඉවත් කරන්න"
-    },
-    "repeat": {
-        "message": "Repeat කරන්න"
-    },
-    "reset": {
-        "message": "Reset කරන්න"
-    },
-    "resetAllSettings": {
-        "message": "සියලුම settings reset කරන්න"
-    },
-    "resetAllShortcuts": {
-        "message": "සියලුම shortcuts reset කරන්න"
-    },
-    "reverse": {
-        "message": "ආපස්සට ගන්න (Reverse)"
-    },
-    "rotate": {
-        "message": "Rotate කරන්න"
-    },
-    "save": {
-        "message": "Save කරන්න"
-    },
-    "screenshot": {
-        "message": "Screenshot ලබාගැනීම"
-    },
-    "scrollBar": {
-        "message": "Scroll Bar එක"
-    },
-    "sd": {
-        "message": "SD කොලිටිය (Data අඩුවෙන් වැයවෙන)"
-    },
-    "searchBarOnly": {
-        "message": "Search bar එක පමණයි"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "සාර්ථකව settings import කරනලදී."
-    },
-    "showChannelVideosCount": {
-        "message": "Channel එකේ තියෙන වීඩියෝ ගාන පෙන්නන්න"
-    },
-    "shuffle": {
-        "message": "Shuffle කරන්න"
-    },
-    "sidebar": {
-        "message": "Sidebar එක"
-    },
-    "spacebar": {
-        "message": "Spacebar එක"
-    },
-    "static": {
-        "message": "ස්ථාවර"
-    },
-    "statsForNerds": {
-        "message": "Show Stats for Nerds (මෝඩ පුද්ගලයන්ගේ තොරතුරු පෙන්වන්න)"
-    },
-    "stop": {
-        "message": "නවත්වන්න"
-    },
-    "style": {
-        "message": "Style එක"
-    },
-    "styles": {
-        "message": "Style වර්ග"
-    },
-    "subtitles": {
-        "message": "උපසිරැසි"
-    },
-    "sunset": {
-        "message": "Sunset (ඉරබහින වෙලාව)"
-    },
-    "sunsetToSunrise": {
-        "message": "Sunset to sunrise (සවස සිට උදෑසන දක්වා)"
-    },
-    "textColor": {
-        "message": "Text color එක"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "සියලුම cookies ඉවත් කරයි."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "නරඹන ලද වීඩියෝ ඉවත් කරයි."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "සියලුම YouTube හි cookies ඉවත් කරයි"
-    },
-    "thisWillResetAllSettings": {
-        "message": "සියලුම settings reset කරයි"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "සියලුම shortcut reset කරයි"
-    },
-    "thumbnailsQuality": {
-        "message": "Thumbnail වල කොලිටිය"
-    },
-    "topChat": {
-        "message": "Top chat එක"
-    },
-    "trackWatchedVideos": {
-        "message": "බලපු වීඩියෝ track කරන්න"
-    },
-    "trailerAutoplay": {
-        "message": "Trailer එක autoplay කරන්න"
-    },
-    "translations": {
-        "message": "Translations (පරිවර්තන)"
-    },
-    "transparentBackground": {
-        "message": "විනිවිද පෙනෙන Background එක"
-    },
-    "tryToReloadThePage": {
-        "message": "Page එක reload කරල බලන්න(කීබෝඩ් එකේ F5 ඔබන්න)"
-    },
-    "upNextAutoplay": {
-        "message": "ඊලඟ වීඩීයෝ එක Autoplay කරන්න"
-    },
-    "use24HourFormat": {
-        "message": "පැය-24 format එක භාවිත කරන්න"
-    },
-    "video": {
-        "message": "වීඩීයෝව"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Category එකේ නම ලබාගැනීමට description එක expand කෙරේ"
-    },
-    "videos": {
-        "message": "වීඩීයෝ"
-    },
-    "volume": {
-        "message": "Volume එක"
-    },
-    "watchTime": {
-        "message": "Watch time එක"
-    },
-    "whenTabIsChanged": {
-        "message": "Tab එක වෙනස් කළ විට"
-    },
-    "white": {
-        "message": "සුදු පාට"
-    },
-    "windowColor": {
-        "message": "Window එකේ වර්ණය"
-    },
-    "windowOpacity": {
-        "message": "Window එකේ opacity එක"
-    },
-    "yellow": {
-        "message": "කහ පාට"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube home page එක"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube language එක"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "h.264 codec සඳහා වීඩියෝ කොලිටිය 1080p දක්වා සීමා කරයි"
-    }
+	"about": {
+		"message": "අපි ගැන"
+	},
+	"accept": {
+		"message": "පිළිගන්නවා"
+	},
+	"activate": {
+		"message": "Activate කරන්න"
+	},
+	"activateCaptions": {
+		"message": "උපසිරැසි Activate කරන්න"
+	},
+	"activated": {
+		"message": "Activate කරනලදී"
+	},
+	"activatedFeatures": {
+		"message": "දැනට ඔන් කරන ලද විශේෂාංග"
+	},
+	"activateFullscreen": {
+		"message": "සම්පූර්ණ තිරය Activate කරන්න"
+	},
+	"activeFeatures": {
+		"message": "දැනට ක්‍රියාත්මක තත්වයේ පවතිය විශේෂාංග"
+	},
+	"addScrollToTop": {
+		"message": "«Scroll to top» බොත්තම ඇඩ් කරන්න"
+	},
+	"ads": {
+		"message": "වෙළද දැන්වීම් (Ads)"
+	},
+	"all": {
+		"message": "සියල්ල"
+	},
+	"allow": {
+		"message": "අවසර දෙන්න"
+	},
+	"alwaysActive": {
+		"message": "සෑම විටම ක්‍රියාත්මක වෙන"
+	},
+	"alwaysShowProgressBar": {
+		"message": "වීඩීයෝ progress bar එක සෑම විටම පෙන්වන්න"
+	},
+	"amber": {
+		"message": "කහපාටට හුරු"
+	},
+	"analyzer": {
+		"message": "විශ්ලේෂක"
+	},
+	"appearance": {
+		"message": "පෙනුම"
+	},
+	"audio": {
+		"message": "ශබ්ද"
+	},
+	"audioFormats": {
+		"message": "ශබ්ද වල ෆෝමැට් එක"
+	},
+	"auto": {
+		"message": "ස්වයංක්‍රීය"
+	},
+	"autoFullscreen": {
+		"message": "ස්වයංක්‍රීය සම්පූර්ණ තිරය"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "ටැබ් අතර මාරුවෙද්දි වීඩීයෝ එක pause වන ලෙස සැකසීම"
+	},
+	"avoidAv1": {
+		"message": "AV1 මගහරින්න"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "AV1, VP8, VP9 මගහරින්න"
+	},
+	"avoidAv1Vp9": {
+		"message": "AV1, VP9 මගහරින්න"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "පුලුවන් විට cpu හරහා render වීම නවත්වන්න"
+	},
+	"backgroundColor": {
+		"message": "පසුබිමේ පාට"
+	},
+	"backgroundOpacity": {
+		"message": "පසුබිමේ opacity එක"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "System colors මත පදනම්ව"
+	},
+	"belowPlayer": {
+		"message": "player එකට යටින්"
+	},
+	"blockAll": {
+		"message": "සියල්ල Block කරන්න"
+	},
+	"blockAv1": {
+		"message": "AV1 බ්ලොක් කරන්න"
+	},
+	"blockH264": {
+		"message": "H.264 බ්ලොක් කරන්න"
+	},
+	"blocklist": {
+		"message": "Blocklist එක"
+	},
+	"blockMusic": {
+		"message": "Music එක බ්ලොක් කරන්න"
+	},
+	"blockVp8": {
+		"message": "VP8 බ්ලොක් කරන්න"
+	},
+	"blockVp9": {
+		"message": "VP9 බ්ලොක් කරන්න"
+	},
+	"blue": {
+		"message": "නිල්"
+	},
+	"brown": {
+		"message": "දුඹුරු"
+	},
+	"browser": {
+		"message": "බ්‍රවුසරය"
+	},
+	"browserVersion": {
+		"message": "වෙබ් බ්‍රවුසරයේ වර්ශන් එක"
+	},
+	"bubbles": {
+		"message": "බුබුලු"
+	},
+	"bug": {
+		"message": "දෝෂය"
+	},
+	"buttons": {
+		"message": "බටන්"
+	},
+	"categories": {
+		"message": "වර්ග"
+	},
+	"channel": {
+		"message": "චැනල් එක"
+	},
+	"channels": {
+		"message": "චැනල්"
+	},
+	"clipboard": {
+		"message": "Clipboard එක"
+	},
+	"collapsed": {
+		"message": "හකුලන ලදී"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Subscribe කරන කොටස හකුලන්න"
+	},
+	"confirmationBeforeClosing": {
+		"message": "වසා දැමීමට පෙර confirm කිරීම"
+	},
+	"custom": {
+		"message": "තමන්ට කැමති විදිහට"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "playback ස්පීඩ් එක අඩුකරන්න"
+	},
+	"decreaseVolume": {
+		"message": "volume එක අඩුකරන්න"
+	},
+	"deepOrange": {
+		"message": "තද තැඹිලි පාට"
+	},
+	"deepPurple": {
+		"message": "තද දම් පාට"
+	},
+	"default": {
+		"message": "සාමාන්‍ය"
+	},
+	"defaultChannelTab": {
+		"message": "සාමාන්‍ය චැනල් tab එක"
+	},
+	"defaultContentCountry": {
+		"message": "සාමාන්‍ය content country එක"
+	},
+	"deleteWatchedVideos": {
+		"message": "බලපු වීඩියෝ delete කරන්න"
+	},
+	"deleteYoutubeCookies": {
+		"message": "YouTube cookies delete කරන්න"
+	},
+	"depressed": {
+		"message": "මානසික අවපීඩනය"
+	},
+	"description": {
+		"message": "Description එක"
+	},
+	"desert": {
+		"message": "අතුරුපස"
+	},
+	"details": {
+		"message": "විස්තර"
+	},
+	"device": {
+		"message": "Device එක"
+	},
+	"dim": {
+		"message": "කිසිවක් නැත"
+	},
+	"donate": {
+		"message": "Donate කරන්න"
+	},
+	"doNotChange": {
+		"message": "වෙනස් කරන්න එපා"
+	},
+	"draggable": {
+		"message": "Drag කළ හැකි"
+	},
+	"dropShadow": {
+		"message": "හෙවනැල්ල"
+	},
+	"email": {
+		"message": "Email එක"
+	},
+	"empty": {
+		"message": "හිස්"
+	},
+	"enabledForced": {
+		"message": "Enabled (බලහත්කාරයෙන්)"
+	},
+	"expanded": {
+		"message": "පුළුල් කර ඇත"
+	},
+	"exportSettings": {
+		"message": "Settings Export කරන්න"
+	},
+	"font": {
+		"message": "ෆොන්ට් එක"
+	},
+	"fontColor": {
+		"message": "ෆොන්ට් එකේ පාට"
+	},
+	"fontOpacity": {
+		"message": "Font එකේ opacity (විනිවිද පෙනෙන බව) එක"
+	},
+	"fontSize": {
+		"message": "Font එකේ size එක"
+	},
+	"footer": {
+		"message": "Footer එක"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "වීඩියෝව මුල සිට බලහත්කාරයෙන් play කරන්න"
+	},
+	"foundABug": {
+		"message": "දෝෂයක් හම්බුනාද ඔයාට?"
+	},
+	"general": {
+		"message": "සාමාන්‍ය"
+	},
+	"github": {
+		"message": "ගිට්හබ්"
+	},
+	"googleApiKey": {
+		"message": "Google API key එක"
+	},
+	"goToSearchBox": {
+		"message": "Search box එකට යන්න"
+	},
+	"gpu": {
+		"message": "GPU එක"
+	},
+	"green": {
+		"message": "කොළ"
+	},
+	"header": {
+		"message": "Header එක"
+	},
+	"hidden": {
+		"message": "සැඟවුණු"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Animate කරපු thumbnail සඟවන්න"
+	},
+	"hideAnnotations": {
+		"message": "Annotations සඟවන්න"
+	},
+	"hideCards": {
+		"message": "Cards සඟවන්න"
+	},
+	"hideCountryCode": {
+		"message": "Country code එක හංගන්න"
+	},
+	"hideDate": {
+		"message": "Date එක හංගන්න"
+	},
+	"hideDetails": {
+		"message": "Details හංගන්න"
+	},
+	"hideEndscreen": {
+		"message": "Endscreen එක හංගන්න"
+	},
+	"hideFeaturedContent": {
+		"message": "Featured content හංගන්න"
+	},
+	"hideFooter": {
+		"message": "Footer එක හංගන්න"
+	},
+	"hideGradientBottom": {
+		"message": "Player-bar එක වටේ තියෙන shadow එක සගවන්න"
+	},
+	"hideHomePageShorts": {
+		"message": "මුල් පිටුවේ ෂෝට් ඉවත් කරනවා"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Player controls bar එක සඟවන්න"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Player controls bar එකේ තියෙන button සඟවන්න"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Player controls options සඟවන්න"
+	},
+	"hidePlaylist": {
+		"message": "Playlist සඟවන්න"
+	},
+	"hideRightButtons": {
+		"message": "දකුණු පැත්තෙ තියෙන button සඟවන්න"
+	},
+	"hideScrollForDetails": {
+		"message": "«Scroll for details» සඟවන්න"
+	},
+	"hideSkipOverlay": {
+		"message": "5 seconds skip animation එක සඟවන්න"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Thumbnail මත තිබෙන button සඟවන්න"
+	},
+	"hideThumbnails": {
+		"message": "Thumbnail සඟවන්න"
+	},
+	"hideViewsCount": {
+		"message": "Views count එක සඟවන්න"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Voice search button එක සඟවන්න"
+	},
+	"hover": {
+		"message": "Hover (මවුස් පොයින්ටරය තබාගෙන සිටින විට)"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "වීඩියෝ එක අප්ලෝඩ් කරල කොච්චර කල් වෙනවද"
+	},
+	"iconsOnly": {
+		"message": "Icons පමණයි"
+	},
+	"importSettings": {
+		"message": "Backup කරපු settings import කරන්න"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Playback speed එක අඩුකරන්න."
+	},
+	"increaseVolume": {
+		"message": "සද්දෙ අඩුකරන්න"
+	},
+	"indigo": {
+		"message": "ඉන්ඩිගෝ"
+	},
+	"language": {
+		"message": "භාෂාව"
+	},
+	"languages": {
+		"message": "භාෂාවන්"
+	},
+	"limitPageWidth": {
+		"message": "Page එකේ පළල සීමා කරන්න"
+	},
+	"list": {
+		"message": "List එක"
+	},
+	"liveChat": {
+		"message": "Live chat එක"
+	},
+	"liveChatType": {
+		"message": "Live chat type එක තෝරන්න"
+	},
+	"location": {
+		"message": "Location එක"
+	},
+	"loop": {
+		"message": "Loop (නැවත නැවත play වෙන ලෙස සැකසීම)"
+	},
+	"loudnessNormalization": {
+		"message": "Loudness සාමාන්‍යකරණය"
+	},
+	"markWatchedVideos": {
+		"message": "කලින් බලපු වීඩියෝ Mark කරන්න"
+	},
+	"mixer": {
+		"message": "Mixer එක"
+	},
+	"moveSidebarLeft": {
+		"message": "Sidebar එක වම් පැත්තට යවන්න"
+	},
+	"moveThumbnailsRight": {
+		"message": "Thumbnail දකුණු පැත්තට කරන්න"
+	},
+	"name": {
+		"message": "නම"
+	},
+	"nativeMiniPlayer": {
+		"message": "යූටූබ් වලටම ආවේණික mini player එක"
+	},
+	"nextVideo": {
+		"message": "මීළඟ video එක"
+	},
+	"noActiveFeatures": {
+		"message": "ක්‍රියාකාරීව තිබෙන Features නොමැත"
+	},
+	"none": {
+		"message": "None (කිසිවක් නැහැ)"
+	},
+	"noOpenVideoTabs": {
+		"message": "Open කරපු වීඩියෝ ටැබ් නැත"
+	},
+	"normal": {
+		"message": "සාමාන්‍ය"
+	},
+	"old": {
+		"message": "පරණ"
+	},
+	"onAllVideos": {
+		"message": "සියලුම වීඩියෝ මත"
+	},
+	"onSubscribedChannels": {
+		"message": "Subscribe කරපු චැනල් මත"
+	},
+	"openPopupPlayer": {
+		"message": "video හෝ playlist new window එකකින් open කරන්න"
+	},
+	"orange": {
+		"message": "තැඹිලි පාට"
+	},
+	"os": {
+		"message": "OS එක (මෙහෙයුම් පද්ධතිය)"
+	},
+	"other": {
+		"message": "අනෙකුත්"
+	},
+	"outline": {
+		"message": "Outline එක"
+	},
+	"permissions": {
+		"message": "අවසරයන්"
+	},
+	"pink": {
+		"message": "රෝස පාට"
+	},
+	"platform": {
+		"message": "Platform එක"
+	},
+	"playbackSpeed": {
+		"message": "Playback speed එක"
+	},
+	"player": {
+		"message": "Player එක"
+	},
+	"playerColor": {
+		"message": "Player එකේ පැහැය"
+	},
+	"playerSize": {
+		"message": "Player එකේ ප්‍රමාණය"
+	},
+	"playlist": {
+		"message": "Playlist එක"
+	},
+	"playPause": {
+		"message": "Play කරන්න / Pause කරන්න"
+	},
+	"position": {
+		"message": "Position එක"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "ඕනෑම key එකක් හෝ mouse wheel එක යොදාගන්න."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "ඕනෑම key එකක් හෝ mouse wheel එක යොදාගන්න"
+	},
+	"previousVideo": {
+		"message": "කලින් video එක"
+	},
+	"primaryColor": {
+		"message": "Primary color එක"
+	},
+	"purple": {
+		"message": "දම් පාට"
+	},
+	"quality": {
+		"message": "Quality එක"
+	},
+	"ram": {
+		"message": "RAM එක"
+	},
+	"rateMe": {
+		"message": "මාව Rate කරන්න"
+	},
+	"rateUs": {
+		"message": "අපිව Rate කරන්න"
+	},
+	"redDislikeButton": {
+		"message": "Dislike button එක රතුපාටින් පෙන්වන්න."
+	},
+	"removeRelatedSearchResults": {
+		"message": "Related search results කොටස ඉවත් කරන්න"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "සෙවා ප්‍රතිඵල සෙයානක් ඉවත් කරන්න"
+	},
+	"repeat": {
+		"message": "Repeat කරන්න"
+	},
+	"reset": {
+		"message": "Reset කරන්න"
+	},
+	"resetAllSettings": {
+		"message": "සියලුම settings reset කරන්න"
+	},
+	"resetAllShortcuts": {
+		"message": "සියලුම shortcuts reset කරන්න"
+	},
+	"reverse": {
+		"message": "ආපස්සට ගන්න (Reverse)"
+	},
+	"rotate": {
+		"message": "Rotate කරන්න"
+	},
+	"save": {
+		"message": "Save කරන්න"
+	},
+	"screenshot": {
+		"message": "Screenshot ලබාගැනීම"
+	},
+	"scrollBar": {
+		"message": "Scroll Bar එක"
+	},
+	"sd": {
+		"message": "SD කොලිටිය (Data අඩුවෙන් වැයවෙන)"
+	},
+	"searchBarOnly": {
+		"message": "Search bar එක පමණයි"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "සාර්ථකව settings import කරනලදී."
+	},
+	"showChannelVideosCount": {
+		"message": "Channel එකේ තියෙන වීඩියෝ ගාන පෙන්නන්න"
+	},
+	"shuffle": {
+		"message": "Shuffle කරන්න"
+	},
+	"sidebar": {
+		"message": "Sidebar එක"
+	},
+	"spacebar": {
+		"message": "Spacebar එක"
+	},
+	"static": {
+		"message": "ස්ථාවර"
+	},
+	"statsForNerds": {
+		"message": "Show Stats for Nerds (මෝඩ පුද්ගලයන්ගේ තොරතුරු පෙන්වන්න)"
+	},
+	"stop": {
+		"message": "නවත්වන්න"
+	},
+	"style": {
+		"message": "Style එක"
+	},
+	"styles": {
+		"message": "Style වර්ග"
+	},
+	"subtitles": {
+		"message": "උපසිරැසි"
+	},
+	"sunset": {
+		"message": "Sunset (ඉරබහින වෙලාව)"
+	},
+	"sunsetToSunrise": {
+		"message": "Sunset to sunrise (සවස සිට උදෑසන දක්වා)"
+	},
+	"textColor": {
+		"message": "Text color එක"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "සියලුම cookies ඉවත් කරයි."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "නරඹන ලද වීඩියෝ ඉවත් කරයි."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "සියලුම YouTube හි cookies ඉවත් කරයි"
+	},
+	"thisWillResetAllSettings": {
+		"message": "සියලුම settings reset කරයි"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "සියලුම shortcut reset කරයි"
+	},
+	"thumbnailsQuality": {
+		"message": "Thumbnail වල කොලිටිය"
+	},
+	"topChat": {
+		"message": "Top chat එක"
+	},
+	"trackWatchedVideos": {
+		"message": "බලපු වීඩියෝ track කරන්න"
+	},
+	"trailerAutoplay": {
+		"message": "Trailer එක autoplay කරන්න"
+	},
+	"translations": {
+		"message": "Translations (පරිවර්තන)"
+	},
+	"transparentBackground": {
+		"message": "විනිවිද පෙනෙන Background එක"
+	},
+	"tryToReloadThePage": {
+		"message": "Page එක reload කරල බලන්න(කීබෝඩ් එකේ F5 ඔබන්න)"
+	},
+	"upNextAutoplay": {
+		"message": "ඊලඟ වීඩීයෝ එක Autoplay කරන්න"
+	},
+	"use24HourFormat": {
+		"message": "පැය-24 format එක භාවිත කරන්න"
+	},
+	"video": {
+		"message": "වීඩීයෝව"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Category එකේ නම ලබාගැනීමට description එක expand කෙරේ"
+	},
+	"videos": {
+		"message": "වීඩීයෝ"
+	},
+	"volume": {
+		"message": "Volume එක"
+	},
+	"watchTime": {
+		"message": "Watch time එක"
+	},
+	"whenTabIsChanged": {
+		"message": "Tab එක වෙනස් කළ විට"
+	},
+	"white": {
+		"message": "සුදු පාට"
+	},
+	"windowColor": {
+		"message": "Window එකේ වර්ණය"
+	},
+	"windowOpacity": {
+		"message": "Window එකේ opacity එක"
+	},
+	"yellow": {
+		"message": "කහ පාට"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube home page එක"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube language එක"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "h.264 codec සඳහා වීඩියෝ කොලිටිය 1080p දක්වා සීමා කරයි"
+	}
 }

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -1,740 +1,731 @@
 {
-    "about": {
-        "message": "O"
-    },
-    "accept": {
-        "message": "Prijať"
-    },
-    "activate": {
-        "message": "Aktivovať"
-    },
-    "activateCaptions": {
-        "message": "Aktivovať titulky"
-    },
-    "activated": {
-        "message": "Aktivované"
-    },
-    "activatedFeatures": {
-        "message": "Aktivované fukncie"
-    },
-    "activateFullscreen": {
-        "message": "Aktivovať zobrazenie na celú obrazovku"
-    },
-    "activeFeatures": {
-        "message": "Aktívne funkcie"
-    },
-    "addScrollToTop": {
-        "message": "Prejdite «Vrátiť sa na začiatok»"
-    },
-    "ads": {
-        "message": "Reklamy"
-    },
-    "all": {
-        "message": "Všetko"
-    },
-    "allow": {
-        "message": "Povoliť"
-    },
-    "alwaysActive": {
-        "message": "Vždy aktívne"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Vždy zobrazovať ukazateľ priebehu"
-    },
-    "amber": {
-        "message": "Ambra"
-    },
-    "analyzer": {
-        "message": "Analyzátor"
-    },
-    "appearance": {
-        "message": "Vzhľad"
-    },
-    "audio": {
-        "message": "Zvuk"
-    },
-    "audioFormats": {
-        "message": "Formát zvuku"
-    },
-    "auto": {
-        "message": "Automaticky"
-    },
-    "autoFullscreen": {
-        "message": "Automaticky-fullscreen"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Automatické pozastavenie pri prepínaní kariet"
-    },
-    "autoplay": {
-        "message": "Automatické prehrávanie"
-    },
-    "backupAndReset": {
-        "message": "Zálohovanie & Obnova"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Nastavené podľa farby systému"
-    },
-    "belowPlayer": {
-        "message": "Pod prehrávačom"
-    },
-    "black": {
-        "message": "Čierna"
-    },
-    "blockAll": {
-        "message": "Zablokovať všetko"
-    },
-    "blue": {
-        "message": "Modrá"
-    },
-    "blueGray": {
-        "message": "Šedo-modrá"
-    },
-    "bluelight": {
-        "message": "Modré svetlo"
-    },
-    "brown": {
-        "message": "Hnedá"
-    },
-    "browser": {
-        "message": "Prehliadac"
-    },
-    "browserVersion": {
-        "message": "Verzie prehliadača"
-    },
-    "bubbles": {
-        "message": "Bubliny"
-    },
-    "bug": {
-        "message": "Chyba"
-    },
-    "buttons": {
-        "message": "Tlačidlá"
-    },
-    "cancel": {
-        "message": "Zrušiť"
-    },
-    "categories": {
-        "message": "Kategórie"
-    },
-    "channel": {
-        "message": "Kanál"
-    },
-    "channels": {
-        "message": "Kanály"
-    },
-    "clipboard": {
-        "message": "Schránka"
-    },
-    "codecH264": {
-        "message": "Kodek h.264"
-    },
-    "collapsed": {
-        "message": "Zbaliť"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Zbaliť sekciu Odber"
-    },
-    "comments": {
-        "message": "Komentáre"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Potvrdiť pred zatvorenímk"
-    },
-    "cores": {
-        "message": "Jadrá"
-    },
-    "customCss": {
-        "message": "Vlastné CSS"
-    },
-    "customJs": {
-        "message": "Vlastné JS"
-    },
-    "cyan": {
-        "message": "Tyrkysová"
-    },
-    "dark": {
-        "message": "Tmavý"
-    },
-    "darkTheme": {
-        "message": "Tmavá téma"
-    },
-    "dateAndTime": {
-        "message": "Dátum a čas"
-    },
-    "dawn": {
-        "message": "Svitanie"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Znížiť rýchlosť prehrávania"
-    },
-    "decreaseVolume": {
-        "message": "Znížiť hlasitosť"
-    },
-    "deepOrange": {
-        "message": "Tmavo oranžová"
-    },
-    "deepPurple": {
-        "message": "Tmavo fialová"
-    },
-    "defaultChannelTab": {
-        "message": "Predvolená karta kanálu"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Vymazať YouTube cookies"
-    },
-    "desert": {
-        "message": "Púšť"
-    },
-    "details": {
-        "message": "Detaily"
-    },
-    "developerOptions": {
-        "message": "Možnosti pre vývojara"
-    },
-    "device": {
-        "message": "Zariadenie"
-    },
-    "dim": {
-        "message": "Stmvaviť"
-    },
-    "disabled": {
-        "message": "Vypnutý"
-    },
-    "donate": {
-        "message": "Prispieť"
-    },
-    "doNotChange": {
-        "message": "Nemeniť"
-    },
-    "draggable": {
-        "message": "Posuvné"
-    },
-    "empty": {
-        "message": "Prázdny"
-    },
-    "enabled": {
-        "message": "Zapnuté"
-    },
-    "enabledForced": {
-        "message": "Zapnuté (vynútene)"
-    },
-    "expanded": {
-        "message": "Rozbalené"
-    },
-    "exportSettings": {
-        "message": "Exportovať nastavenia"
-    },
-    "extension": {
-        "message": "Rozšírenia"
-    },
-    "file": {
-        "message": "Súbor"
-    },
-    "filters": {
-        "message": "Filtre"
-    },
-    "fitToWindow": {
-        "message": "Prispôsobiť oknu"
-    },
-    "flash": {
-        "message": "Blikať"
-    },
-    "font": {
-        "message": "Písmo"
-    },
-    "footer": {
-        "message": "Pätička"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Vynútená rýchlosť prehrávania"
-    },
-    "forcedTheaterMode": {
-        "message": "Vynútený divadelný režim"
-    },
-    "forcedVolume": {
-        "message": "Vynútená hlasitosť"
-    },
-    "foundABug": {
-        "message": "Našli ste chybu?"
-    },
-    "fullWindow": {
-        "message": "Celé okno"
-    },
-    "general": {
-        "message": "Všeobecné"
-    },
-    "goToSearchBox": {
-        "message": "Prejdite do vyhľadávanieho poľa"
-    },
-    "green": {
-        "message": "Zelená"
-    },
-    "hdThumbnail": {
-        "message": "HD náhlad"
-    },
-    "header": {
-        "message": "Hlavička"
-    },
-    "hidden": {
-        "message": "Skryté"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Skyté na stránke videa"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Skryť animované náhľady"
-    },
-    "hideAnnotations": {
-        "message": "Skryť anotácie"
-    },
-    "hideCards": {
-        "message": "Skryť karty"
-    },
-    "hideDetails": {
-        "message": "Skryť detaily"
-    },
-    "hideEndscreen": {
-        "message": "Skryť zobrazenie na konci videa"
-    },
-    "hideFeaturedContent": {
-        "message": "Skryť odporúčaný obsah"
-    },
-    "hideFooter": {
-        "message": "Hide pätičku"
-    },
-    "hideGradientBottom": {
-        "message": "Hide Gradient Bottom"
-    },
-    "hideHomePageShorts": {
-        "message": "Odstrániť Shorts zo začiatočnej stránky"
-    },
-    "hidePlaylist": {
-        "message": "Skryť zoznam videí"
-    },
-    "hideRightButtons": {
-        "message": "Skryť tlčidlá v pravo"
-    },
-    "hideScrollForDetails": {
-        "message": "Skryť «Zarolujte pre detaily»"
-    },
-    "hideSkipOverlay": {
-        "message": "Hide Skip Overlay"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Hide thumbnail overlay"
-    },
-    "hideViewsCount": {
-        "message": "Skyť počet videní"
-    },
-    "history": {
-        "message": "História"
-    },
-    "home": {
-        "message": "Domov"
-    },
-    "hover": {
-        "message": "Vznášať sa"
-    },
-    "hoverOnVideoPage": {
-        "message": "Umiestnite kurzor na stránku videa"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Kedy bolo toto video nahrané?"
-    },
-    "icons": {
-        "message": "Ikony"
-    },
-    "iconsOnly": {
-        "message": "Iba ikony"
-    },
-    "importSettings": {
-        "message": "Importovať nastavenia"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube ikona na YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube jazyk"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube verzia"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Zvýšiť rýchlosť prehrávania"
-    },
-    "increaseVolume": {
-        "message": "Zvýšiť hlasitosť"
-    },
-    "languages": {
-        "message": "Jazyky"
-    },
-    "legacyYoutube": {
-        "message": "Starý YouTube"
-    },
-    "light": {
-        "message": "Svetlo"
-    },
-    "lightBlue": {
-        "message": "Svetlo modrá"
-    },
-    "lightGreen": {
-        "message": "Svetlo zelená"
-    },
-    "like": {
-        "message": "Páči sa mi to"
-    },
-    "lime": {
-        "message": "Limetková"
-    },
-    "list": {
-        "message": "Zoznam"
-    },
-    "liveChat": {
-        "message": "Živí chat"
-    },
-    "liveChatType": {
-        "message": "Typ živého chatu"
-    },
-    "loudnessNormalization": {
-        "message": "Vyrovnanie hlasitosti"
-    },
-    "markWatchedVideos": {
-        "message": "Označiť ako videné"
-    },
-    "mixer": {
-        "message": "Mixér"
-    },
-    "myColors": {
-        "message": "Moje farby"
-    },
-    "name": {
-        "message": "Meno"
-    },
-    "nativeMiniPlayer": {
-        "message": "Natívny mini prehrávač"
-    },
-    "new": {
-        "message": "Nový"
-    },
-    "nextVideo": {
-        "message": "Ďalšie video"
-    },
-    "night": {
-        "message": "Noc"
-    },
-    "noActiveFeatures": {
-        "message": "Žiadne aktívne fukncie"
-    },
-    "none": {
-        "message": "Žiadny"
-    },
-    "noOpenVideoTabs": {
-        "message": "Žiadne otvorené karty s videami"
-    },
-    "normal": {
-        "message": "Normále"
-    },
-    "old": {
-        "message": "Starý"
-    },
-    "onAllVideos": {
-        "message": "Na všetkých videách"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Aktívne iba na YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Prehrávať iba jedno video"
-    },
-    "onSubscribedChannels": {
-        "message": "Na odoberaných kanáloch"
-    },
-    "orange": {
-        "message": "Oranžová"
-    },
-    "other": {
-        "message": "Ostatné"
-    },
-    "permissions": {
-        "message": "Povolenia"
-    },
-    "pictureInPicture": {
-        "message": "Obraz v obraze"
-    },
-    "pink": {
-        "message": "Ružová"
-    },
-    "plain": {
-        "message": "Jednoduchý"
-    },
-    "platform": {
-        "message": "Platforma"
-    },
-    "playbackSpeed": {
-        "message": "Rýchlosť prehrávania"
-    },
-    "player": {
-        "message": "Prehrávač"
-    },
-    "playerColor": {
-        "message": "Farba prehrávača"
-    },
-    "playerSize": {
-        "message": "Veľkosť prehrávača"
-    },
-    "playlist": {
-        "message": "Zoznam videí"
-    },
-    "playlists": {
-        "message": "Zoznamy videí"
-    },
-    "playPause": {
-        "message": "Prehrať / Pozastavť"
-    },
-    "popupPlayer": {
-        "message": "Popup prehrávač"
-    },
-    "position": {
-        "message": "Pozícia"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Stlačte ľubovolnú klávesu alebo použite kolisko myšky."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Stlačte ľubovolnú klávesu alebo použite kolisko myšky"
-    },
-    "previousVideo": {
-        "message": "Predchýdzajúce video"
-    },
-    "primaryColor": {
-        "message": "Primárna farba"
-    },
-    "purple": {
-        "message": "Fialová"
-    },
-    "quality": {
-        "message": "Kvalita"
-    },
-    "rateUs": {
-        "message": "Ohodnoťte nás"
-    },
-    "red": {
-        "message": "Červená"
-    },
-    "relatedVideos": {
-        "message": "Súvisiace videá"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Odstránte príbuzné výsledky vyhľadávania"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Odstráňte karusel Shorts z výsledkov vyhľadávania"
-    },
-    "repeat": {
-        "message": "Opakovať"
-    },
-    "reset": {
-        "message": "Obnoviť"
-    },
-    "resetAllSettings": {
-        "message": "Obnoviť všetky nastavenia"
-    },
-    "resetAllShortcuts": {
-        "message": "Obnoviť všetky skratky"
-    },
-    "reverse": {
-        "message": "Obrátené"
-    },
-    "rotate": {
-        "message": "Otočiť"
-    },
-    "save": {
-        "message": "Uložiť"
-    },
-    "saveAs": {
-        "message": "Uložiť ako"
-    },
-    "schedule": {
-        "message": "Naplánovať"
-    },
-    "screen": {
-        "message": "Obrazovka"
-    },
-    "search": {
-        "message": "Vyhľadať"
-    },
-    "searchBarOnly": {
-        "message": "Iba vyhľadávacie pole"
-    },
-    "seekBackward10Seconds": {
-        "message": "Pretočiť spät o 10 sekúnd"
-    },
-    "seekForward10Seconds": {
-        "message": "Pretočiť dopredu o 10 sekúnd"
-    },
-    "seekNextChapter": {
-        "message": "seekNextChapter"
-    },
-    "seekPreviousChapter": {
-        "message": "seekPreviousChapter"
-    },
-    "settings": {
-        "message": "Nastavenia"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Nastavenia úspešne importované"
-    },
-    "shortcuts": {
-        "message": "Skratky"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Zobraziť karty pri prechode myšou"
-    },
-    "showChannelVideosCount": {
-        "message": "Zobraziť počet videí kanálu"
-    },
-    "shuffle": {
-        "message": "Náhodne"
-    },
-    "sidebar": {
-        "message": "Bočný panel"
-    },
-    "spacebar": {
-        "message": "Medzera"
-    },
-    "squaredUserImages": {
-        "message": "Štvorcový obrázok užívateľa"
-    },
-    "static": {
-        "message": "Statické"
-    },
-    "step": {
-        "message": "Krok"
-    },
-    "style": {
-        "message": "Štýl"
-    },
-    "styles": {
-        "message": "Štýly"
-    },
-    "subscriptions": {
-        "message": "Odbery"
-    },
-    "subtitles": {
-        "message": "Titulky"
-    },
-    "sunset": {
-        "message": "Západ slnka"
-    },
-    "sunsetToSunrise": {
-        "message": "Západ slnka do východu slnka"
-    },
-    "systemPeferenceDark": {
-        "message": "Predvolené: tmavé"
-    },
-    "systemPeferenceLight": {
-        "message": "Predvolené: svetlé"
-    },
-    "teal": {
-        "message": "Modrozelený"
-    },
-    "textColor": {
-        "message": "Farba textu"
-    },
-    "themes": {
-        "message": "Témy"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Toto odstráni všetky cookies."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Toto odstráni všetky YouTube cookies"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Toto obnový všetky nastavenia."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Toto obnový všetky skratky"
-    },
-    "thumbnails": {
-        "message": "Náhlady"
-    },
-    "timeFrom": {
-        "message": "Čas od"
-    },
-    "timeTo": {
-        "message": "Čas do"
-    },
-    "todayAt": {
-        "message": "Dnes o"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "trailerAutoplay": {
-        "message": "Automatické prehrávanie ukážky"
-    },
-    "translations": {
-        "message": "Preklady"
-    },
-    "transparentBackground": {
-        "message": "Priehľadné pozadie"
-    },
-    "tryToReloadThePage": {
-        "message": "Skúsťe obnoviť stránku"
-    },
-    "type": {
-        "message": "Typ"
-    },
-    "upNextAutoplay": {
-        "message": "Automaticky prehrať ďaľšie v poradí"
-    },
-    "use24HourFormat": {
-        "message": "Použť 24-hodinový formát"
-    },
-    "version": {
-        "message": "Verzia"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Podrobnosti videa budú zobrazené pre získanie názvu kategórie"
-    },
-    "videoFormats": {
-        "message": "Formáty videa"
-    },
-    "videos": {
-        "message": "Vedeá"
-    },
-    "volume": {
-        "message": "Hlasitosť"
-    },
-    "watchLater": {
-        "message": "Pozrieť neskor"
-    },
-    "watchTime": {
-        "message": "Čas sledovania"
-    },
-    "whenTabIsChanged": {
-        "message": "Pri zmene karty"
-    },
-    "white": {
-        "message": "Biela"
-    },
-    "yellow": {
-        "message": "Žltá"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube hlavička (vľavo)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube hlavička (vpravo)"
-    },
-    "youtubeHomePage": {
-        "message": "Domáca stránka YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Jazyk YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube obmedzuje kvalitu videa na 1080p pri kodeku h.264"
-    }
+	"about": {
+		"message": "O"
+	},
+	"accept": {
+		"message": "Prijať"
+	},
+	"activate": {
+		"message": "Aktivovať"
+	},
+	"activateCaptions": {
+		"message": "Aktivovať titulky"
+	},
+	"activated": {
+		"message": "Aktivované"
+	},
+	"activatedFeatures": {
+		"message": "Aktivované fukncie"
+	},
+	"activateFullscreen": {
+		"message": "Aktivovať zobrazenie na celú obrazovku"
+	},
+	"activeFeatures": {
+		"message": "Aktívne funkcie"
+	},
+	"addScrollToTop": {
+		"message": "Prejdite «Vrátiť sa na začiatok»"
+	},
+	"ads": {
+		"message": "Reklamy"
+	},
+	"all": {
+		"message": "Všetko"
+	},
+	"allow": {
+		"message": "Povoliť"
+	},
+	"alwaysActive": {
+		"message": "Vždy aktívne"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Vždy zobrazovať ukazateľ priebehu"
+	},
+	"amber": {
+		"message": "Ambra"
+	},
+	"analyzer": {
+		"message": "Analyzátor"
+	},
+	"appearance": {
+		"message": "Vzhľad"
+	},
+	"audio": {
+		"message": "Zvuk"
+	},
+	"audioFormats": {
+		"message": "Formát zvuku"
+	},
+	"auto": {
+		"message": "Automaticky"
+	},
+	"autoFullscreen": {
+		"message": "Automaticky-fullscreen"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Automatické pozastavenie pri prepínaní kariet"
+	},
+	"autoplay": {
+		"message": "Automatické prehrávanie"
+	},
+	"backupAndReset": {
+		"message": "Zálohovanie & Obnova"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Nastavené podľa farby systému"
+	},
+	"belowPlayer": {
+		"message": "Pod prehrávačom"
+	},
+	"black": {
+		"message": "Čierna"
+	},
+	"blockAll": {
+		"message": "Zablokovať všetko"
+	},
+	"blue": {
+		"message": "Modrá"
+	},
+	"blueGray": {
+		"message": "Šedo-modrá"
+	},
+	"bluelight": {
+		"message": "Modré svetlo"
+	},
+	"brown": {
+		"message": "Hnedá"
+	},
+	"browser": {
+		"message": "Prehliadac"
+	},
+	"browserVersion": {
+		"message": "Verzie prehliadača"
+	},
+	"bubbles": {
+		"message": "Bubliny"
+	},
+	"bug": {
+		"message": "Chyba"
+	},
+	"buttons": {
+		"message": "Tlačidlá"
+	},
+	"cancel": {
+		"message": "Zrušiť"
+	},
+	"categories": {
+		"message": "Kategórie"
+	},
+	"channel": {
+		"message": "Kanál"
+	},
+	"channels": {
+		"message": "Kanály"
+	},
+	"clipboard": {
+		"message": "Schránka"
+	},
+	"codecH264": {
+		"message": "Kodek h.264"
+	},
+	"collapsed": {
+		"message": "Zbaliť"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Zbaliť sekciu Odber"
+	},
+	"comments": {
+		"message": "Komentáre"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Potvrdiť pred zatvorenímk"
+	},
+	"cores": {
+		"message": "Jadrá"
+	},
+	"customCss": {
+		"message": "Vlastné CSS"
+	},
+	"customJs": {
+		"message": "Vlastné JS"
+	},
+	"cyan": {
+		"message": "Tyrkysová"
+	},
+	"dark": {
+		"message": "Tmavý"
+	},
+	"darkTheme": {
+		"message": "Tmavá téma"
+	},
+	"dateAndTime": {
+		"message": "Dátum a čas"
+	},
+	"dawn": {
+		"message": "Svitanie"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Znížiť rýchlosť prehrávania"
+	},
+	"decreaseVolume": {
+		"message": "Znížiť hlasitosť"
+	},
+	"deepOrange": {
+		"message": "Tmavo oranžová"
+	},
+	"deepPurple": {
+		"message": "Tmavo fialová"
+	},
+	"defaultChannelTab": {
+		"message": "Predvolená karta kanálu"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Vymazať YouTube cookies"
+	},
+	"desert": {
+		"message": "Púšť"
+	},
+	"details": {
+		"message": "Detaily"
+	},
+	"developerOptions": {
+		"message": "Možnosti pre vývojara"
+	},
+	"device": {
+		"message": "Zariadenie"
+	},
+	"dim": {
+		"message": "Stmvaviť"
+	},
+	"disabled": {
+		"message": "Vypnutý"
+	},
+	"donate": {
+		"message": "Prispieť"
+	},
+	"doNotChange": {
+		"message": "Nemeniť"
+	},
+	"draggable": {
+		"message": "Posuvné"
+	},
+	"empty": {
+		"message": "Prázdny"
+	},
+	"enabled": {
+		"message": "Zapnuté"
+	},
+	"enabledForced": {
+		"message": "Zapnuté (vynútene)"
+	},
+	"expanded": {
+		"message": "Rozbalené"
+	},
+	"exportSettings": {
+		"message": "Exportovať nastavenia"
+	},
+	"extension": {
+		"message": "Rozšírenia"
+	},
+	"file": {
+		"message": "Súbor"
+	},
+	"filters": {
+		"message": "Filtre"
+	},
+	"fitToWindow": {
+		"message": "Prispôsobiť oknu"
+	},
+	"flash": {
+		"message": "Blikať"
+	},
+	"font": {
+		"message": "Písmo"
+	},
+	"footer": {
+		"message": "Pätička"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Vynútená rýchlosť prehrávania"
+	},
+	"forcedTheaterMode": {
+		"message": "Vynútený divadelný režim"
+	},
+	"forcedVolume": {
+		"message": "Vynútená hlasitosť"
+	},
+	"foundABug": {
+		"message": "Našli ste chybu?"
+	},
+	"fullWindow": {
+		"message": "Celé okno"
+	},
+	"general": {
+		"message": "Všeobecné"
+	},
+	"goToSearchBox": {
+		"message": "Prejdite do vyhľadávanieho poľa"
+	},
+	"green": {
+		"message": "Zelená"
+	},
+	"hdThumbnail": {
+		"message": "HD náhlad"
+	},
+	"header": {
+		"message": "Hlavička"
+	},
+	"hidden": {
+		"message": "Skryté"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Skyté na stránke videa"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Skryť animované náhľady"
+	},
+	"hideAnnotations": {
+		"message": "Skryť anotácie"
+	},
+	"hideCards": {
+		"message": "Skryť karty"
+	},
+	"hideDetails": {
+		"message": "Skryť detaily"
+	},
+	"hideEndscreen": {
+		"message": "Skryť zobrazenie na konci videa"
+	},
+	"hideFeaturedContent": {
+		"message": "Skryť odporúčaný obsah"
+	},
+	"hideFooter": {
+		"message": "Hide pätičku"
+	},
+	"hideGradientBottom": {
+		"message": "Hide Gradient Bottom"
+	},
+	"hideHomePageShorts": {
+		"message": "Odstrániť Shorts zo začiatočnej stránky"
+	},
+	"hidePlaylist": {
+		"message": "Skryť zoznam videí"
+	},
+	"hideRightButtons": {
+		"message": "Skryť tlčidlá v pravo"
+	},
+	"hideScrollForDetails": {
+		"message": "Skryť «Zarolujte pre detaily»"
+	},
+	"hideViewsCount": {
+		"message": "Skyť počet videní"
+	},
+	"history": {
+		"message": "História"
+	},
+	"home": {
+		"message": "Domov"
+	},
+	"hover": {
+		"message": "Vznášať sa"
+	},
+	"hoverOnVideoPage": {
+		"message": "Umiestnite kurzor na stránku videa"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Kedy bolo toto video nahrané?"
+	},
+	"icons": {
+		"message": "Ikony"
+	},
+	"iconsOnly": {
+		"message": "Iba ikony"
+	},
+	"importSettings": {
+		"message": "Importovať nastavenia"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube ikona na YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube jazyk"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube verzia"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Zvýšiť rýchlosť prehrávania"
+	},
+	"increaseVolume": {
+		"message": "Zvýšiť hlasitosť"
+	},
+	"languages": {
+		"message": "Jazyky"
+	},
+	"legacyYoutube": {
+		"message": "Starý YouTube"
+	},
+	"light": {
+		"message": "Svetlo"
+	},
+	"lightBlue": {
+		"message": "Svetlo modrá"
+	},
+	"lightGreen": {
+		"message": "Svetlo zelená"
+	},
+	"like": {
+		"message": "Páči sa mi to"
+	},
+	"lime": {
+		"message": "Limetková"
+	},
+	"list": {
+		"message": "Zoznam"
+	},
+	"liveChat": {
+		"message": "Živí chat"
+	},
+	"liveChatType": {
+		"message": "Typ živého chatu"
+	},
+	"loudnessNormalization": {
+		"message": "Vyrovnanie hlasitosti"
+	},
+	"markWatchedVideos": {
+		"message": "Označiť ako videné"
+	},
+	"mixer": {
+		"message": "Mixér"
+	},
+	"myColors": {
+		"message": "Moje farby"
+	},
+	"name": {
+		"message": "Meno"
+	},
+	"nativeMiniPlayer": {
+		"message": "Natívny mini prehrávač"
+	},
+	"new": {
+		"message": "Nový"
+	},
+	"nextVideo": {
+		"message": "Ďalšie video"
+	},
+	"night": {
+		"message": "Noc"
+	},
+	"noActiveFeatures": {
+		"message": "Žiadne aktívne fukncie"
+	},
+	"none": {
+		"message": "Žiadny"
+	},
+	"noOpenVideoTabs": {
+		"message": "Žiadne otvorené karty s videami"
+	},
+	"normal": {
+		"message": "Normále"
+	},
+	"old": {
+		"message": "Starý"
+	},
+	"onAllVideos": {
+		"message": "Na všetkých videách"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Aktívne iba na YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Prehrávať iba jedno video"
+	},
+	"onSubscribedChannels": {
+		"message": "Na odoberaných kanáloch"
+	},
+	"orange": {
+		"message": "Oranžová"
+	},
+	"other": {
+		"message": "Ostatné"
+	},
+	"permissions": {
+		"message": "Povolenia"
+	},
+	"pictureInPicture": {
+		"message": "Obraz v obraze"
+	},
+	"pink": {
+		"message": "Ružová"
+	},
+	"plain": {
+		"message": "Jednoduchý"
+	},
+	"platform": {
+		"message": "Platforma"
+	},
+	"playbackSpeed": {
+		"message": "Rýchlosť prehrávania"
+	},
+	"player": {
+		"message": "Prehrávač"
+	},
+	"playerColor": {
+		"message": "Farba prehrávača"
+	},
+	"playerSize": {
+		"message": "Veľkosť prehrávača"
+	},
+	"playlist": {
+		"message": "Zoznam videí"
+	},
+	"playlists": {
+		"message": "Zoznamy videí"
+	},
+	"playPause": {
+		"message": "Prehrať / Pozastavť"
+	},
+	"popupPlayer": {
+		"message": "Popup prehrávač"
+	},
+	"position": {
+		"message": "Pozícia"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Stlačte ľubovolnú klávesu alebo použite kolisko myšky."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Stlačte ľubovolnú klávesu alebo použite kolisko myšky"
+	},
+	"previousVideo": {
+		"message": "Predchýdzajúce video"
+	},
+	"primaryColor": {
+		"message": "Primárna farba"
+	},
+	"purple": {
+		"message": "Fialová"
+	},
+	"quality": {
+		"message": "Kvalita"
+	},
+	"rateUs": {
+		"message": "Ohodnoťte nás"
+	},
+	"red": {
+		"message": "Červená"
+	},
+	"relatedVideos": {
+		"message": "Súvisiace videá"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Odstránte príbuzné výsledky vyhľadávania"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Odstráňte karusel Shorts z výsledkov vyhľadávania"
+	},
+	"repeat": {
+		"message": "Opakovať"
+	},
+	"reset": {
+		"message": "Obnoviť"
+	},
+	"resetAllSettings": {
+		"message": "Obnoviť všetky nastavenia"
+	},
+	"resetAllShortcuts": {
+		"message": "Obnoviť všetky skratky"
+	},
+	"reverse": {
+		"message": "Obrátené"
+	},
+	"rotate": {
+		"message": "Otočiť"
+	},
+	"save": {
+		"message": "Uložiť"
+	},
+	"saveAs": {
+		"message": "Uložiť ako"
+	},
+	"schedule": {
+		"message": "Naplánovať"
+	},
+	"screen": {
+		"message": "Obrazovka"
+	},
+	"search": {
+		"message": "Vyhľadať"
+	},
+	"searchBarOnly": {
+		"message": "Iba vyhľadávacie pole"
+	},
+	"seekBackward10Seconds": {
+		"message": "Pretočiť spät o 10 sekúnd"
+	},
+	"seekForward10Seconds": {
+		"message": "Pretočiť dopredu o 10 sekúnd"
+	},
+	"seekNextChapter": {
+		"message": "seekNextChapter"
+	},
+	"seekPreviousChapter": {
+		"message": "seekPreviousChapter"
+	},
+	"settings": {
+		"message": "Nastavenia"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Nastavenia úspešne importované"
+	},
+	"shortcuts": {
+		"message": "Skratky"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Zobraziť karty pri prechode myšou"
+	},
+	"showChannelVideosCount": {
+		"message": "Zobraziť počet videí kanálu"
+	},
+	"shuffle": {
+		"message": "Náhodne"
+	},
+	"sidebar": {
+		"message": "Bočný panel"
+	},
+	"spacebar": {
+		"message": "Medzera"
+	},
+	"squaredUserImages": {
+		"message": "Štvorcový obrázok užívateľa"
+	},
+	"static": {
+		"message": "Statické"
+	},
+	"step": {
+		"message": "Krok"
+	},
+	"style": {
+		"message": "Štýl"
+	},
+	"styles": {
+		"message": "Štýly"
+	},
+	"subscriptions": {
+		"message": "Odbery"
+	},
+	"subtitles": {
+		"message": "Titulky"
+	},
+	"sunset": {
+		"message": "Západ slnka"
+	},
+	"sunsetToSunrise": {
+		"message": "Západ slnka do východu slnka"
+	},
+	"systemPeferenceDark": {
+		"message": "Predvolené: tmavé"
+	},
+	"systemPeferenceLight": {
+		"message": "Predvolené: svetlé"
+	},
+	"teal": {
+		"message": "Modrozelený"
+	},
+	"textColor": {
+		"message": "Farba textu"
+	},
+	"themes": {
+		"message": "Témy"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Toto odstráni všetky cookies."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Toto odstráni všetky YouTube cookies"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Toto obnový všetky nastavenia."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Toto obnový všetky skratky"
+	},
+	"thumbnails": {
+		"message": "Náhlady"
+	},
+	"timeFrom": {
+		"message": "Čas od"
+	},
+	"timeTo": {
+		"message": "Čas do"
+	},
+	"todayAt": {
+		"message": "Dnes o"
+	},
+	"trailerAutoplay": {
+		"message": "Automatické prehrávanie ukážky"
+	},
+	"translations": {
+		"message": "Preklady"
+	},
+	"transparentBackground": {
+		"message": "Priehľadné pozadie"
+	},
+	"tryToReloadThePage": {
+		"message": "Skúsťe obnoviť stránku"
+	},
+	"type": {
+		"message": "Typ"
+	},
+	"upNextAutoplay": {
+		"message": "Automaticky prehrať ďaľšie v poradí"
+	},
+	"use24HourFormat": {
+		"message": "Použť 24-hodinový formát"
+	},
+	"version": {
+		"message": "Verzia"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Podrobnosti videa budú zobrazené pre získanie názvu kategórie"
+	},
+	"videoFormats": {
+		"message": "Formáty videa"
+	},
+	"videos": {
+		"message": "Vedeá"
+	},
+	"volume": {
+		"message": "Hlasitosť"
+	},
+	"watchLater": {
+		"message": "Pozrieť neskor"
+	},
+	"watchTime": {
+		"message": "Čas sledovania"
+	},
+	"whenTabIsChanged": {
+		"message": "Pri zmene karty"
+	},
+	"white": {
+		"message": "Biela"
+	},
+	"yellow": {
+		"message": "Žltá"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube hlavička (vľavo)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube hlavička (vpravo)"
+	},
+	"youtubeHomePage": {
+		"message": "Domáca stránka YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Jazyk YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube obmedzuje kvalitu videa na 1080p pri kodeku h.264"
+	}
 }

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Odstrani Shorts s prve strani"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Odstrani Shorts kolut iz rezultatov iskanja"
-    }
+	"hideHomePageShorts": {
+		"message": "Odstrani Shorts s prve strani"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Odstrani Shorts kolut iz rezultatov iskanja"
+	}
 }

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -1,14 +1,8 @@
 {
-    "areYouSureYouWantToImportTheData": {
-        "message": "Are you sure you want to import the data?"
-    },
-    "hideHomePageShorts": {
-        "message": "Уклоните Shorts са почетне стране"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Hide player controls bar buttons"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Уклоните каруселу Shorts из резултата претраге"
-    }
+	"hideHomePageShorts": {
+		"message": "Уклоните Shorts са почетне стране"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Уклоните каруселу Shorts из резултата претраге"
+	}
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,977 +1,977 @@
 {
-    "about": {
-        "message": "Om"
-    },
-    "accept": {
-        "message": "Acceptera"
-    },
-    "activate": {
-        "message": "Aktivera"
-    },
-    "activateCaptions": {
-        "message": "Aktivera undertexter"
-    },
-    "activated": {
-        "message": "Aktiverad"
-    },
-    "activatedFeatures": {
-        "message": "Aktiverade funktioner"
-    },
-    "activateFullscreen": {
-        "message": "Aktivera helskärm"
-    },
-    "activeFeatures": {
-        "message": "Aktiva funktioner"
-    },
-    "addScrollToTop": {
-        "message": "Lägg till «Scrolla till toppen»"
-    },
-    "ads": {
-        "message": "Reklam"
-    },
-    "all": {
-        "message": "Allt"
-    },
-    "allow": {
-        "message": "Tillåt"
-    },
-    "always": {
-        "message": "Alltid"
-    },
-    "alwaysActive": {
-        "message": "Alltid aktiv"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Visa alltid tidslinje"
-    },
-    "amber": {
-        "message": "Bärnsten"
-    },
-    "animations": {
-        "message": "Animationer"
-    },
-    "appearance": {
-        "message": "Utseende"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Är du säker på att du vill exportera data?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Är du säker på att du vill importera data?"
-    },
-    "audio": {
-        "message": "Ljud"
-    },
-    "audioFormats": {
-        "message": "Ljudformat"
-    },
-    "autoFullscreen": {
-        "message": "Automatisk helskärm"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Pausa automatiskt när jag inte är i fliken"
-    },
-    "avoidAv1": {
-        "message": "Undvik AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Undvik AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Undvik AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Undvik CPU-rendering när det är möjligt"
-    },
-    "backgroundColor": {
-        "message": "Bakgrundsfärg"
-    },
-    "backgroundOpacity": {
-        "message": "Opacitet för bakgrund"
-    },
-    "backupAndReset": {
-        "message": "Backup och återställning"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Basera på systemets färgschema"
-    },
-    "belowPlayer": {
-        "message": "Under spelaren"
-    },
-    "black": {
-        "message": "Svart"
-    },
-    "blockAll": {
-        "message": "Av (blockera eller hoppa över)"
-    },
-    "blockAv1": {
-        "message": "Blockera AV1"
-    },
-    "blockH264": {
-        "message": "Blockera H.264"
-    },
-    "blockMusic": {
-        "message": "Hoppa över reklam medan jag spelar musik"
-    },
-    "blockVp8": {
-        "message": "Blockera VP8"
-    },
-    "blue": {
-        "message": "Blå"
-    },
-    "blueGray": {
-        "message": "Blågrå"
-    },
-    "bluelight": {
-        "message": "Blåljus"
-    },
-    "brown": {
-        "message": "Brun"
-    },
-    "browser": {
-        "message": "Webbläsare"
-    },
-    "browserVersion": {
-        "message": "Webbläsarversion"
-    },
-    "bubbles": {
-        "message": "Bubblor"
-    },
-    "bug": {
-        "message": "Fel"
-    },
-    "buttons": {
-        "message": "Knappar"
-    },
-    "cancel": {
-        "message": "Avbryt"
-    },
-    "categories": {
-        "message": "Kategorier"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanaler"
-    },
-    "characterEdgeStyle": {
-        "message": "Karaktärsgräns"
-    },
-    "clipboard": {
-        "message": "Urklipp"
-    },
-    "collapsed": {
-        "message": "Hopvikt"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Vik prenumerationernas sektioner (hopfällt dragspel)"
-    },
-    "comments": {
-        "message": "Kommentarer"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Bekräftelse vid stängning"
-    },
-    "cores": {
-        "message": "Kärnor"
-    },
-    "cropChapterTitles": {
-        "message": "Beskär kapiteltitlar"
-    },
-    "custom": {
-        "message": "Anpassad"
-    },
-    "customCss": {
-        "message": "Anpassad CSS"
-    },
-    "customJs": {
-        "message": "Anpassad JS"
-    },
-    "customMiniPlayer": {
-        "message": "Anpassad Mini-Player"
-    },
-    "dark": {
-        "message": "Mörk"
-    },
-    "darkTheme": {
-        "message": "Mörkt tema"
-    },
-    "dateAndTime": {
-        "message": "Datum och tid"
-    },
-    "dawn": {
-        "message": "Gryning"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Sänka uppspelningshastigheten"
-    },
-    "decreaseVolume": {
-        "message": "Sänka volymen"
-    },
-    "deepOrange": {
-        "message": "Djupt orange"
-    },
-    "deepPurple": {
-        "message": "Djupt lila"
-    },
-    "default": {
-        "message": "Standard"
-    },
-    "defaultChannelTab": {
-        "message": "Standardflik för kanal"
-    },
-    "defaultContentCountry": {
-        "message": "Land (virtual travel)"
-    },
-    "deleteWatchedVideos": {
-        "message": "Radera tittade videor"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Radera YouTube-cookies"
-    },
-    "description": {
-        "message": "Beskrivning"
-    },
-    "desert": {
-        "message": "Öken"
-    },
-    "details": {
-        "message": "Detaljer"
-    },
-    "developerOptions": {
-        "message": "Utvecklingsalternativ"
-    },
-    "device": {
-        "message": "Enhet"
-    },
-    "disabled": {
-        "message": "Inaktiverad"
-    },
-    "dislike": {
-        "message": "Gilla inte"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Visa veckodag"
-    },
-    "donate": {
-        "message": "Donera"
-    },
-    "doNotChange": {
-        "message": "Ändra ej"
-    },
-    "draggable": {
-        "message": "Flyttbar"
-    },
-    "durationWithSpeed": {
-        "message": "Visa återstående tid i förhållande till uppspelningshastigheten"
-    },
-    "email": {
-        "message": "E-mail"
-    },
-    "empty": {
-        "message": "tomt"
-    },
-    "enabled": {
-        "message": "Aktiverad"
-    },
-    "enabledForced": {
-        "message": "Aktiverad (tvingad)"
-    },
-    "expanded": {
-        "message": "Expanderad"
-    },
-    "exportSettings": {
-        "message": "Exportera inställningar"
-    },
-    "extension": {
-        "message": "Tillägg"
-    },
-    "file": {
-        "message": "Fil"
-    },
-    "filters": {
-        "message": "Filter"
-    },
-    "fitToWindow": {
-        "message": "Gammalt alternativ ('Anpassa till fönster')"
-    },
-    "font": {
-        "message": "Teckensnitt"
-    },
-    "fontColor": {
-        "message": "Teckensnittsfärg"
-    },
-    "fontFamily": {
-        "message": "Teckensnittsfamilj"
-    },
-    "fontOpacity": {
-        "message": "Opacitet för teckensnitt"
-    },
-    "fontSize": {
-        "message": "Teckenstorlek"
-    },
-    "footer": {
-        "message": "Sidfot"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Forcerad uppspelningshastighet"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Tvinga uppspelningshastighet även för musik?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Tvinga video att spela från början"
-    },
-    "forcedTheaterMode": {
-        "message": "Påtvingad teaterläge"
-    },
-    "forcedVolume": {
-        "message": "Påtvingad volym"
-    },
-    "forceSDR": {
-        "message": "Undvik HDR, använd SDR"
-    },
-    "foundABug": {
-        "message": "Hittade ett fel?"
-    },
-    "fullWindow": {
-        "message": "Helt fönster"
-    },
-    "general": {
-        "message": "Allmänt"
-    },
-    "geoPreference": {
-        "message": "Geo-preferens"
-    },
-    "goToSearchBox": {
-        "message": "Gå till sökfältet"
-    },
-    "green": {
-        "message": "Grön"
-    },
-    "hardwareInformation": {
-        "message": "Information om hårdvara"
-    },
-    "hdThumbnail": {
-        "message": "HD miniatyrbild"
-    },
-    "header": {
-        "message": "Rubrik"
-    },
-    "hidden": {
-        "message": "Dold"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Dold på videosidan"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Dölj animerade miniatyrbilder"
-    },
-    "hideAnnotations": {
-        "message": "Dölj anteckningar"
-    },
-    "hideCards": {
-        "message": "Dölj kort"
-    },
-    "hideCategories": {
-        "message": "Dölj kategorier"
-    },
-    "hideCommentsCount": {
-        "message": "Dölj antal kommentarer"
-    },
-    "hideCountryCode": {
-        "message": "Dölj landskod"
-    },
-    "hideDate": {
-        "message": "Dölj datum"
-    },
-    "hideDetailButton": {
-        "message": "Knappar"
-    },
-    "hideDetails": {
-        "message": "Dölj detaljer"
-    },
-    "hideEndscreen": {
-        "message": "Dölj slutskärm"
-    },
-    "hideFeaturedContent": {
-        "message": "Dölj framhävt innehåll"
-    },
-    "hideFooter": {
-        "message": "Dölj sidfoten"
-    },
-    "hideGradientBottom": {
-        "message": "Dölj skuggor runt spelarfältet"
-    },
-    "hideHomePageShorts": {
-        "message": "Ta bort Shorts från startsidan"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Dölj kontrollfältet för spelare"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Dölj knappar i fältet för spelarkontroller"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Dölj alternativ för spelarkontroll"
-    },
-    "hidePlaylist": {
-        "message": "Dölj spellista"
-    },
-    "hideRightButtons": {
-        "message": "Dölj högerknappar"
-    },
-    "hideScrollForDetails": {
-        "message": "Dölj «Bläddra för detaljer»"
-    },
-    "hideSkipOverlay": {
-        "message": "Dölj 5 sekunders hoppa över animering"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Dölj knappar på miniatyrbilder"
-    },
-    "hideThumbnails": {
-        "message": "Dölj miniatyrbilder"
-    },
-    "hideViewsCount": {
-        "message": "Dölj antal visningar"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Dölj knappen för röstsökning"
-    },
-    "high": {
-        "message": "Hög"
-    },
-    "history": {
-        "message": "Historik"
-    },
-    "home": {
-        "message": "Hem"
-    },
-    "hover": {
-        "message": "Visa vid muspekning"
-    },
-    "hoverOnVideoPage": {
-        "message": "Visa vid muspekning på videosidor"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Visa videons ålder (sedan uppladdningsdatum)"
-    },
-    "icons": {
-        "message": "Ikoner"
-    },
-    "iconsOnly": {
-        "message": "Endast ikoner"
-    },
-    "importSettings": {
-        "message": "Importera inställningar"
-    },
-    "improvedtubeButtons": {
-        "message": "ImprovedTube knappar"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "ImprovedTube ikon på YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube språk"
-    },
-    "improveLogo": {
-        "message": "Förbättra logotypen"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Öka uppspelningshastigheten"
-    },
-    "increaseVolume": {
-        "message": "Höj volymen"
-    },
-    "language": {
-        "message": "Språk"
-    },
-    "languages": {
-        "message": "Språk"
-    },
-    "layerAnimationScale": {
-        "message": "Skala för lageranimering"
-    },
-    "legacyYoutube": {
-        "message": "Klassisk YouTube"
-    },
-    "library": {
-        "message": "Bibliotek"
-    },
-    "light": {
-        "message": "Ljus"
-    },
-    "lightBlue": {
-        "message": "Ljusblå"
-    },
-    "lightGreen": {
-        "message": "Ljusgrön"
-    },
-    "like": {
-        "message": "Gilla"
-    },
-    "liked": {
-        "message": "Gillat"
-    },
-    "limitPageWidth": {
-        "message": "Begränsa sidbredd"
-    },
-    "list": {
-        "message": "Lista"
-    },
-    "liveChat": {
-        "message": "Livechatt"
-    },
-    "liveChatType": {
-        "message": "Typ av livechatt"
-    },
-    "location": {
-        "message": "Plats"
-    },
-    "loudnessNormalization": {
-        "message": "Normalisering av ljudnivå"
-    },
-    "low": {
-        "message": "Låg"
-    },
-    "markWatchedVideos": {
-        "message": "Markera visade videor"
-    },
-    "more": {
-        "message": "Mera"
-    },
-    "mostViewedChannels": {
-        "message": "Mest visade kanaler"
-    },
-    "moveSidebarLeft": {
-        "message": "Till vänster!"
-    },
-    "moveThumbnailsRight": {
-        "message": "Miniatyrbilder till höger!"
-    },
-    "myColors": {
-        "message": "Mina färger"
-    },
-    "name": {
-        "message": "Namn"
-    },
-    "nativeMiniPlayer": {
-        "message": "Inbyggd mini-spelare"
-    },
-    "new": {
-        "message": "Ny"
-    },
-    "nextVideo": {
-        "message": "Nästa video"
-    },
-    "night": {
-        "message": "Natt"
-    },
-    "nightMode": {
-        "message": "Nattläge"
-    },
-    "noActiveFeatures": {
-        "message": "Inga aktiva funktioner"
-    },
-    "none": {
-        "message": "Inga"
-    },
-    "noOpenVideoTabs": {
-        "message": "Inga öppna videoflikar"
-    },
-    "off": {
-        "message": "Av"
-    },
-    "old": {
-        "message": "Gammal"
-    },
-    "onAllVideos": {
-        "message": "På"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Enbart aktivt på YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Pausa medan jag tittar på en andra video"
-    },
-    "onSubscribedChannels": {
-        "message": "Av, förutom på mina prenumererade kanaler"
-    },
-    "openPopupPlayer": {
-        "message": "Öppna video/spellista i ny flik"
-    },
-    "other": {
-        "message": "Annat"
-    },
-    "outline": {
-        "message": "Gräns"
-    },
-    "overlay": {
-        "message": "Överlägg"
-    },
-    "permissions": {
-        "message": "Tillstånd"
-    },
-    "pictureInPicture": {
-        "message": "Bild-i-bild"
-    },
-    "pink": {
-        "message": "Rosa"
-    },
-    "plain": {
-        "message": "Slät"
-    },
-    "platform": {
-        "message": "Plattform"
-    },
-    "playAllButton": {
-        "message": "\"Spela allt\"knapp"
-    },
-    "playbackSpeed": {
-        "message": "Uppspelningshastighet"
-    },
-    "player": {
-        "message": "Spelare"
-    },
-    "playerColor": {
-        "message": "Färj på spelare"
-    },
-    "playerSize": {
-        "message": "Storlek på spelare"
-    },
-    "playlist": {
-        "message": "Spellista"
-    },
-    "playlists": {
-        "message": "Spellistor"
-    },
-    "playPause": {
-        "message": "Spela / Pausa"
-    },
-    "popupPlayer": {
-        "message": "Spelare i eget fönster"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Tryck på valfri knapp eller använd mushjulet."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Tryck på valfri knapp eller använd mushjulet."
-    },
-    "previousVideo": {
-        "message": "Föregående video"
-    },
-    "primaryColor": {
-        "message": "Primärfärg"
-    },
-    "purple": {
-        "message": "Lila"
-    },
-    "quality": {
-        "message": "Kvalitet"
-    },
-    "raised": {
-        "message": "Höjd"
-    },
-    "rateMe": {
-        "message": "Betygsätt mig"
-    },
-    "rateUs": {
-        "message": "Betygsätt oss"
-    },
-    "red": {
-        "message": "Röd"
-    },
-    "redDislikeButton": {
-        "message": "Röd Gilla inte-knapp"
-    },
-    "relatedVideos": {
-        "message": "Relaterade videor"
-    },
-    "remote": {
-        "message": "Spela på TV"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Ta bort relaterade sökresultat"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Ta bort Shorts-reel från sökresultaten"
-    },
-    "repeat": {
-        "message": "Repetera"
-    },
-    "report": {
-        "message": "Rapportera"
-    },
-    "reset": {
-        "message": "Återställ"
-    },
-    "resetAllSettings": {
-        "message": "Återställ alla inställningar"
-    },
-    "resetAllShortcuts": {
-        "message": "Återställ alla snabbkommandon"
-    },
-    "reverse": {
-        "message": "Omvänd"
-    },
-    "rotate": {
-        "message": "Rotera"
-    },
-    "save": {
-        "message": "Spara"
-    },
-    "saveAs": {
-        "message": "Spara som"
-    },
-    "schedule": {
-        "message": "Tidsplan"
-    },
-    "screen": {
-        "message": "Bildskärm"
-    },
-    "screenshot": {
-        "message": "Skärmdump"
-    },
-    "scrollBar": {
-        "message": "Rullningslist"
-    },
-    "search": {
-        "message": "Sök"
-    },
-    "searchBarOnly": {
-        "message": "Endast sökfält"
-    },
-    "seekBackward10Seconds": {
-        "message": "Sök bakåt 10 sekunder"
-    },
-    "seekForward10Seconds": {
-        "message": "Sök framåt 10 sekunder"
-    },
-    "seekNextChapter": {
-        "message": "Sök nästa kapitel"
-    },
-    "seekPreviousChapter": {
-        "message": "Sök föregående kapitel"
-    },
-    "settings": {
-        "message": "Inställningar"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Inställningarna har importerats"
-    },
-    "share": {
-        "message": "Dela"
-    },
-    "shortcuts": {
-        "message": "Snabbkommandon"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Visa informationskort vid muspekaren"
-    },
-    "showChannelVideosCount": {
-        "message": "Visa antal kanalvideor"
-    },
-    "showLess": {
-        "message": "Visa färre"
-    },
-    "showMore": {
-        "message": "Visa fler"
-    },
-    "showRemainingDuration": {
-        "message": "Visa återstående videotid"
-    },
-    "showVersion": {
-        "message": "Visa version"
-    },
-    "shuffle": {
-        "message": "Blanda"
-    },
-    "sidebar": {
-        "message": "Sidofält"
-    },
-    "softwareInformation": {
-        "message": "Programvaruinformation"
-    },
-    "spacebar": {
-        "message": "Mellanslag"
-    },
-    "squaredUserImages": {
-        "message": "Användarbilder i kvadrat"
-    },
-    "static": {
-        "message": "Statisk"
-    },
-    "statsForNerds": {
-        "message": "Visa statistik för nördar"
-    },
-    "step": {
-        "message": "Steg"
-    },
-    "stop": {
-        "message": "Stopp"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stiler"
-    },
-    "subscribe": {
-        "message": "Prenumerera"
-    },
-    "subscriptions": {
-        "message": "Prenumerationer"
-    },
-    "subtitles": {
-        "message": "Undertexter"
-    },
-    "sunset": {
-        "message": "Solnedgång"
-    },
-    "sunsetToSunrise": {
-        "message": "Solnedgång till soluppgång"
-    },
-    "systemPeferenceDark": {
-        "message": "Systemval: mörk"
-    },
-    "systemPeferenceLight": {
-        "message": "Systemval: ljus"
-    },
-    "teal": {
-        "message": "Blågrön"
-    },
-    "textColor": {
-        "message": "Textfärg"
-    },
-    "thanks": {
-        "message": "Tack"
-    },
-    "themes": {
-        "message": "Teman"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Detta tar bort alla cookies."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Detta tar bort alla tittade videor."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Detta tar bort alla YouTube-cookies"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Detta återställer alla inställningar."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Detta återställer alla snabbkommandon"
-    },
-    "thumbnails": {
-        "message": "Miniatyrbilder"
-    },
-    "thumbnailsQuality": {
-        "message": "Kvalitet på miniatyrbilder"
-    },
-    "timeFrom": {
-        "message": "Tid från"
-    },
-    "timeTo": {
-        "message": "Tid till"
-    },
-    "todayAt": {
-        "message": "Idag vid"
-    },
-    "toggleAutoplay": {
-        "message": "Växla autoplay"
-    },
-    "toggleCards": {
-        "message": "Växla kort"
-    },
-    "toggleControls": {
-        "message": "Växla spelarkontroller"
-    },
-    "topChat": {
-        "message": "Topp chatt"
-    },
-    "trackWatchedVideos": {
-        "message": "Spåra visade videor"
-    },
-    "trailerAutoplay": {
-        "message": "Autoplay av trailer"
-    },
-    "translations": {
-        "message": "Översättningar"
-    },
-    "transparentBackground": {
-        "message": "Transparent bakgrund"
-    },
-    "trending": {
-        "message": "Trendande"
-    },
-    "tryToReloadThePage": {
-        "message": "Försök att ladda om sidan"
-    },
-    "type": {
-        "message": "Typ"
-    },
-    "upNextAutoplay": {
-        "message": "Spela nästa video automatiskt"
-    },
-    "use24HourFormat": {
-        "message": "Använd 24-timmars format"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Videobeskrivningen kommer att utökas för att få namnet på kategorin"
-    },
-    "videoFormats": {
-        "message": "Videoformat"
-    },
-    "videos": {
-        "message": "Videor"
-    },
-    "viewMode": {
-        "message": "Visningsläge"
-    },
-    "volume": {
-        "message": "Volym"
-    },
-    "watchLater": {
-        "message": "Titta på senare"
-    },
-    "watchTime": {
-        "message": "Visningstid"
-    },
-    "whenPaused": {
-        "message": "När pausad"
-    },
-    "whenTabIsChanged": {
-        "message": "När fliken ändras"
-    },
-    "white": {
-        "message": "Vit"
-    },
-    "windowColor": {
-        "message": "Fönsterfärg"
-    },
-    "windowOpacity": {
-        "message": "Fönstrets opacitet"
-    },
-    "yellow": {
-        "message": "Gul"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube rubrik (vänster)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube rubrik (höger)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube hemsida"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube språk"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube begränsar videokvaliteten till 1080p för h.264-codec."
-    }
+	"about": {
+		"message": "Om"
+	},
+	"accept": {
+		"message": "Acceptera"
+	},
+	"activate": {
+		"message": "Aktivera"
+	},
+	"activateCaptions": {
+		"message": "Aktivera undertexter"
+	},
+	"activated": {
+		"message": "Aktiverad"
+	},
+	"activatedFeatures": {
+		"message": "Aktiverade funktioner"
+	},
+	"activateFullscreen": {
+		"message": "Aktivera helskärm"
+	},
+	"activeFeatures": {
+		"message": "Aktiva funktioner"
+	},
+	"addScrollToTop": {
+		"message": "Lägg till «Scrolla till toppen»"
+	},
+	"ads": {
+		"message": "Reklam"
+	},
+	"all": {
+		"message": "Allt"
+	},
+	"allow": {
+		"message": "Tillåt"
+	},
+	"always": {
+		"message": "Alltid"
+	},
+	"alwaysActive": {
+		"message": "Alltid aktiv"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Visa alltid tidslinje"
+	},
+	"amber": {
+		"message": "Bärnsten"
+	},
+	"animations": {
+		"message": "Animationer"
+	},
+	"appearance": {
+		"message": "Utseende"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Är du säker på att du vill exportera data?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Är du säker på att du vill importera data?"
+	},
+	"audio": {
+		"message": "Ljud"
+	},
+	"audioFormats": {
+		"message": "Ljudformat"
+	},
+	"autoFullscreen": {
+		"message": "Automatisk helskärm"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Pausa automatiskt när jag inte är i fliken"
+	},
+	"avoidAv1": {
+		"message": "Undvik AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Undvik AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Undvik AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Undvik CPU-rendering när det är möjligt"
+	},
+	"backgroundColor": {
+		"message": "Bakgrundsfärg"
+	},
+	"backgroundOpacity": {
+		"message": "Opacitet för bakgrund"
+	},
+	"backupAndReset": {
+		"message": "Backup och återställning"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Basera på systemets färgschema"
+	},
+	"belowPlayer": {
+		"message": "Under spelaren"
+	},
+	"black": {
+		"message": "Svart"
+	},
+	"blockAll": {
+		"message": "Av (blockera eller hoppa över)"
+	},
+	"blockAv1": {
+		"message": "Blockera AV1"
+	},
+	"blockH264": {
+		"message": "Blockera H.264"
+	},
+	"blockMusic": {
+		"message": "Hoppa över reklam medan jag spelar musik"
+	},
+	"blockVp8": {
+		"message": "Blockera VP8"
+	},
+	"blue": {
+		"message": "Blå"
+	},
+	"blueGray": {
+		"message": "Blågrå"
+	},
+	"bluelight": {
+		"message": "Blåljus"
+	},
+	"brown": {
+		"message": "Brun"
+	},
+	"browser": {
+		"message": "Webbläsare"
+	},
+	"browserVersion": {
+		"message": "Webbläsarversion"
+	},
+	"bubbles": {
+		"message": "Bubblor"
+	},
+	"bug": {
+		"message": "Fel"
+	},
+	"buttons": {
+		"message": "Knappar"
+	},
+	"cancel": {
+		"message": "Avbryt"
+	},
+	"categories": {
+		"message": "Kategorier"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanaler"
+	},
+	"characterEdgeStyle": {
+		"message": "Karaktärsgräns"
+	},
+	"clipboard": {
+		"message": "Urklipp"
+	},
+	"collapsed": {
+		"message": "Hopvikt"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Vik prenumerationernas sektioner (hopfällt dragspel)"
+	},
+	"comments": {
+		"message": "Kommentarer"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Bekräftelse vid stängning"
+	},
+	"cores": {
+		"message": "Kärnor"
+	},
+	"cropChapterTitles": {
+		"message": "Beskär kapiteltitlar"
+	},
+	"custom": {
+		"message": "Anpassad"
+	},
+	"customCss": {
+		"message": "Anpassad CSS"
+	},
+	"customJs": {
+		"message": "Anpassad JS"
+	},
+	"customMiniPlayer": {
+		"message": "Anpassad Mini-Player"
+	},
+	"dark": {
+		"message": "Mörk"
+	},
+	"darkTheme": {
+		"message": "Mörkt tema"
+	},
+	"dateAndTime": {
+		"message": "Datum och tid"
+	},
+	"dawn": {
+		"message": "Gryning"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Sänka uppspelningshastigheten"
+	},
+	"decreaseVolume": {
+		"message": "Sänka volymen"
+	},
+	"deepOrange": {
+		"message": "Djupt orange"
+	},
+	"deepPurple": {
+		"message": "Djupt lila"
+	},
+	"default": {
+		"message": "Standard"
+	},
+	"defaultChannelTab": {
+		"message": "Standardflik för kanal"
+	},
+	"defaultContentCountry": {
+		"message": "Land (virtual travel)"
+	},
+	"deleteWatchedVideos": {
+		"message": "Radera tittade videor"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Radera YouTube-cookies"
+	},
+	"description": {
+		"message": "Beskrivning"
+	},
+	"desert": {
+		"message": "Öken"
+	},
+	"details": {
+		"message": "Detaljer"
+	},
+	"developerOptions": {
+		"message": "Utvecklingsalternativ"
+	},
+	"device": {
+		"message": "Enhet"
+	},
+	"disabled": {
+		"message": "Inaktiverad"
+	},
+	"dislike": {
+		"message": "Gilla inte"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Visa veckodag"
+	},
+	"donate": {
+		"message": "Donera"
+	},
+	"doNotChange": {
+		"message": "Ändra ej"
+	},
+	"draggable": {
+		"message": "Flyttbar"
+	},
+	"durationWithSpeed": {
+		"message": "Visa återstående tid i förhållande till uppspelningshastigheten"
+	},
+	"email": {
+		"message": "E-mail"
+	},
+	"empty": {
+		"message": "tomt"
+	},
+	"enabled": {
+		"message": "Aktiverad"
+	},
+	"enabledForced": {
+		"message": "Aktiverad (tvingad)"
+	},
+	"expanded": {
+		"message": "Expanderad"
+	},
+	"exportSettings": {
+		"message": "Exportera inställningar"
+	},
+	"extension": {
+		"message": "Tillägg"
+	},
+	"file": {
+		"message": "Fil"
+	},
+	"filters": {
+		"message": "Filter"
+	},
+	"fitToWindow": {
+		"message": "Gammalt alternativ ('Anpassa till fönster')"
+	},
+	"font": {
+		"message": "Teckensnitt"
+	},
+	"fontColor": {
+		"message": "Teckensnittsfärg"
+	},
+	"fontFamily": {
+		"message": "Teckensnittsfamilj"
+	},
+	"fontOpacity": {
+		"message": "Opacitet för teckensnitt"
+	},
+	"fontSize": {
+		"message": "Teckenstorlek"
+	},
+	"footer": {
+		"message": "Sidfot"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Forcerad uppspelningshastighet"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(Tvinga uppspelningshastighet även för musik?)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Tvinga video att spela från början"
+	},
+	"forcedTheaterMode": {
+		"message": "Påtvingad teaterläge"
+	},
+	"forcedVolume": {
+		"message": "Påtvingad volym"
+	},
+	"forceSDR": {
+		"message": "Undvik HDR, använd SDR"
+	},
+	"foundABug": {
+		"message": "Hittade ett fel?"
+	},
+	"fullWindow": {
+		"message": "Helt fönster"
+	},
+	"general": {
+		"message": "Allmänt"
+	},
+	"geoPreference": {
+		"message": "Geo-preferens"
+	},
+	"goToSearchBox": {
+		"message": "Gå till sökfältet"
+	},
+	"green": {
+		"message": "Grön"
+	},
+	"hardwareInformation": {
+		"message": "Information om hårdvara"
+	},
+	"hdThumbnail": {
+		"message": "HD miniatyrbild"
+	},
+	"header": {
+		"message": "Rubrik"
+	},
+	"hidden": {
+		"message": "Dold"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Dold på videosidan"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Dölj animerade miniatyrbilder"
+	},
+	"hideAnnotations": {
+		"message": "Dölj anteckningar"
+	},
+	"hideCards": {
+		"message": "Dölj kort"
+	},
+	"hideCategories": {
+		"message": "Dölj kategorier"
+	},
+	"hideCommentsCount": {
+		"message": "Dölj antal kommentarer"
+	},
+	"hideCountryCode": {
+		"message": "Dölj landskod"
+	},
+	"hideDate": {
+		"message": "Dölj datum"
+	},
+	"hideDetailButton": {
+		"message": "Knappar"
+	},
+	"hideDetails": {
+		"message": "Dölj detaljer"
+	},
+	"hideEndscreen": {
+		"message": "Dölj slutskärm"
+	},
+	"hideFeaturedContent": {
+		"message": "Dölj framhävt innehåll"
+	},
+	"hideFooter": {
+		"message": "Dölj sidfoten"
+	},
+	"hideGradientBottom": {
+		"message": "Dölj skuggor runt spelarfältet"
+	},
+	"hideHomePageShorts": {
+		"message": "Ta bort Shorts från startsidan"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Dölj kontrollfältet för spelare"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Dölj knappar i fältet för spelarkontroller"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Dölj alternativ för spelarkontroll"
+	},
+	"hidePlaylist": {
+		"message": "Dölj spellista"
+	},
+	"hideRightButtons": {
+		"message": "Dölj högerknappar"
+	},
+	"hideScrollForDetails": {
+		"message": "Dölj «Bläddra för detaljer»"
+	},
+	"hideSkipOverlay": {
+		"message": "Dölj 5 sekunders hoppa över animering"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Dölj knappar på miniatyrbilder"
+	},
+	"hideThumbnails": {
+		"message": "Dölj miniatyrbilder"
+	},
+	"hideViewsCount": {
+		"message": "Dölj antal visningar"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Dölj knappen för röstsökning"
+	},
+	"high": {
+		"message": "Hög"
+	},
+	"history": {
+		"message": "Historik"
+	},
+	"home": {
+		"message": "Hem"
+	},
+	"hover": {
+		"message": "Visa vid muspekning"
+	},
+	"hoverOnVideoPage": {
+		"message": "Visa vid muspekning på videosidor"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Visa videons ålder (sedan uppladdningsdatum)"
+	},
+	"icons": {
+		"message": "Ikoner"
+	},
+	"iconsOnly": {
+		"message": "Endast ikoner"
+	},
+	"importSettings": {
+		"message": "Importera inställningar"
+	},
+	"improvedtubeButtons": {
+		"message": "ImprovedTube knappar"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "ImprovedTube ikon på YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube språk"
+	},
+	"improveLogo": {
+		"message": "Förbättra logotypen"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Öka uppspelningshastigheten"
+	},
+	"increaseVolume": {
+		"message": "Höj volymen"
+	},
+	"language": {
+		"message": "Språk"
+	},
+	"languages": {
+		"message": "Språk"
+	},
+	"layerAnimationScale": {
+		"message": "Skala för lageranimering"
+	},
+	"legacyYoutube": {
+		"message": "Klassisk YouTube"
+	},
+	"library": {
+		"message": "Bibliotek"
+	},
+	"light": {
+		"message": "Ljus"
+	},
+	"lightBlue": {
+		"message": "Ljusblå"
+	},
+	"lightGreen": {
+		"message": "Ljusgrön"
+	},
+	"like": {
+		"message": "Gilla"
+	},
+	"liked": {
+		"message": "Gillat"
+	},
+	"limitPageWidth": {
+		"message": "Begränsa sidbredd"
+	},
+	"list": {
+		"message": "Lista"
+	},
+	"liveChat": {
+		"message": "Livechatt"
+	},
+	"liveChatType": {
+		"message": "Typ av livechatt"
+	},
+	"location": {
+		"message": "Plats"
+	},
+	"loudnessNormalization": {
+		"message": "Normalisering av ljudnivå"
+	},
+	"low": {
+		"message": "Låg"
+	},
+	"markWatchedVideos": {
+		"message": "Markera visade videor"
+	},
+	"more": {
+		"message": "Mera"
+	},
+	"mostViewedChannels": {
+		"message": "Mest visade kanaler"
+	},
+	"moveSidebarLeft": {
+		"message": "Till vänster!"
+	},
+	"moveThumbnailsRight": {
+		"message": "Miniatyrbilder till höger!"
+	},
+	"myColors": {
+		"message": "Mina färger"
+	},
+	"name": {
+		"message": "Namn"
+	},
+	"nativeMiniPlayer": {
+		"message": "Inbyggd mini-spelare"
+	},
+	"new": {
+		"message": "Ny"
+	},
+	"nextVideo": {
+		"message": "Nästa video"
+	},
+	"night": {
+		"message": "Natt"
+	},
+	"nightMode": {
+		"message": "Nattläge"
+	},
+	"noActiveFeatures": {
+		"message": "Inga aktiva funktioner"
+	},
+	"none": {
+		"message": "Inga"
+	},
+	"noOpenVideoTabs": {
+		"message": "Inga öppna videoflikar"
+	},
+	"off": {
+		"message": "Av"
+	},
+	"old": {
+		"message": "Gammal"
+	},
+	"onAllVideos": {
+		"message": "På"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Enbart aktivt på YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Pausa medan jag tittar på en andra video"
+	},
+	"onSubscribedChannels": {
+		"message": "Av, förutom på mina prenumererade kanaler"
+	},
+	"openPopupPlayer": {
+		"message": "Öppna video/spellista i ny flik"
+	},
+	"other": {
+		"message": "Annat"
+	},
+	"outline": {
+		"message": "Gräns"
+	},
+	"overlay": {
+		"message": "Överlägg"
+	},
+	"permissions": {
+		"message": "Tillstånd"
+	},
+	"pictureInPicture": {
+		"message": "Bild-i-bild"
+	},
+	"pink": {
+		"message": "Rosa"
+	},
+	"plain": {
+		"message": "Slät"
+	},
+	"platform": {
+		"message": "Plattform"
+	},
+	"playAllButton": {
+		"message": "\"Spela allt\"knapp"
+	},
+	"playbackSpeed": {
+		"message": "Uppspelningshastighet"
+	},
+	"player": {
+		"message": "Spelare"
+	},
+	"playerColor": {
+		"message": "Färj på spelare"
+	},
+	"playerSize": {
+		"message": "Storlek på spelare"
+	},
+	"playlist": {
+		"message": "Spellista"
+	},
+	"playlists": {
+		"message": "Spellistor"
+	},
+	"playPause": {
+		"message": "Spela / Pausa"
+	},
+	"popupPlayer": {
+		"message": "Spelare i eget fönster"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Tryck på valfri knapp eller använd mushjulet."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Tryck på valfri knapp eller använd mushjulet."
+	},
+	"previousVideo": {
+		"message": "Föregående video"
+	},
+	"primaryColor": {
+		"message": "Primärfärg"
+	},
+	"purple": {
+		"message": "Lila"
+	},
+	"quality": {
+		"message": "Kvalitet"
+	},
+	"raised": {
+		"message": "Höjd"
+	},
+	"rateMe": {
+		"message": "Betygsätt mig"
+	},
+	"rateUs": {
+		"message": "Betygsätt oss"
+	},
+	"red": {
+		"message": "Röd"
+	},
+	"redDislikeButton": {
+		"message": "Röd Gilla inte-knapp"
+	},
+	"relatedVideos": {
+		"message": "Relaterade videor"
+	},
+	"remote": {
+		"message": "Spela på TV"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Ta bort relaterade sökresultat"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Ta bort Shorts-reel från sökresultaten"
+	},
+	"repeat": {
+		"message": "Repetera"
+	},
+	"report": {
+		"message": "Rapportera"
+	},
+	"reset": {
+		"message": "Återställ"
+	},
+	"resetAllSettings": {
+		"message": "Återställ alla inställningar"
+	},
+	"resetAllShortcuts": {
+		"message": "Återställ alla snabbkommandon"
+	},
+	"reverse": {
+		"message": "Omvänd"
+	},
+	"rotate": {
+		"message": "Rotera"
+	},
+	"save": {
+		"message": "Spara"
+	},
+	"saveAs": {
+		"message": "Spara som"
+	},
+	"schedule": {
+		"message": "Tidsplan"
+	},
+	"screen": {
+		"message": "Bildskärm"
+	},
+	"screenshot": {
+		"message": "Skärmdump"
+	},
+	"scrollBar": {
+		"message": "Rullningslist"
+	},
+	"search": {
+		"message": "Sök"
+	},
+	"searchBarOnly": {
+		"message": "Endast sökfält"
+	},
+	"seekBackward10Seconds": {
+		"message": "Sök bakåt 10 sekunder"
+	},
+	"seekForward10Seconds": {
+		"message": "Sök framåt 10 sekunder"
+	},
+	"seekNextChapter": {
+		"message": "Sök nästa kapitel"
+	},
+	"seekPreviousChapter": {
+		"message": "Sök föregående kapitel"
+	},
+	"settings": {
+		"message": "Inställningar"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Inställningarna har importerats"
+	},
+	"share": {
+		"message": "Dela"
+	},
+	"shortcuts": {
+		"message": "Snabbkommandon"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Visa informationskort vid muspekaren"
+	},
+	"showChannelVideosCount": {
+		"message": "Visa antal kanalvideor"
+	},
+	"showLess": {
+		"message": "Visa färre"
+	},
+	"showMore": {
+		"message": "Visa fler"
+	},
+	"showRemainingDuration": {
+		"message": "Visa återstående videotid"
+	},
+	"showVersion": {
+		"message": "Visa version"
+	},
+	"shuffle": {
+		"message": "Blanda"
+	},
+	"sidebar": {
+		"message": "Sidofält"
+	},
+	"softwareInformation": {
+		"message": "Programvaruinformation"
+	},
+	"spacebar": {
+		"message": "Mellanslag"
+	},
+	"squaredUserImages": {
+		"message": "Användarbilder i kvadrat"
+	},
+	"static": {
+		"message": "Statisk"
+	},
+	"statsForNerds": {
+		"message": "Visa statistik för nördar"
+	},
+	"step": {
+		"message": "Steg"
+	},
+	"stop": {
+		"message": "Stopp"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stiler"
+	},
+	"subscribe": {
+		"message": "Prenumerera"
+	},
+	"subscriptions": {
+		"message": "Prenumerationer"
+	},
+	"subtitles": {
+		"message": "Undertexter"
+	},
+	"sunset": {
+		"message": "Solnedgång"
+	},
+	"sunsetToSunrise": {
+		"message": "Solnedgång till soluppgång"
+	},
+	"systemPeferenceDark": {
+		"message": "Systemval: mörk"
+	},
+	"systemPeferenceLight": {
+		"message": "Systemval: ljus"
+	},
+	"teal": {
+		"message": "Blågrön"
+	},
+	"textColor": {
+		"message": "Textfärg"
+	},
+	"thanks": {
+		"message": "Tack"
+	},
+	"themes": {
+		"message": "Teman"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Detta tar bort alla cookies."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Detta tar bort alla tittade videor."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Detta tar bort alla YouTube-cookies"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Detta återställer alla inställningar."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Detta återställer alla snabbkommandon"
+	},
+	"thumbnails": {
+		"message": "Miniatyrbilder"
+	},
+	"thumbnailsQuality": {
+		"message": "Kvalitet på miniatyrbilder"
+	},
+	"timeFrom": {
+		"message": "Tid från"
+	},
+	"timeTo": {
+		"message": "Tid till"
+	},
+	"todayAt": {
+		"message": "Idag vid"
+	},
+	"toggleAutoplay": {
+		"message": "Växla autoplay"
+	},
+	"toggleCards": {
+		"message": "Växla kort"
+	},
+	"toggleControls": {
+		"message": "Växla spelarkontroller"
+	},
+	"topChat": {
+		"message": "Topp chatt"
+	},
+	"trackWatchedVideos": {
+		"message": "Spåra visade videor"
+	},
+	"trailerAutoplay": {
+		"message": "Autoplay av trailer"
+	},
+	"translations": {
+		"message": "Översättningar"
+	},
+	"transparentBackground": {
+		"message": "Transparent bakgrund"
+	},
+	"trending": {
+		"message": "Trendande"
+	},
+	"tryToReloadThePage": {
+		"message": "Försök att ladda om sidan"
+	},
+	"type": {
+		"message": "Typ"
+	},
+	"upNextAutoplay": {
+		"message": "Spela nästa video automatiskt"
+	},
+	"use24HourFormat": {
+		"message": "Använd 24-timmars format"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Videobeskrivningen kommer att utökas för att få namnet på kategorin"
+	},
+	"videoFormats": {
+		"message": "Videoformat"
+	},
+	"videos": {
+		"message": "Videor"
+	},
+	"viewMode": {
+		"message": "Visningsläge"
+	},
+	"volume": {
+		"message": "Volym"
+	},
+	"watchLater": {
+		"message": "Titta på senare"
+	},
+	"watchTime": {
+		"message": "Visningstid"
+	},
+	"whenPaused": {
+		"message": "När pausad"
+	},
+	"whenTabIsChanged": {
+		"message": "När fliken ändras"
+	},
+	"white": {
+		"message": "Vit"
+	},
+	"windowColor": {
+		"message": "Fönsterfärg"
+	},
+	"windowOpacity": {
+		"message": "Fönstrets opacitet"
+	},
+	"yellow": {
+		"message": "Gul"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube rubrik (vänster)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube rubrik (höger)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube hemsida"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube språk"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube begränsar videokvaliteten till 1080p för h.264-codec."
+	}
 }

--- a/_locales/sw/messages.json
+++ b/_locales/sw/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "Ondoa Shorts kutoka ukurasa wa nyumbani"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Ondoa gurudumu la Shorts kutoka kwenye matokeo ya utafutaji"
-    }
+	"hideHomePageShorts": {
+		"message": "Ondoa Shorts kutoka ukurasa wa nyumbani"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Ondoa gurudumu la Shorts kutoka kwenye matokeo ya utafutaji"
+	}
 }

--- a/_locales/sw_KE/messages.json
+++ b/_locales/sw_KE/messages.json
@@ -1,1292 +1,1232 @@
 {
-    "about": {
-        "message": "Kuhusu/"
-    },
-    "accept": {
-        "message": "Kubali"
-    },
-    "activate": {
-        "message": "Amilisha/ wezesha"
-    },
-    "activateCaptions": {
-        "message": "Washa manukuu"
-    },
-    "activated": {
-        "message": "Imewashwa"
-    },
-    "activatedFeatures": {
-        "message": "Vipengele vilivyoamilishwa"
-    },
-    "activateFullscreen": {
-        "message": "Washa skrini nzima"
-    },
-    "activeFeatures": {
-        "message": "Vipengele vyangu vinavyotumika"
-    },
-    "addScrollToTop": {
-        "message": "Ongeza «STembeza hadi juu»"
-    },
-    "ads": {
-        "message": "Matangazo"
-    },
-    "all": {
-        "message": "Yote"
-    },
-    "allow": {
-        "message": "Ruhusu"
-    },
-    "Allow_auto_generate": {
-        "message": "Ruhusu kuzalisha kiotomatiki"
-    },
-    "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "Mipangilio yako yote itafutwa na haiwezi kurejeshwa"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "Njia zako zote za mkato zitafutwa na haziwezi kurejeshwa"
-    },
-    "always": {
-        "message": "Kila mara"
-    },
-    "alwaysActive": {
-        "message": "Inatumika kila wakati"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Onyesha upau wa maendeleo kila wakati"
-    },
-    "amber": {
-        "message": "Amber"
-    },
-    "analyzer": {
-        "message": "Analyzer"
-    },
-    "animations": {
-        "message": "Katuni"
-    },
-    "appearance": {
-        "message": "Muonekano"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Je, una uhakika unataka kuhamisha data?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Je, una uhakika unataka kuleta data hii?"
-    },
-    "ARROWDOWN": {
-        "message": "Chini"
-    },
-    "ARROWLEFT": {
-        "message": "Kushoto/ kando"
-    },
-    "ARROWRIGHT": {
-        "message": "Kulia/ kando"
-    },
-    "ARROWUP": {
-        "message": "Juu"
-    },
-    "atHistory": {
-        "message": "kwa 'Historia'"
-    },
-    "atSubscriptions": {
-        "message": "kwa 'Usajili'"
-    },
-    "atTrending": {
-        "message": "Yanayovuma"
-    },
-    "audio": {
-        "message": "Sauti"
-    },
-    "audioFormats": {
-        "message": "Miundo ya sauti"
-    },
-    "auto": {
-        "message": "Otomatiki"
-    },
-    "Auto_PiP_picture_in_picture": {
-        "message": "Auto-PiP (picha kwenye picha)"
-    },
-    "autoFullscreen": {
-        "message": "Skrini kamili kiotomatiki"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Sitisha kiotomatiki wakati sipo kwenye kichupo"
-    },
-    "autoPictureInPicture": {
-        "message": "Picha-Katika-Picha ya Kiotomatiki"
-    },
-    "autoplay": {
-        "message": "Autoplay"
-    },
-    "avoidAv1": {
-        "message": "Epuka AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Epuka AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Epuka AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Epuka utoaji wa CPU inapowezekana"
-    },
-    "backgroundColor": {
-        "message": "Rangi ya usuli"
-    },
-    "backgroundOpacity": {
-        "message": "Ufinyu wa mandharinyuma"
-    },
-    "backupAndReset": {
-        "message": "Hifadhi nakala na uweke upya"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Kulingana na mpango wa rangi ya mfumo"
-    },
-    "belowPlayer": {
-        "message": "Chini ya mchezaji"
-    },
-    "bitness": {
-        "message": "Bitness"
-    },
-    "black": {
-        "message": "Nyeusi"
-    },
-    "block_Codec_Alert_h264": {
-        "message": "Unahitaji H.264 au VP9 kuwezeshwa kwa YouTube ili kucheza video."
-    },
-    "blockAll": {
-        "message": "Imezimwa (zuia au ruka)"
-    },
-    "blockAv1": {
-        "message": "Zuia AV1"
-    },
-    "blockH264": {
-        "message": "Zuia H.264"
-    },
-    "blocklist": {
-        "message": "Orodha ya kuzuia"
-    },
-    "blockMusic": {
-        "message": "Ruka matangazo ninapocheza muziki"
-    },
-    "blockVp8": {
-        "message": "Zuia VP8"
-    },
-    "blockVp9": {
-        "message": "Zuia VP9"
-    },
-    "blue": {
-        "message": "Bluu"
-    },
-    "blueGray": {
-        "message": "Bluu kijivu"
-    },
-    "bluelight": {
-        "message": "Mwanga wa Bluu"
-    },
-    "brightness": {
-        "message": "Mwangaza"
-    },
-    "brown": {
-        "message": "Brown"
-    },
-    "browser": {
-        "message": "Kivinjari/ Browser"
-    },
-    "browserVersion": {
-        "message": "Toleo la kivinjari"
-    },
-    "bubbles": {
-        "message": "Mapovu"
-    },
-    "bug": {
-        "message": "Mdudu"
-    },
-    "buttons": {
-        "message": "Vidude"
-    },
-    "cancel": {
-        "message": "Ghairi/ kata"
-    },
-    "categories": {
-        "message": "Kategoria"
-    },
-    "channel": {
-        "message": "Kituo"
-    },
-    "channels": {
-        "message": "Vituo"
-    },
-    "chapters": {
-        "message": "Sura"
-    },
-    "characterEdgeStyle": {
-        "message": "Mtindo wa makali ya tabia"
-    },
-    "clip": {
-        "message": "Klipu"
-    },
-    "clipboard": {
-        "message": "Ubao wa kunakili"
-    },
-    "codecH264": {
-        "message": "Kodeki h.264"
-    },
-    "codecs": {
-        "message": "Kodeki"
-    },
-    "collapsed": {
-        "message": "Imekunjwa"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Pinda sehemu za usajili (accordion iliyokunjwa)"
-    },
-    "comments": {
-        "message": "Maoni"
-    },
-    "compact_spacing": {
-        "message": "Nafasi Iliyounganishwa"
-    },
-    "compactTheme": {
-        "message": "Mandhari Compact"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Uthibitisho kabla ya kufungwa"
-    },
-    "cookies": {
-        "message": "Vidakuzi"
-    },
-    "cores": {
-        "message": "Mihimili"
-    },
-    "cropChapterTitles": {
-        "message": "kata vichwa vya sura"
-    },
-    "Currently_requiring_a_YouTube_API_key": {
-        "message": "(Kwa sasa inahitaji ufunguo-API wa YouTube :)"
-    },
-    "custom": {
-        "message": "Desturi"
-    },
-    "customCss": {
-        "message": "Desturi CSS"
-    },
-    "customJs": {
-        "message": "Desturi JS"
-    },
-    "customMiniPlayer": {
-        "message": "Kicheza Kidogo Maalum"
-    },
-    "cyan": {
-        "message": "Cyan"
-    },
-    "dark": {
-        "message": "Giza"
-    },
-    "darkTheme": {
-        "message": "Mandhari meusi"
-    },
-    "dateAndTime": {
-        "message": "Tarehe na wakati"
-    },
-    "dawn": {
-        "message": "Alfajiri"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Punguza kasi ya kucheza"
-    },
-    "decreaseVolume": {
-        "message": "Punguza Sauti"
-    },
-    "deepOrange": {
-        "message": "Chungwa kirefu"
-    },
-    "deepPurple": {
-        "message": "Zambarau ya kina"
-    },
-    "default": {
-        "message": "Chaguomsingi"
-    },
-    "default_CC": {
-        "message": "chaguo-msingi"
-    },
-    "default_theme": {
-        "message": "chaguo-msingi (mandhari)"
-    },
-    "defaultChannelTab": {
-        "message": "Kichupo chaguomsingi cha kituo"
-    },
-    "defaultContentCountry": {
-        "message": "Nchi (safari halisi)"
-    },
-    "defaultPlaybackSpeed": {
-        "message": "Kasi ya Uchezaji Chaguomsingi"
-    },
-    "deleteWatchedVideos": {
-        "message": "Futa video ulizotazama"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Futa vidakuzi vya YouTube"
-    },
-    "depressed": {
-        "message": "Unyogovu"
-    },
-    "description": {
-        "message": "Maelezo"
-    },
-    "description_ext": {
-        "message": "YouTube, nadhifu + nadhifu? Video ya YouTube ukubwa wa kichezaji cha youtube rangi ya tangazo ruka kasi ya vitambulisho vya nahodha wa orodha ya kucheza"
-    },
-    "desert": {
-        "message": "Jangwa"
-    },
-    "details": {
-        "message": "Maelezo"
-    },
-    "developerOptions": {
-        "message": "Chaguzi za msanidi/ developa"
-    },
-    "device": {
-        "message": "Kifaa/ Chombo"
-    },
-    "dim": {
-        "message": "Dim"
-    },
-    "disabled": {
-        "message": "Imezimwa"
-    },
-    "dislike": {
-        "message": "Sipendi"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Siku ya maonyesho ya wiki"
-    },
-    "donate": {
-        "message": "Changia"
-    },
-    "doNotChange": {
-        "message": "Usibadilike"
-    },
-    "download": {
-        "message": "Pakua"
-    },
-    "draggable": {
-        "message": "Inaweza kuburuzwa"
-    },
-    "dropShadow": {
-        "message": "Kuacha kivuli"
-    },
-    "durationWithSpeed": {
-        "message": "Onyesha muda uliosalia kwa kurejelea kasi ya uchezaji"
-    },
-    "email": {
-        "message": "Barua pepe/ Email"
-    },
-    "embedded_Hide_Share": {
-        "message": "Imepachikwa Ficha Kushiriki"
-    },
-    "Embedded_YouTube": {
-        "message": "YouTube iliyopachikwa"
-    },
-    "empty": {
-        "message": "Tupu"
-    },
-    "enabled": {
-        "message": "Imewashwa"
-    },
-    "enabledForced": {
-        "message": "Imewashwa (kulazimishwa)"
-    },
-    "expanded": {
-        "message": "Imepanuliwa"
-    },
-    "exportSettings": {
-        "message": "Hamisha mipangilio"
-    },
-    "extension": {
-        "message": "Ugani"
-    },
-    "ExtraButtons": {
-        "message": "Vidude zaidi"
-    },
-    "extraButtonsBelowThePlayer": {
-        "message": "Vifungo vya ziada chini ya mchezaji"
-    },
-    "Feature_not_yet_available": {
-        "message": "Kipengele bado hakijapatikana"
-    },
-    "file": {
-        "message": "Faili"
-    },
-    "filters": {
-        "message": "Vichujio"
-    },
-    "fitToWindow": {
-        "message": "Mbadala wa zamani ('Fit to window')"
-    },
-    "flash": {
-        "message": "Mwako"
-    },
-    "font": {
-        "message": "Fonti"
-    },
-    "fontColor": {
-        "message": "Rangi ya herufi"
-    },
-    "fontFamily": {
-        "message": "Familia ya herufi"
-    },
-    "fontOpacity": {
-        "message": "Uwazi wa fonti"
-    },
-    "fontSize": {
-        "message": "Ukubwa wa herufi"
-    },
-    "footer": {
-        "message": "Kijachini"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Kuangalia kasi: Kasi ya kudumu"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Lazimisha kasi ya kucheza hata kwa muziki?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Lazimisha video kucheza tangu mwanzo"
-    },
-    "forcedTheaterMode": {
-        "message": "Hali ya ukumbi wa michezo ya kulazimishwa"
-    },
-    "forcedVolume": {
-        "message": "Kiasi cha kulazimishwa/ sauti ya kulazimishwa"
-    },
-    "forceSDR": {
-        "message": "Epuka HDR, weka SDR"
-    },
-    "foundABug": {
-        "message": "Imepata mdudu?"
-    },
-    "fullWindow": {
-        "message": "Urefu kamili"
-    },
-    "general": {
-        "message": "Mkuu"
-    },
-    "geoPreference": {
-        "message": "Upendeleo wa Geo"
-    },
-    "github": {
-        "message": "GitHub"
-    },
-    "googleApiKey": {
-        "message": "Ufunguo wa API ya Google"
-    },
-    "goToSearchBox": {
-        "message": "Nenda kwenye kisanduku cha kutafutia"
-    },
-    "gpu": {
-        "message": "GPU"
-    },
-    "GPUnotindatabase": {
-        "message": "GPU haiko kwenye hifadhidata"
-    },
-    "green": {
-        "message": "Kijani"
-    },
-    "grey": {
-        "message": "Kijivu"
-    },
-    "halfTransparent": {
-        "message": "Nusu angavu"
-    },
-    "Hamburger_Menu": {
-        "message": "Menyu ya Hamburger"
-    },
-    "hardwareInformation": {
-        "message": "Maelezo ya vifaa"
-    },
-    "hd": {
-        "message": "HD"
-    },
-    "hdThumbnail": {
-        "message": "Kijipicha cha HD"
-    },
-    "header": {
-        "message": "Kijajuu/ Kichwa"
-    },
-    "hidden": {
-        "message": "Imefichwa"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Imefichwa kwenye ukurasa wa video"
-    },
-    "hide_author_avatars": {
-        "message": "Ficha ishara za mwandishi"
-    },
-    "hide_labels": {
-        "message": "Ficha majina"
-    },
-    "Hide_Pause_Overlay": {
-        "message": "Ficha Sitisha Uwekeleaji"
-    },
-    "Hide_Shorts_remixing_this_video": {
-        "message": "Ficha Shorts zinazochanganya video hii upya"
-    },
-    "Hide_sidebar": {
-        "message": "Ficha utepe"
-    },
-    "Hide_the_tabs_only": {
-        "message": "Ficha vichupo pekee"
-    },
-    "Hide_YouTube_Logo": {
-        "message": "Ficha Nembo ya YouTube"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Ficha vijipicha vilivyohuishwa"
-    },
-    "hideAnnotations": {
-        "message": "Ficha ufafanuzi"
-    },
-    "hideCards": {
-        "message": "Ficha kadi"
-    },
-    "hideCategories": {
-        "message": "Ficha kategoria"
-    },
-    "hideCommentsCount": {
-        "message": "Ficha idadi ya maoni"
-    },
-    "hideCountryCode": {
-        "message": "Ficha msimbo wa nchi"
-    },
-    "hideDate": {
-        "message": "Ficha tarehe"
-    },
-    "hideDetailButton": {
-        "message": "Vifungo (chini ya mchezaji)"
-    },
-    "hideDetails": {
-        "message": "Ficha maelezo"
-    },
-    "hideEndscreen": {
-        "message": "Ficha skrini ya mwisho"
-    },
-    "hideFeaturedContent": {
-        "message": "Ficha maudhui yaliyoangaziwa"
-    },
-    "hideFooter": {
-        "message": "Ficha kijachini"
-    },
-    "hideGradientBottom": {
-        "message": "Ficha kivuli karibu na upau wa mchezaji"
-    },
-    "hideHomePageShorts": {
-        "message": "Ficha Shorts kwenye ukurasa wa nyumbani"
-    },
-    "hideMore": {
-        "message": "Ficha Mengi zaidi"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ficha upau wa vidhibiti vya mchezaji"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ficha vifungo vya udhibiti wa mchezaji"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ficha chaguzi za vidhibiti vya mchezaji"
-    },
-    "hidePlaylist": {
-        "message": "Ficha orodha ya kucheza"
-    },
-    "hideReport": {
-        "message": "Ficha Ripoti"
-    },
-    "hideRightButtons": {
-        "message": "Ficha vifungo vya kulia"
-    },
-    "hideScrollForDetails": {
-        "message": "Ficha «Sogeza kwa maelezo»"
-    },
-    "hideSkipOverlay": {
-        "message": "Ficha uhuishaji wa kuruka kwa sekunde 5"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ficha vitufe kwenye vijipicha"
-    },
-    "hideThumbnails": {
-        "message": "Ficha vijipicha"
-    },
-    "hideVideoTitleFullScreen": {
-        "message": "Ficha kichwa cha video kwenye skrini nzima"
-    },
-    "hideViewsCount": {
-        "message": "Ficha idadi ya waliotazamwa"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ficha kitufe cha kutafuta kwa kutamka"
-    },
-    "high": {
-        "message": "Juu"
-    },
-    "history": {
-        "message": "Historia"
-    },
-    "home": {
-        "message": "Nyumbani"
-    },
-    "homeScreen": {
-        "message": "Skrini ya nyumbani"
-    },
-    "hover": {
-        "message": "Elea juu"
-    },
-    "hoverOnVideoPage": {
-        "message": "Elea kwenye ukurasa wa video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Onyesha umri wa video (ilipakiwa kwa muda gani)"
-    },
-    "icons": {
-        "message": "Aikoni"
-    },
-    "iconsOnly": {
-        "message": "Aikoni pekee"
-    },
-    "importSettings": {
-        "message": "Ingiza mipangilio"
-    },
-    "ImprovedTube": {
-        "message": "Tube ilioimarika"
-    },
-    "improvedtubeButtons": {
-        "message": "Vifungo vyaTube vilivyoboreshwa"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Ikoni yaTube iliyoboreshwa kwenye YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube toleo"
-    },
-    "improveLogo": {
-        "message": "Boresha nembo"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Ongeza kasi ya kucheza"
-    },
-    "increaseVolume": {
-        "message": "Ongeza sauti"
-    },
-    "indigo": {
-        "message": "Indigo"
-    },
-    "items": {
-        "message": "Vipengee"
-    },
-    "language": {
-        "message": "Lugha"
-    },
-    "language_closed_caption": {
-        "message": "Lugha Chaguomsingi - Manukuu Yaliyofungwa"
-    },
-    "languages": {
-        "message": "Lugha"
-    },
-    "layerAnimationScale": {
-        "message": "Kiwango cha uhuishaji wa safu"
-    },
-    "layout": {
-        "message": "Mpangilio"
-    },
-    "legacyYoutube": {
-        "message": "Urithi wa YouTube"
-    },
-    "library": {
-        "message": "Maktaba"
-    },
-    "light": {
-        "message": "Mwanga"
-    },
-    "lightBlue": {
-        "message": "Bluu nyepesi"
-    },
-    "lightGreen": {
-        "message": "Mwanga wa kijani"
-    },
-    "like": {
-        "message": "Penda"
-    },
-    "liked": {
-        "message": "limependwa"
-    },
-    "likes": {
-        "message": "mapendo"
-    },
-    "lime": {
-        "message": "Chokaa/ Ndimu"
-    },
-    "limitPageWidth": {
-        "message": "Punguza upana wa ukurasa"
-    },
-    "list": {
-        "message": "Orodha"
-    },
-    "liveChat": {
-        "message": "Gumzo la moja kwa moja"
-    },
-    "liveChatType": {
-        "message": "Aina ya mazungumzo ya moja kwa moja"
-    },
-    "location": {
-        "message": "Mahali"
-    },
-    "loop": {
-        "message": "Kitanzi/ zunguka"
-    },
-    "loudnessNormalization": {
-        "message": "Urekebishaji wa sauti"
-    },
-    "low": {
-        "message": "Chini"
-    },
-    "markWatchedVideos": {
-        "message": "Weka alama kwenye video"
-    },
-    "medium": {
-        "message": "Kati/ katikati"
-    },
-    "mixer": {
-        "message": "Mchanganyiko"
-    },
-    "more": {
-        "message": "Mengi"
-    },
-    "mostViewedChannels": {
-        "message": "Vituo vilivyotazamwa zaidi"
-    },
-    "moveSidebarLeft": {
-        "message": "Upande wa kushoto!"
-    },
-    "moveThumbnailsRight": {
-        "message": "Vijipicha kulia!"
-    },
-    "My_specs": {
-        "message": "Vigezo vyangu"
-    },
-    "myColors": {
-        "message": "Rangi zangu"
-    },
-    "name": {
-        "message": "Jina"
-    },
-    "nativeMiniPlayer": {
-        "message": "Mchezaji mdogo wa asili"
-    },
-    "new": {
-        "message": "Mpya"
-    },
-    "nextVideo": {
-        "message": "Video inayofuata"
-    },
-    "night": {
-        "message": "Usiku"
-    },
-    "nightMode": {
-        "message": "Hali ya usiku"
-    },
-    "noActiveFeatures": {
-        "message": "Hakuna vipengele vinavyotumika"
-    },
-    "none": {
-        "message": "Hakuna"
-    },
-    "noOpenVideoTabs": {
-        "message": "Hakuna vichupo vya video vilivyofunguliwa"
-    },
-    "normal": {
-        "message": "Kawaida"
-    },
-    "Not_optimal": {
-        "message": "Sio bora"
-    },
-    "off": {
-        "message": "Imezimwa"
-    },
-    "ok": {
-        "message": "Sawa"
-    },
-    "old": {
-        "message": "Nzee/ zee"
-    },
-    "onAllVideos": {
-        "message": "Imewashwa"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Inatumika kwenye YouTube pekee"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Sitisha ninapotazama video ya pili"
-    },
-    "onSmallCreators": {
-        "message": "Imezimwa, isipokuwa chaneli ndogo"
-    },
-    "onSubscribedChannels": {
-        "message": "Imezimwa, isipokuwa kwenye vituo nilivyofuatilia"
-    },
-    "openNewTab": {
-        "message": "Fungua kwenye kichupo kipya"
-    },
-    "openPopupPlayer": {
-        "message": "Fungua video/orodha ya kucheza katika dirisha jipya"
-    },
-    "optimizeCodecForHardwareAcceleration": {
-        "message": "Boresha Kodeki kwa kuongeza kasi ya maunzi"
-    },
-    "orange": {
-        "message": "Chungwa"
-    },
-    "os": {
-        "message": "OS"
-    },
-    "other": {
-        "message": "ingine"
-    },
-    "outline": {
-        "message": "Muhtasari"
-    },
-    "overlay": {
-        "message": "Uwekeleaji"
-    },
-    "permissions": {
-        "message": "Ruhusa"
-    },
-    "pictureInPicture": {
-        "message": "Picha-ndani-Picha"
-    },
-    "pink": {
-        "message": "Pink"
-    },
-    "plain": {
-        "message": "Wazi"
-    },
-    "platform": {
-        "message": "Jukwaa"
-    },
-    "playAllButton": {
-        "message": "\"Cheza zote\"kifungo"
-    },
-    "playbackSpeed": {
-        "message": "Kasi ya uchezaji"
-    },
-    "player": {
-        "message": "Mchezaji"
-    },
-    "player_dont_speed_education": {
-        "message": "Usiharakishe kategoria (nadra) : Elimu"
-    },
-    "player_fit_to_win_button": {
-        "message": "Inafaa kwa dirisha"
-    },
-    "player_rotate_button": {
-        "message": "Zungusha video"
-    },
-    "playerColor": {
-        "message": "Rangi ya upau wa maendeleo"
-    },
-    "playerSize": {
-        "message": "Ukubwa wa mchezaji"
-    },
-    "playlist": {
-        "message": "Orodha ya kucheza"
-    },
-    "playlists": {
-        "message": "Orodha za kucheza"
-    },
-    "playPause": {
-        "message": "Cheza / Sitisha"
-    },
-    "popupPlayer": {
-        "message": "Kicheza ibukizi"
-    },
-    "popupWindowButtons": {
-        "message": "Ongeza kitufe cha kicheza-dukizo kwa kila kijipicha"
-    },
-    "position": {
-        "message": "Nafasi"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Bonyeza kitufe chochote au tumia gurudumu la kipanya."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Bonyeza kitufe chochote au tumia gurudumu la kipanya"
-    },
-    "previousVideo": {
-        "message": "Video iliyotangulia"
-    },
-    "primaryColor": {
-        "message": "Rangi ya msingi"
-    },
-    "purple": {
-        "message": "Zambarau"
-    },
-    "quality": {
-        "message": "Ubora"
-    },
-    "raised": {
-        "message": "Imeinuliwa"
-    },
-    "ram": {
-        "message": "RAM"
-    },
-    "rateMe": {
-        "message": "Nikadirie"
-    },
-    "rateUs": {
-        "message": "Tukadirie"
-    },
-    "red": {
-        "message": "Nyekundu"
-    },
-    "redDislikeButton": {
-        "message": "Nyekundu wakati haipendi"
-    },
-    "relatedVideos": {
-        "message": "Video zinazohusiana"
-    },
-    "remote": {
-        "message": "Cheza kwenye TV"
-    },
-    "Remove": {
-        "message": "Ondoa"
-    },
-    "removeIcons": {
-        "message": "Remove icons"
-    },
-    "removeNames": {
-        "message": "Ondoa majina/ Toa majina"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Ondoa matokeo ya utafutaji yanayohusiana"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Ondoa reel Fupi kutoka kwa matokeo ya utafutaji"
-    },
-    "repeat": {
-        "message": "Rudia"
-    },
-    "report": {
-        "message": "Ripoti"
-    },
-    "reset": {
-        "message": "Weka upya"
-    },
-    "resetAllSettings": {
-        "message": "Weka upya mipangilio yote"
-    },
-    "resetAllShortcuts": {
-        "message": "Weka upya njia zote za mkato"
-    },
-    "reverse": {
-        "message": "Reverse"
-    },
-    "rotate": {
-        "message": "Zungusha"
-    },
-    "save": {
-        "message": "Hifadhi"
-    },
-    "saveAs": {
-        "message": "Hifadhi kama"
-    },
-    "schedule": {
-        "message": "Ratiba"
-    },
-    "screen": {
-        "message": "Skrini"
-    },
-    "screenshot": {
-        "message": "Picha ya skrini"
-    },
-    "scrollBar": {
-        "message": "Upau wa kusogeza"
-    },
-    "sd": {
-        "message": "SD"
-    },
-    "search": {
-        "message": "Tafuta"
-    },
-    "searchBarOnly": {
-        "message": "Upau wa utafutaji pekee"
-    },
-    "seekBackward10Seconds": {
-        "message": "Tafuta nyuma kwa sekunde 10"
-    },
-    "seekForward10Seconds": {
-        "message": "Songa mbele kwa sekunde 10"
-    },
-    "seekNextChapter": {
-        "message": "Tafuta Sura Inayofuata"
-    },
-    "seekPreviousChapter": {
-        "message": "Tafuta Sura Iliyotangulia"
-    },
-    "settings": {
-        "message": "Mipangilio"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Mipangilio imefaulu kuletwa"
-    },
-    "share": {
-        "message": "Shiriki"
-    },
-    "shortcut_chapters": {
-        "message": "Onyesha sura Upau wa kando"
-    },
-    "shortcut_screenshot": {
-        "message": "Picha ya skrini"
-    },
-    "shortcuts": {
-        "message": "Njia za mkato"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Onyesha kadi kwenye kielelezo cha kipanya"
-    },
-    "showChannelVideosCount": {
-        "message": "Onyesha idadi ya video za kituo"
-    },
-    "showLess": {
-        "message": "Onyesha kidogo"
-    },
-    "showMore": {
-        "message": "Onyesha zaidi"
-    },
-    "showRemainingDuration": {
-        "message": "Onyesha muda uliosalia wa video"
-    },
-    "showVersion": {
-        "message": "Onyesha toleo"
-    },
-    "shuffle": {
-        "message": "Changanya"
-    },
-    "sidebar": {
-        "message": "Upau wa kando"
-    },
-    "Sidebar_simple_alternative": {
-        "message": "Upau wa kando (mbadala rahisi)"
-    },
-    "softwareInformation": {
-        "message": "Taarifa za programu"
-    },
-    "spacebar": {
-        "message": "Upau wa nafasi"
-    },
-    "squaredUserImages": {
-        "message": "Picha za mtumiaji zenye mraba"
-    },
-    "static": {
-        "message": "Tuli"
-    },
-    "statsForNerds": {
-        "message": "Onyesha Takwimu za Wajanja"
-    },
-    "step": {
-        "message": "Hatua"
-    },
-    "stop": {
-        "message": "Acha/ Sitisha"
-    },
-    "style": {
-        "message": "Mtindo"
-    },
-    "styles": {
-        "message": "Mitindo"
-    },
-    "subscribe": {
-        "message": "Jisajili"
-    },
-    "subscriptions": {
-        "message": "Usajili"
-    },
-    "Subtitle_Capture_including_the_current_words": {
-        "message": "Manukuu (Nasa ikijumuisha maneno ya sasa)"
-    },
-    "subtitles": {
-        "message": "Manukuu"
-    },
-    "sunset": {
-        "message": "machweo"
-    },
-    "sunsetToSunrise": {
-        "message": "Machweo hadi mawio"
-    },
-    "systemPeferenceDark": {
-        "message": "Upendeleo wa mfumo: giza"
-    },
-    "systemPeferenceLight": {
-        "message": "Upendeleo wa mfumo: mwanga"
-    },
-    "teal": {
-        "message": "Teal"
-    },
-    "textColor": {
-        "message": "Rangi ya maandishi"
-    },
-    "thanks": {
-        "message": "Asante"
-    },
-    "themes": {
-        "message": "Mandhari"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Hii itaondoa vidakuzi vyote."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Hii itaondoa video zote zilizotazamwa."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Hii itaondoa vidakuzi vyote vya YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Hii itaweka upya mipangilio yote."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Hii itaweka upya njia zote za mkato"
-    },
-    "thumbnails": {
-        "message": "Vijipicha"
-    },
-    "thumbnailsQuality": {
-        "message": "Vijipicha Ubora"
-    },
-    "timeFrom": {
-        "message": "Muda kutoka"
-    },
-    "timeTo": {
-        "message": "Muda wa"
-    },
-    "To_the_side_No_page_margin": {
-        "message": "Kwa upande! (Hakuna ukingo wa ukurasa)"
-    },
-    "todayAt": {
-        "message": "Leo saa"
-    },
-    "toggleAutoplay": {
-        "message": "Geuza uchezaji kiotomatiki"
-    },
-    "toggleCards": {
-        "message": "Geuza kadi"
-    },
-    "toggleControls": {
-        "message": "Geuza vidhibiti vya wachezaji"
-    },
-    "topChat": {
-        "message": "Gumzo la juu"
-    },
-    "trackWatchedVideos": {
-        "message": "Fuatilia video zilizotazamwa"
-    },
-    "trailerAutoplay": {
-        "message": "Kucheza kiotomatiki kwa trela"
-    },
-    "Transcript": {
-        "message": "Nakala/ risiti"
-    },
-    "translations": {
-        "message": "Tafsiri"
-    },
-    "transparentBackground": {
-        "message": "Mandharinyuma yenye uwazi"
-    },
-    "transparentColor": {
-        "message": "Angavu"
-    },
-    "trending": {
-        "message": "Zinazovuma"
-    },
-    "tryToReloadThePage": {
-        "message": "Jaribu kupakia upya ukurasa"
-    },
-    "type": {
-        "message": "Aina"
-    },
-    "upNextAutoplay": {
-        "message": "Cheza kiotomatiki kinachofuata"
-    },
-    "use24HourFormat": {
-        "message": "Tumia umbizo la saa 24"
-    },
-    "version": {
-        "message": "Toleo"
-    },
-    "video": {
-        "message": "Video"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Maelezo ya video yatapanuliwa ili kupata jina la kitengo"
-    },
-    "videoFormats": {
-        "message": "Miundo ya video"
-    },
-    "videos": {
-        "message": "Video"
-    },
-    "viewMode": {
-        "message": "Mtazamo wa Hali"
-    },
-    "volume": {
-        "message": "Kiasi"
-    },
-    "watchedVideos": {
-        "message": "Umetazama video"
-    },
-    "watchLater": {
-        "message": "Tazama Baadaye"
-    },
-    "watchTime": {
-        "message": "Wakati wa kutazama"
-    },
-    "whenPaused": {
-        "message": "Wakati umesitishwa"
-    },
-    "whenTabIsChanged": {
-        "message": "Wakati kichupo kinabadilishwa"
-    },
-    "white": {
-        "message": "Nyeupe"
-    },
-    "windowColor": {
-        "message": "Rangi ya dirisha"
-    },
-    "windowOpacity": {
-        "message": "Uwazi wa dirisha"
-    },
-    "with_scrollbars": {
-        "message": "na upau wa kusogeza?"
-    },
-    "yellow": {
-        "message": "Njano"
-    },
-    "Youtube_Search": {
-        "message": "kwa 'Youtube-Tafuta'"
-    },
-    "youTubeButtons": {
-        "message": "Vifungo vya YouTube"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Kijajuu cha YouTube (kushoto)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Kijajuu cha YouTube (kulia)"
-    },
-    "youtubeHomePage": {
-        "message": "Ukurasa wa nyumbani wa YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Lugha ya YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube inaweka kikomo ubora wa video hadi 1080p kwa kodeki ya h.264"
-    }
+	"about": {
+		"message": "Kuhusu/"
+	},
+	"accept": {
+		"message": "Kubali"
+	},
+	"activate": {
+		"message": "Amilisha/ wezesha"
+	},
+	"activateCaptions": {
+		"message": "Washa manukuu"
+	},
+	"activated": {
+		"message": "Imewashwa"
+	},
+	"activatedFeatures": {
+		"message": "Vipengele vilivyoamilishwa"
+	},
+	"activateFullscreen": {
+		"message": "Washa skrini nzima"
+	},
+	"activeFeatures": {
+		"message": "Vipengele vyangu vinavyotumika"
+	},
+	"addScrollToTop": {
+		"message": "Ongeza «STembeza hadi juu»"
+	},
+	"ads": {
+		"message": "Matangazo"
+	},
+	"all": {
+		"message": "Yote"
+	},
+	"allow": {
+		"message": "Ruhusu"
+	},
+	"Allow_auto_generate": {
+		"message": "Ruhusu kuzalisha kiotomatiki"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "Mipangilio yako yote itafutwa na haiwezi kurejeshwa"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Njia zako zote za mkato zitafutwa na haziwezi kurejeshwa"
+	},
+	"always": {
+		"message": "Kila mara"
+	},
+	"alwaysActive": {
+		"message": "Inatumika kila wakati"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Onyesha upau wa maendeleo kila wakati"
+	},
+	"animations": {
+		"message": "Katuni"
+	},
+	"appearance": {
+		"message": "Muonekano"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Je, una uhakika unataka kuhamisha data?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Je, una uhakika unataka kuleta data hii?"
+	},
+	"ARROWDOWN": {
+		"message": "Chini"
+	},
+	"ARROWLEFT": {
+		"message": "Kushoto/ kando"
+	},
+	"ARROWRIGHT": {
+		"message": "Kulia/ kando"
+	},
+	"ARROWUP": {
+		"message": "Juu"
+	},
+	"atHistory": {
+		"message": "kwa 'Historia'"
+	},
+	"atSubscriptions": {
+		"message": "kwa 'Usajili'"
+	},
+	"atTrending": {
+		"message": "Yanayovuma"
+	},
+	"audio": {
+		"message": "Sauti"
+	},
+	"audioFormats": {
+		"message": "Miundo ya sauti"
+	},
+	"auto": {
+		"message": "Otomatiki"
+	},
+	"Auto_PiP_picture_in_picture": {
+		"message": "Auto-PiP (picha kwenye picha)"
+	},
+	"autoFullscreen": {
+		"message": "Skrini kamili kiotomatiki"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Sitisha kiotomatiki wakati sipo kwenye kichupo"
+	},
+	"autoPictureInPicture": {
+		"message": "Picha-Katika-Picha ya Kiotomatiki"
+	},
+	"avoidAv1": {
+		"message": "Epuka AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Epuka AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Epuka AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Epuka utoaji wa CPU inapowezekana"
+	},
+	"backgroundColor": {
+		"message": "Rangi ya usuli"
+	},
+	"backgroundOpacity": {
+		"message": "Ufinyu wa mandharinyuma"
+	},
+	"backupAndReset": {
+		"message": "Hifadhi nakala na uweke upya"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Kulingana na mpango wa rangi ya mfumo"
+	},
+	"belowPlayer": {
+		"message": "Chini ya mchezaji"
+	},
+	"black": {
+		"message": "Nyeusi"
+	},
+	"block_Codec_Alert_h264": {
+		"message": "Unahitaji H.264 au VP9 kuwezeshwa kwa YouTube ili kucheza video."
+	},
+	"blockAll": {
+		"message": "Imezimwa (zuia au ruka)"
+	},
+	"blockAv1": {
+		"message": "Zuia AV1"
+	},
+	"blockH264": {
+		"message": "Zuia H.264"
+	},
+	"blocklist": {
+		"message": "Orodha ya kuzuia"
+	},
+	"blockMusic": {
+		"message": "Ruka matangazo ninapocheza muziki"
+	},
+	"blockVp8": {
+		"message": "Zuia VP8"
+	},
+	"blockVp9": {
+		"message": "Zuia VP9"
+	},
+	"blue": {
+		"message": "Bluu"
+	},
+	"blueGray": {
+		"message": "Bluu kijivu"
+	},
+	"bluelight": {
+		"message": "Mwanga wa Bluu"
+	},
+	"brightness": {
+		"message": "Mwangaza"
+	},
+	"browser": {
+		"message": "Kivinjari/ Browser"
+	},
+	"browserVersion": {
+		"message": "Toleo la kivinjari"
+	},
+	"bubbles": {
+		"message": "Mapovu"
+	},
+	"bug": {
+		"message": "Mdudu"
+	},
+	"buttons": {
+		"message": "Vidude"
+	},
+	"cancel": {
+		"message": "Ghairi/ kata"
+	},
+	"categories": {
+		"message": "Kategoria"
+	},
+	"channel": {
+		"message": "Kituo"
+	},
+	"channels": {
+		"message": "Vituo"
+	},
+	"chapters": {
+		"message": "Sura"
+	},
+	"characterEdgeStyle": {
+		"message": "Mtindo wa makali ya tabia"
+	},
+	"clip": {
+		"message": "Klipu"
+	},
+	"clipboard": {
+		"message": "Ubao wa kunakili"
+	},
+	"codecH264": {
+		"message": "Kodeki h.264"
+	},
+	"codecs": {
+		"message": "Kodeki"
+	},
+	"collapsed": {
+		"message": "Imekunjwa"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Pinda sehemu za usajili (accordion iliyokunjwa)"
+	},
+	"comments": {
+		"message": "Maoni"
+	},
+	"compact_spacing": {
+		"message": "Nafasi Iliyounganishwa"
+	},
+	"compactTheme": {
+		"message": "Mandhari Compact"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Uthibitisho kabla ya kufungwa"
+	},
+	"cookies": {
+		"message": "Vidakuzi"
+	},
+	"cores": {
+		"message": "Mihimili"
+	},
+	"cropChapterTitles": {
+		"message": "kata vichwa vya sura"
+	},
+	"Currently_requiring_a_YouTube_API_key": {
+		"message": "(Kwa sasa inahitaji ufunguo-API wa YouTube :)"
+	},
+	"custom": {
+		"message": "Desturi"
+	},
+	"customCss": {
+		"message": "Desturi CSS"
+	},
+	"customJs": {
+		"message": "Desturi JS"
+	},
+	"customMiniPlayer": {
+		"message": "Kicheza Kidogo Maalum"
+	},
+	"dark": {
+		"message": "Giza"
+	},
+	"darkTheme": {
+		"message": "Mandhari meusi"
+	},
+	"dateAndTime": {
+		"message": "Tarehe na wakati"
+	},
+	"dawn": {
+		"message": "Alfajiri"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Punguza kasi ya kucheza"
+	},
+	"decreaseVolume": {
+		"message": "Punguza Sauti"
+	},
+	"deepOrange": {
+		"message": "Chungwa kirefu"
+	},
+	"deepPurple": {
+		"message": "Zambarau ya kina"
+	},
+	"default": {
+		"message": "Chaguomsingi"
+	},
+	"default_CC": {
+		"message": "chaguo-msingi"
+	},
+	"default_theme": {
+		"message": "chaguo-msingi (mandhari)"
+	},
+	"defaultChannelTab": {
+		"message": "Kichupo chaguomsingi cha kituo"
+	},
+	"defaultContentCountry": {
+		"message": "Nchi (safari halisi)"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Kasi ya Uchezaji Chaguomsingi"
+	},
+	"deleteWatchedVideos": {
+		"message": "Futa video ulizotazama"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Futa vidakuzi vya YouTube"
+	},
+	"depressed": {
+		"message": "Unyogovu"
+	},
+	"description": {
+		"message": "Maelezo"
+	},
+	"description_ext": {
+		"message": "YouTube, nadhifu + nadhifu? Video ya YouTube ukubwa wa kichezaji cha youtube rangi ya tangazo ruka kasi ya vitambulisho vya nahodha wa orodha ya kucheza"
+	},
+	"desert": {
+		"message": "Jangwa"
+	},
+	"details": {
+		"message": "Maelezo"
+	},
+	"developerOptions": {
+		"message": "Chaguzi za msanidi/ developa"
+	},
+	"device": {
+		"message": "Kifaa/ Chombo"
+	},
+	"disabled": {
+		"message": "Imezimwa"
+	},
+	"dislike": {
+		"message": "Sipendi"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Siku ya maonyesho ya wiki"
+	},
+	"donate": {
+		"message": "Changia"
+	},
+	"doNotChange": {
+		"message": "Usibadilike"
+	},
+	"download": {
+		"message": "Pakua"
+	},
+	"draggable": {
+		"message": "Inaweza kuburuzwa"
+	},
+	"dropShadow": {
+		"message": "Kuacha kivuli"
+	},
+	"durationWithSpeed": {
+		"message": "Onyesha muda uliosalia kwa kurejelea kasi ya uchezaji"
+	},
+	"email": {
+		"message": "Barua pepe/ Email"
+	},
+	"embedded_Hide_Share": {
+		"message": "Imepachikwa Ficha Kushiriki"
+	},
+	"Embedded_YouTube": {
+		"message": "YouTube iliyopachikwa"
+	},
+	"empty": {
+		"message": "Tupu"
+	},
+	"enabled": {
+		"message": "Imewashwa"
+	},
+	"enabledForced": {
+		"message": "Imewashwa (kulazimishwa)"
+	},
+	"expanded": {
+		"message": "Imepanuliwa"
+	},
+	"exportSettings": {
+		"message": "Hamisha mipangilio"
+	},
+	"extension": {
+		"message": "Ugani"
+	},
+	"ExtraButtons": {
+		"message": "Vidude zaidi"
+	},
+	"extraButtonsBelowThePlayer": {
+		"message": "Vifungo vya ziada chini ya mchezaji"
+	},
+	"Feature_not_yet_available": {
+		"message": "Kipengele bado hakijapatikana"
+	},
+	"file": {
+		"message": "Faili"
+	},
+	"filters": {
+		"message": "Vichujio"
+	},
+	"fitToWindow": {
+		"message": "Mbadala wa zamani ('Fit to window')"
+	},
+	"flash": {
+		"message": "Mwako"
+	},
+	"font": {
+		"message": "Fonti"
+	},
+	"fontColor": {
+		"message": "Rangi ya herufi"
+	},
+	"fontFamily": {
+		"message": "Familia ya herufi"
+	},
+	"fontOpacity": {
+		"message": "Uwazi wa fonti"
+	},
+	"fontSize": {
+		"message": "Ukubwa wa herufi"
+	},
+	"footer": {
+		"message": "Kijachini"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Kuangalia kasi: Kasi ya kudumu"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(Lazimisha kasi ya kucheza hata kwa muziki?)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Lazimisha video kucheza tangu mwanzo"
+	},
+	"forcedTheaterMode": {
+		"message": "Hali ya ukumbi wa michezo ya kulazimishwa"
+	},
+	"forcedVolume": {
+		"message": "Kiasi cha kulazimishwa/ sauti ya kulazimishwa"
+	},
+	"forceSDR": {
+		"message": "Epuka HDR, weka SDR"
+	},
+	"foundABug": {
+		"message": "Imepata mdudu?"
+	},
+	"fullWindow": {
+		"message": "Urefu kamili"
+	},
+	"general": {
+		"message": "Mkuu"
+	},
+	"geoPreference": {
+		"message": "Upendeleo wa Geo"
+	},
+	"googleApiKey": {
+		"message": "Ufunguo wa API ya Google"
+	},
+	"goToSearchBox": {
+		"message": "Nenda kwenye kisanduku cha kutafutia"
+	},
+	"GPUnotindatabase": {
+		"message": "GPU haiko kwenye hifadhidata"
+	},
+	"green": {
+		"message": "Kijani"
+	},
+	"grey": {
+		"message": "Kijivu"
+	},
+	"halfTransparent": {
+		"message": "Nusu angavu"
+	},
+	"Hamburger_Menu": {
+		"message": "Menyu ya Hamburger"
+	},
+	"hardwareInformation": {
+		"message": "Maelezo ya vifaa"
+	},
+	"hdThumbnail": {
+		"message": "Kijipicha cha HD"
+	},
+	"header": {
+		"message": "Kijajuu/ Kichwa"
+	},
+	"hidden": {
+		"message": "Imefichwa"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Imefichwa kwenye ukurasa wa video"
+	},
+	"hide_author_avatars": {
+		"message": "Ficha ishara za mwandishi"
+	},
+	"hide_labels": {
+		"message": "Ficha majina"
+	},
+	"Hide_Pause_Overlay": {
+		"message": "Ficha Sitisha Uwekeleaji"
+	},
+	"Hide_Shorts_remixing_this_video": {
+		"message": "Ficha Shorts zinazochanganya video hii upya"
+	},
+	"Hide_sidebar": {
+		"message": "Ficha utepe"
+	},
+	"Hide_the_tabs_only": {
+		"message": "Ficha vichupo pekee"
+	},
+	"Hide_YouTube_Logo": {
+		"message": "Ficha Nembo ya YouTube"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Ficha vijipicha vilivyohuishwa"
+	},
+	"hideAnnotations": {
+		"message": "Ficha ufafanuzi"
+	},
+	"hideCards": {
+		"message": "Ficha kadi"
+	},
+	"hideCategories": {
+		"message": "Ficha kategoria"
+	},
+	"hideCommentsCount": {
+		"message": "Ficha idadi ya maoni"
+	},
+	"hideCountryCode": {
+		"message": "Ficha msimbo wa nchi"
+	},
+	"hideDate": {
+		"message": "Ficha tarehe"
+	},
+	"hideDetailButton": {
+		"message": "Vifungo (chini ya mchezaji)"
+	},
+	"hideDetails": {
+		"message": "Ficha maelezo"
+	},
+	"hideEndscreen": {
+		"message": "Ficha skrini ya mwisho"
+	},
+	"hideFeaturedContent": {
+		"message": "Ficha maudhui yaliyoangaziwa"
+	},
+	"hideFooter": {
+		"message": "Ficha kijachini"
+	},
+	"hideGradientBottom": {
+		"message": "Ficha kivuli karibu na upau wa mchezaji"
+	},
+	"hideHomePageShorts": {
+		"message": "Ficha Shorts kwenye ukurasa wa nyumbani"
+	},
+	"hideMore": {
+		"message": "Ficha Mengi zaidi"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ficha upau wa vidhibiti vya mchezaji"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ficha vifungo vya udhibiti wa mchezaji"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ficha chaguzi za vidhibiti vya mchezaji"
+	},
+	"hidePlaylist": {
+		"message": "Ficha orodha ya kucheza"
+	},
+	"hideReport": {
+		"message": "Ficha Ripoti"
+	},
+	"hideRightButtons": {
+		"message": "Ficha vifungo vya kulia"
+	},
+	"hideScrollForDetails": {
+		"message": "Ficha «Sogeza kwa maelezo»"
+	},
+	"hideSkipOverlay": {
+		"message": "Ficha uhuishaji wa kuruka kwa sekunde 5"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ficha vitufe kwenye vijipicha"
+	},
+	"hideThumbnails": {
+		"message": "Ficha vijipicha"
+	},
+	"hideVideoTitleFullScreen": {
+		"message": "Ficha kichwa cha video kwenye skrini nzima"
+	},
+	"hideViewsCount": {
+		"message": "Ficha idadi ya waliotazamwa"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ficha kitufe cha kutafuta kwa kutamka"
+	},
+	"high": {
+		"message": "Juu"
+	},
+	"history": {
+		"message": "Historia"
+	},
+	"home": {
+		"message": "Nyumbani"
+	},
+	"homeScreen": {
+		"message": "Skrini ya nyumbani"
+	},
+	"hover": {
+		"message": "Elea juu"
+	},
+	"hoverOnVideoPage": {
+		"message": "Elea kwenye ukurasa wa video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Onyesha umri wa video (ilipakiwa kwa muda gani)"
+	},
+	"icons": {
+		"message": "Aikoni"
+	},
+	"iconsOnly": {
+		"message": "Aikoni pekee"
+	},
+	"importSettings": {
+		"message": "Ingiza mipangilio"
+	},
+	"ImprovedTube": {
+		"message": "Tube ilioimarika"
+	},
+	"improvedtubeButtons": {
+		"message": "Vifungo vyaTube vilivyoboreshwa"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Ikoni yaTube iliyoboreshwa kwenye YouTube"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube toleo"
+	},
+	"improveLogo": {
+		"message": "Boresha nembo"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Ongeza kasi ya kucheza"
+	},
+	"increaseVolume": {
+		"message": "Ongeza sauti"
+	},
+	"items": {
+		"message": "Vipengee"
+	},
+	"language": {
+		"message": "Lugha"
+	},
+	"language_closed_caption": {
+		"message": "Lugha Chaguomsingi - Manukuu Yaliyofungwa"
+	},
+	"languages": {
+		"message": "Lugha"
+	},
+	"layerAnimationScale": {
+		"message": "Kiwango cha uhuishaji wa safu"
+	},
+	"layout": {
+		"message": "Mpangilio"
+	},
+	"legacyYoutube": {
+		"message": "Urithi wa YouTube"
+	},
+	"library": {
+		"message": "Maktaba"
+	},
+	"light": {
+		"message": "Mwanga"
+	},
+	"lightBlue": {
+		"message": "Bluu nyepesi"
+	},
+	"lightGreen": {
+		"message": "Mwanga wa kijani"
+	},
+	"like": {
+		"message": "Penda"
+	},
+	"liked": {
+		"message": "limependwa"
+	},
+	"likes": {
+		"message": "mapendo"
+	},
+	"lime": {
+		"message": "Chokaa/ Ndimu"
+	},
+	"limitPageWidth": {
+		"message": "Punguza upana wa ukurasa"
+	},
+	"list": {
+		"message": "Orodha"
+	},
+	"liveChat": {
+		"message": "Gumzo la moja kwa moja"
+	},
+	"liveChatType": {
+		"message": "Aina ya mazungumzo ya moja kwa moja"
+	},
+	"location": {
+		"message": "Mahali"
+	},
+	"loop": {
+		"message": "Kitanzi/ zunguka"
+	},
+	"loudnessNormalization": {
+		"message": "Urekebishaji wa sauti"
+	},
+	"low": {
+		"message": "Chini"
+	},
+	"markWatchedVideos": {
+		"message": "Weka alama kwenye video"
+	},
+	"medium": {
+		"message": "Kati/ katikati"
+	},
+	"mixer": {
+		"message": "Mchanganyiko"
+	},
+	"more": {
+		"message": "Mengi"
+	},
+	"mostViewedChannels": {
+		"message": "Vituo vilivyotazamwa zaidi"
+	},
+	"moveSidebarLeft": {
+		"message": "Upande wa kushoto!"
+	},
+	"moveThumbnailsRight": {
+		"message": "Vijipicha kulia!"
+	},
+	"My_specs": {
+		"message": "Vigezo vyangu"
+	},
+	"myColors": {
+		"message": "Rangi zangu"
+	},
+	"name": {
+		"message": "Jina"
+	},
+	"nativeMiniPlayer": {
+		"message": "Mchezaji mdogo wa asili"
+	},
+	"new": {
+		"message": "Mpya"
+	},
+	"nextVideo": {
+		"message": "Video inayofuata"
+	},
+	"night": {
+		"message": "Usiku"
+	},
+	"nightMode": {
+		"message": "Hali ya usiku"
+	},
+	"noActiveFeatures": {
+		"message": "Hakuna vipengele vinavyotumika"
+	},
+	"none": {
+		"message": "Hakuna"
+	},
+	"noOpenVideoTabs": {
+		"message": "Hakuna vichupo vya video vilivyofunguliwa"
+	},
+	"normal": {
+		"message": "Kawaida"
+	},
+	"Not_optimal": {
+		"message": "Sio bora"
+	},
+	"off": {
+		"message": "Imezimwa"
+	},
+	"ok": {
+		"message": "Sawa"
+	},
+	"old": {
+		"message": "Nzee/ zee"
+	},
+	"onAllVideos": {
+		"message": "Imewashwa"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Inatumika kwenye YouTube pekee"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Sitisha ninapotazama video ya pili"
+	},
+	"onSmallCreators": {
+		"message": "Imezimwa, isipokuwa chaneli ndogo"
+	},
+	"onSubscribedChannels": {
+		"message": "Imezimwa, isipokuwa kwenye vituo nilivyofuatilia"
+	},
+	"openNewTab": {
+		"message": "Fungua kwenye kichupo kipya"
+	},
+	"openPopupPlayer": {
+		"message": "Fungua video/orodha ya kucheza katika dirisha jipya"
+	},
+	"optimizeCodecForHardwareAcceleration": {
+		"message": "Boresha Kodeki kwa kuongeza kasi ya maunzi"
+	},
+	"orange": {
+		"message": "Chungwa"
+	},
+	"other": {
+		"message": "ingine"
+	},
+	"outline": {
+		"message": "Muhtasari"
+	},
+	"overlay": {
+		"message": "Uwekeleaji"
+	},
+	"permissions": {
+		"message": "Ruhusa"
+	},
+	"pictureInPicture": {
+		"message": "Picha-ndani-Picha"
+	},
+	"plain": {
+		"message": "Wazi"
+	},
+	"platform": {
+		"message": "Jukwaa"
+	},
+	"playAllButton": {
+		"message": "\"Cheza zote\"kifungo"
+	},
+	"playbackSpeed": {
+		"message": "Kasi ya uchezaji"
+	},
+	"player": {
+		"message": "Mchezaji"
+	},
+	"player_dont_speed_education": {
+		"message": "Usiharakishe kategoria (nadra) : Elimu"
+	},
+	"player_fit_to_win_button": {
+		"message": "Inafaa kwa dirisha"
+	},
+	"player_rotate_button": {
+		"message": "Zungusha video"
+	},
+	"playerColor": {
+		"message": "Rangi ya upau wa maendeleo"
+	},
+	"playerSize": {
+		"message": "Ukubwa wa mchezaji"
+	},
+	"playlist": {
+		"message": "Orodha ya kucheza"
+	},
+	"playlists": {
+		"message": "Orodha za kucheza"
+	},
+	"playPause": {
+		"message": "Cheza / Sitisha"
+	},
+	"popupPlayer": {
+		"message": "Kicheza ibukizi"
+	},
+	"popupWindowButtons": {
+		"message": "Ongeza kitufe cha kicheza-dukizo kwa kila kijipicha"
+	},
+	"position": {
+		"message": "Nafasi"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Bonyeza kitufe chochote au tumia gurudumu la kipanya."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Bonyeza kitufe chochote au tumia gurudumu la kipanya"
+	},
+	"previousVideo": {
+		"message": "Video iliyotangulia"
+	},
+	"primaryColor": {
+		"message": "Rangi ya msingi"
+	},
+	"purple": {
+		"message": "Zambarau"
+	},
+	"quality": {
+		"message": "Ubora"
+	},
+	"raised": {
+		"message": "Imeinuliwa"
+	},
+	"rateMe": {
+		"message": "Nikadirie"
+	},
+	"rateUs": {
+		"message": "Tukadirie"
+	},
+	"red": {
+		"message": "Nyekundu"
+	},
+	"redDislikeButton": {
+		"message": "Nyekundu wakati haipendi"
+	},
+	"relatedVideos": {
+		"message": "Video zinazohusiana"
+	},
+	"remote": {
+		"message": "Cheza kwenye TV"
+	},
+	"Remove": {
+		"message": "Ondoa"
+	},
+	"removeNames": {
+		"message": "Ondoa majina/ Toa majina"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Ondoa matokeo ya utafutaji yanayohusiana"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Ondoa reel Fupi kutoka kwa matokeo ya utafutaji"
+	},
+	"repeat": {
+		"message": "Rudia"
+	},
+	"report": {
+		"message": "Ripoti"
+	},
+	"reset": {
+		"message": "Weka upya"
+	},
+	"resetAllSettings": {
+		"message": "Weka upya mipangilio yote"
+	},
+	"resetAllShortcuts": {
+		"message": "Weka upya njia zote za mkato"
+	},
+	"rotate": {
+		"message": "Zungusha"
+	},
+	"save": {
+		"message": "Hifadhi"
+	},
+	"saveAs": {
+		"message": "Hifadhi kama"
+	},
+	"schedule": {
+		"message": "Ratiba"
+	},
+	"screen": {
+		"message": "Skrini"
+	},
+	"screenshot": {
+		"message": "Picha ya skrini"
+	},
+	"scrollBar": {
+		"message": "Upau wa kusogeza"
+	},
+	"search": {
+		"message": "Tafuta"
+	},
+	"searchBarOnly": {
+		"message": "Upau wa utafutaji pekee"
+	},
+	"seekBackward10Seconds": {
+		"message": "Tafuta nyuma kwa sekunde 10"
+	},
+	"seekForward10Seconds": {
+		"message": "Songa mbele kwa sekunde 10"
+	},
+	"seekNextChapter": {
+		"message": "Tafuta Sura Inayofuata"
+	},
+	"seekPreviousChapter": {
+		"message": "Tafuta Sura Iliyotangulia"
+	},
+	"settings": {
+		"message": "Mipangilio"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Mipangilio imefaulu kuletwa"
+	},
+	"share": {
+		"message": "Shiriki"
+	},
+	"shortcut_chapters": {
+		"message": "Onyesha sura Upau wa kando"
+	},
+	"shortcut_screenshot": {
+		"message": "Picha ya skrini"
+	},
+	"shortcuts": {
+		"message": "Njia za mkato"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Onyesha kadi kwenye kielelezo cha kipanya"
+	},
+	"showChannelVideosCount": {
+		"message": "Onyesha idadi ya video za kituo"
+	},
+	"showLess": {
+		"message": "Onyesha kidogo"
+	},
+	"showMore": {
+		"message": "Onyesha zaidi"
+	},
+	"showRemainingDuration": {
+		"message": "Onyesha muda uliosalia wa video"
+	},
+	"showVersion": {
+		"message": "Onyesha toleo"
+	},
+	"shuffle": {
+		"message": "Changanya"
+	},
+	"sidebar": {
+		"message": "Upau wa kando"
+	},
+	"Sidebar_simple_alternative": {
+		"message": "Upau wa kando (mbadala rahisi)"
+	},
+	"softwareInformation": {
+		"message": "Taarifa za programu"
+	},
+	"spacebar": {
+		"message": "Upau wa nafasi"
+	},
+	"squaredUserImages": {
+		"message": "Picha za mtumiaji zenye mraba"
+	},
+	"static": {
+		"message": "Tuli"
+	},
+	"statsForNerds": {
+		"message": "Onyesha Takwimu za Wajanja"
+	},
+	"step": {
+		"message": "Hatua"
+	},
+	"stop": {
+		"message": "Acha/ Sitisha"
+	},
+	"style": {
+		"message": "Mtindo"
+	},
+	"styles": {
+		"message": "Mitindo"
+	},
+	"subscribe": {
+		"message": "Jisajili"
+	},
+	"subscriptions": {
+		"message": "Usajili"
+	},
+	"Subtitle_Capture_including_the_current_words": {
+		"message": "Manukuu (Nasa ikijumuisha maneno ya sasa)"
+	},
+	"subtitles": {
+		"message": "Manukuu"
+	},
+	"sunset": {
+		"message": "machweo"
+	},
+	"sunsetToSunrise": {
+		"message": "Machweo hadi mawio"
+	},
+	"systemPeferenceDark": {
+		"message": "Upendeleo wa mfumo: giza"
+	},
+	"systemPeferenceLight": {
+		"message": "Upendeleo wa mfumo: mwanga"
+	},
+	"textColor": {
+		"message": "Rangi ya maandishi"
+	},
+	"thanks": {
+		"message": "Asante"
+	},
+	"themes": {
+		"message": "Mandhari"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Hii itaondoa vidakuzi vyote."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Hii itaondoa video zote zilizotazamwa."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Hii itaondoa vidakuzi vyote vya YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Hii itaweka upya mipangilio yote."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Hii itaweka upya njia zote za mkato"
+	},
+	"thumbnails": {
+		"message": "Vijipicha"
+	},
+	"thumbnailsQuality": {
+		"message": "Vijipicha Ubora"
+	},
+	"timeFrom": {
+		"message": "Muda kutoka"
+	},
+	"timeTo": {
+		"message": "Muda wa"
+	},
+	"To_the_side_No_page_margin": {
+		"message": "Kwa upande! (Hakuna ukingo wa ukurasa)"
+	},
+	"todayAt": {
+		"message": "Leo saa"
+	},
+	"toggleAutoplay": {
+		"message": "Geuza uchezaji kiotomatiki"
+	},
+	"toggleCards": {
+		"message": "Geuza kadi"
+	},
+	"toggleControls": {
+		"message": "Geuza vidhibiti vya wachezaji"
+	},
+	"topChat": {
+		"message": "Gumzo la juu"
+	},
+	"trackWatchedVideos": {
+		"message": "Fuatilia video zilizotazamwa"
+	},
+	"trailerAutoplay": {
+		"message": "Kucheza kiotomatiki kwa trela"
+	},
+	"Transcript": {
+		"message": "Nakala/ risiti"
+	},
+	"translations": {
+		"message": "Tafsiri"
+	},
+	"transparentBackground": {
+		"message": "Mandharinyuma yenye uwazi"
+	},
+	"transparentColor": {
+		"message": "Angavu"
+	},
+	"trending": {
+		"message": "Zinazovuma"
+	},
+	"tryToReloadThePage": {
+		"message": "Jaribu kupakia upya ukurasa"
+	},
+	"type": {
+		"message": "Aina"
+	},
+	"upNextAutoplay": {
+		"message": "Cheza kiotomatiki kinachofuata"
+	},
+	"use24HourFormat": {
+		"message": "Tumia umbizo la saa 24"
+	},
+	"version": {
+		"message": "Toleo"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Maelezo ya video yatapanuliwa ili kupata jina la kitengo"
+	},
+	"videoFormats": {
+		"message": "Miundo ya video"
+	},
+	"videos": {
+		"message": "Video"
+	},
+	"viewMode": {
+		"message": "Mtazamo wa Hali"
+	},
+	"volume": {
+		"message": "Kiasi"
+	},
+	"watchedVideos": {
+		"message": "Umetazama video"
+	},
+	"watchLater": {
+		"message": "Tazama Baadaye"
+	},
+	"watchTime": {
+		"message": "Wakati wa kutazama"
+	},
+	"whenPaused": {
+		"message": "Wakati umesitishwa"
+	},
+	"whenTabIsChanged": {
+		"message": "Wakati kichupo kinabadilishwa"
+	},
+	"white": {
+		"message": "Nyeupe"
+	},
+	"windowColor": {
+		"message": "Rangi ya dirisha"
+	},
+	"windowOpacity": {
+		"message": "Uwazi wa dirisha"
+	},
+	"with_scrollbars": {
+		"message": "na upau wa kusogeza?"
+	},
+	"yellow": {
+		"message": "Njano"
+	},
+	"Youtube_Search": {
+		"message": "kwa 'Youtube-Tafuta'"
+	},
+	"youTubeButtons": {
+		"message": "Vifungo vya YouTube"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Kijajuu cha YouTube (kushoto)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Kijajuu cha YouTube (kulia)"
+	},
+	"youtubeHomePage": {
+		"message": "Ukurasa wa nyumbani wa YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Lugha ya YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube inaweka kikomo ubora wa video hadi 1080p kwa kodeki ya h.264"
+	}
 }

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "முகப்பு பக்கத்தின் ஷார்ட்ஸ் அகற்று"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "தேடல் முடிவுகளிலிருந்து ஷார்ட்ஸ் ரீலை அகற்று"
-    }
+	"hideHomePageShorts": {
+		"message": "முகப்பு பக்கத்தின் ஷார்ட்ஸ் அகற்று"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "தேடல் முடிவுகளிலிருந்து ஷார்ட்ஸ் ரீலை அகற்று"
+	}
 }

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "ముఖ్య పేజీని షార్ట్స్ తొలగించండి"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "శోర్ట్స్ రీల్‌ను సెర్చ్ ఫలితాల నుండి తీసుకోండి"
-    }
+	"hideHomePageShorts": {
+		"message": "ముఖ్య పేజీని షార్ట్స్ తొలగించండి"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "శోర్ట్స్ రీల్‌ను సెర్చ్ ఫలితాల నుండి తీసుకోండి"
+	}
 }

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -1,8 +1,8 @@
 {
-    "hideHomePageShorts": {
-        "message": "ลบ Shorts ออกจากหน้าแรก"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "ลบ Shorts reel ออกจากผลการค้นหา"
-    }
+	"hideHomePageShorts": {
+		"message": "ลบ Shorts ออกจากหน้าแรก"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "ลบ Shorts reel ออกจากผลการค้นหา"
+	}
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1,1103 +1,1088 @@
 {
-    "about": {
-        "message": "Hakkında"
-    },
-    "accept": {
-        "message": "Onayla"
-    },
-    "activate": {
-        "message": "Aktifleştir"
-    },
-    "activateCaptions": {
-        "message": "Altyazıları Aktifleştir"
-    },
-    "activated": {
-        "message": "Aktifleştirilmiş"
-    },
-    "activatedFeatures": {
-        "message": "Aktifleştirilmiş özellikler"
-    },
-    "activateFullscreen": {
-        "message": "Tam ekranı Aktifleştir"
-    },
-    "activeFeatures": {
-        "message": "Etkin özellikler"
-    },
-    "addScrollToTop": {
-        "message": "«Yukarı kaydır» ekle"
-    },
-    "ads": {
-        "message": "Reklamlar"
-    },
-    "all": {
-        "message": "Tümü"
-    },
-    "allow": {
-        "message": "İzin ver"
-    },
-    "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "Tüm ayarlarınız silinir ve kurtarılamaz"
-    },
-    "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "Tüm kısayollarınız silinir ve kurtarılamaz"
-    },
-    "always": {
-        "message": "Sürekli"
-    },
-    "alwaysActive": {
-        "message": "Sürekli etkin"
-    },
-    "alwaysShowProgressBar": {
-        "message": "İlerleme çubuğunu sürekli göster"
-    },
-    "analyzer": {
-        "message": "Analiz Edici"
-    },
-    "animations": {
-        "message": "Animasyonlar"
-    },
-    "appearance": {
-        "message": "Görünüm"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Verileri dışa aktarmak istediğinizden emin misiniz?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Verileri içe aktarmak istediğinizden emin misiniz?"
-    },
-    "audio": {
-        "message": "Ses"
-    },
-    "audioFormats": {
-        "message": "Ses formatları"
-    },
-    "auto": {
-        "message": "Otomatik"
-    },
-    "autoFullscreen": {
-        "message": "Otomatik tam ekran"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Sekme değiştirildiğinde duraklat"
-    },
-    "autoplay": {
-        "message": "Otomatik oynat"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "AV1, VP8, VP9'u engelle"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Mümkün olduğunda CPU oluşturma işleminden kaçının"
-    },
-    "backgroundColor": {
-        "message": "Arkaplan rengi"
-    },
-    "backgroundOpacity": {
-        "message": "Arkaplan opaklığı"
-    },
-    "backupAndReset": {
-        "message": "Yedek & sıfırla"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Sistem renk şeması temelli"
-    },
-    "belowPlayer": {
-        "message": "Oynatıcının altında"
-    },
-    "black": {
-        "message": "Siyah"
-    },
-    "blockAll": {
-        "message": "Tümünü engelle"
-    },
-    "blockAv1": {
-        "message": "AV1'i engelle"
-    },
-    "blockH264": {
-        "message": "H.264'ü engelle"
-    },
-    "blocklist": {
-        "message": "Kara Liste"
-    },
-    "blockMusic": {
-        "message": "Sesi engelle"
-    },
-    "blockVp8": {
-        "message": "VP8'i engelle"
-    },
-    "blockVp9": {
-        "message": "VP9'u engelle"
-    },
-    "blue": {
-        "message": "Mavi"
-    },
-    "blueGray": {
-        "message": "Mavi gri"
-    },
-    "bluelight": {
-        "message": "Mavi Işık"
-    },
-    "brightness": {
-        "message": "Parlaklık"
-    },
-    "brown": {
-        "message": "Kahverengi"
-    },
-    "browser": {
-        "message": "Tarayıcı"
-    },
-    "browserVersion": {
-        "message": "Tarayıcı Sürümü"
-    },
-    "bubbles": {
-        "message": "Baloncuklar"
-    },
-    "bug": {
-        "message": "Hata"
-    },
-    "buttons": {
-        "message": "Butonlar"
-    },
-    "cancel": {
-        "message": "İptal"
-    },
-    "categories": {
-        "message": "Kategoriler"
-    },
-    "channel": {
-        "message": "Kanal"
-    },
-    "channels": {
-        "message": "Kanallar"
-    },
-    "characterEdgeStyle": {
-        "message": "Karakter kenar stili"
-    },
-    "clip": {
-        "message": "Klip"
-    },
-    "clipboard": {
-        "message": "Pano"
-    },
-    "codecH264": {
-        "message": "Kodek h.264"
-    },
-    "codecs": {
-        "message": "Kodekler"
-    },
-    "collapsed": {
-        "message": "Daraltılmış"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Abonelik bölümlerini daralt"
-    },
-    "comments": {
-        "message": "Yorumlar"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Kapatmadan önce uyar"
-    },
-    "cookies": {
-        "message": "Çerezler"
-    },
-    "cores": {
-        "message": "Çekirdekler"
-    },
-    "cropChapterTitles": {
-        "message": "Bölüm başlıklarını kırp"
-    },
-    "custom": {
-        "message": "Özel"
-    },
-    "customCss": {
-        "message": "Özel CSS"
-    },
-    "customJs": {
-        "message": "Özel JS"
-    },
-    "customMiniPlayer": {
-        "message": "Özel Mini Oynatıcı"
-    },
-    "cyan": {
-        "message": "Camgöbeği"
-    },
-    "dark": {
-        "message": "Koyu"
-    },
-    "darkTheme": {
-        "message": "Koyu tema"
-    },
-    "dateAndTime": {
-        "message": "Tarih & zaman"
-    },
-    "dawn": {
-        "message": "Şafak"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Oynatma hızını azalt"
-    },
-    "decreaseVolume": {
-        "message": "Sesi azalt"
-    },
-    "deepOrange": {
-        "message": "Koyu turuncu"
-    },
-    "deepPurple": {
-        "message": "Koyu mor"
-    },
-    "default": {
-        "message": "Varsayılan"
-    },
-    "defaultChannelTab": {
-        "message": "Varsayılan kanal sekmesi"
-    },
-    "defaultContentCountry": {
-        "message": "Varsayılan içerik ülkesi"
-    },
-    "defaultPlaybackSpeed": {
-        "message": "Varsayılan Oynatma Hızı"
-    },
-    "deleteWatchedVideos": {
-        "message": "İzlenen videoları sil"
-    },
-    "deleteYoutubeCookies": {
-        "message": "YouTube çerezleri sil"
-    },
-    "depressed": {
-        "message": "Bunalımlı"
-    },
-    "description": {
-        "message": "Açıklama"
-    },
-    "description_ext": {
-        "message": "YouTube'u düzenli+akıllı hale getirin! YouTube video renkli reklam hacmi atlama hızı kanal aracı stili HD reklamlar reklam engelleme reklam engelleyici etiketleri anahtar kelime oynatma listesi"
-    },
-    "desert": {
-        "message": "Çöl"
-    },
-    "details": {
-        "message": "Ayrıntılar"
-    },
-    "developerOptions": {
-        "message": "Geliştirici seçenekleri"
-    },
-    "device": {
-        "message": "Cihaz"
-    },
-    "dim": {
-        "message": "Karart"
-    },
-    "disabled": {
-        "message": "Devredışı"
-    },
-    "dislike": {
-        "message": "Beğenmeme"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Zayıfların gününü göster"
-    },
-    "donate": {
-        "message": "Bağış"
-    },
-    "doNotChange": {
-        "message": "Değiştirme"
-    },
-    "download": {
-        "message": "İndir"
-    },
-    "draggable": {
-        "message": "Sürüklenebilir"
-    },
-    "dropShadow": {
-        "message": "Düşen gölge"
-    },
-    "durationWithSpeed": {
-        "message": "Oynatma hızına göre kalan süreyi göster"
-    },
-    "email": {
-        "message": "Eposta"
-    },
-    "empty": {
-        "message": "Boş"
-    },
-    "enabled": {
-        "message": "Etkin"
-    },
-    "enabledForced": {
-        "message": "Etkin (Zorla)"
-    },
-    "expanded": {
-        "message": "Genişletilmiş"
-    },
-    "exportSettings": {
-        "message": "Ayarları dışa aktar"
-    },
-    "extension": {
-        "message": "Uzantı"
-    },
-    "ExtraButtons": {
-        "message": "Ekstra düğmeler"
-    },
-    "Feature_not_yet_available": {
-        "message": "Özellik mevcut değil"
-    },
-    "file": {
-        "message": "Dosya"
-    },
-    "filters": {
-        "message": "Filtreler"
-    },
-    "fitToWindow": {
-        "message": "Pencereye sığdır"
-    },
-    "flash": {
-        "message": "Flaş"
-    },
-    "font": {
-        "message": "Yazı Tipi"
-    },
-    "fontColor": {
-        "message": "Yazı Rengi"
-    },
-    "fontFamily": {
-        "message": "Font Ailesi"
-    },
-    "fontOpacity": {
-        "message": "Yazı tipi opaklığı"
-    },
-    "fontSize": {
-        "message": "Yazı Boyutu"
-    },
-    "footer": {
-        "message": "Altbilgi"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Oynatma hızını uygulamaya zorla"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(Müzik için bile oynatma hızını zorla?)"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "En başından itibaren zorunlu oynatma videosu"
-    },
-    "forcedTheaterMode": {
-        "message": "Sinema modunu zorla"
-    },
-    "forcedVolume": {
-        "message": "Sesi zorla"
-    },
-    "forceSDR": {
-        "message": "SDR Zorla"
-    },
-    "foundABug": {
-        "message": "Hata mı buldun?"
-    },
-    "fullWindow": {
-        "message": "Tam pencere"
-    },
-    "general": {
-        "message": "Genel"
-    },
-    "geoPreference": {
-        "message": "Coğrafi Tercih"
-    },
-    "github": {
-        "message": "GitHub"
-    },
-    "googleApiKey": {
-        "message": "Google API key"
-    },
-    "goToSearchBox": {
-        "message": "Arama kutusuna git"
-    },
-    "gpu": {
-        "message": "GPU"
-    },
-    "green": {
-        "message": "Yeşil"
-    },
-    "grey": {
-        "message": "Gri"
-    },
-    "Hamburger_Menu": {
-        "message": "Hamburger Menu"
-    },
-    "hardwareInformation": {
-        "message": "Donanım Bilgileri"
-    },
-    "hd": {
-        "message": "HD"
-    },
-    "hdThumbnail": {
-        "message": "HD küçük resim"
-    },
-    "header": {
-        "message": "Başlık"
-    },
-    "hidden": {
-        "message": "Gizli"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Video sayfasında gizli"
-    },
-    "hide_labels": {
-        "message": "İsimleri Gizle"
-    },
-    "Hide_sidebar": {
-        "message": "Kenar çubuğunu gizle "
-    },
-    "Hide_the_tabs_only": {
-        "message": "Yalnızca sekmeleri gizle"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Hareketli küçük resimleri gizle"
-    },
-    "hideAnnotations": {
-        "message": "Ek açıklamaları gizle"
-    },
-    "hideCards": {
-        "message": "Video Kartlarını gizle"
-    },
-    "hideCategories": {
-        "message": "Kategorileri gizle"
-    },
-    "hideCommentsCount": {
-        "message": "Yorum sayısını gizle"
-    },
-    "hideCountryCode": {
-        "message": "Ülke kodunu gizle"
-    },
-    "hideDate": {
-        "message": "Tarihi gizle"
-    },
-    "hideDetailButton": {
-        "message": "Ayrıntı Düğmesini Gizle"
-    },
-    "hideDetails": {
-        "message": "Detayları gizle"
-    },
-    "hideEndscreen": {
-        "message": "Ekran sonunu gizle"
-    },
-    "hideFeaturedContent": {
-        "message": "Öne çıkan içeriği gizle"
-    },
-    "hideFooter": {
-        "message": "Altbilgiyi gizle"
-    },
-    "hideGradientBottom": {
-        "message": "Oynatıcı çubuğunun etrafındaki gölgeyi gizle"
-    },
-    "hideHomePageShorts": {
-        "message": "Ana sayfa'dan Shorts'ları kaldır"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Oynatıcı kontrol çubuğunu gizle"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Oynatıcı kontrolleri çubuğu düğmelerini gizle"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Oynatıcı kontrol seçeneklerini gizle"
-    },
-    "hidePlaylist": {
-        "message": "Oynatma Listesi'ni gizle"
-    },
-    "hideRightButtons": {
-        "message": "Sağ butonları gizle"
-    },
-    "hideScrollForDetails": {
-        "message": "«Ayrıntılar için kaydır» gizle"
-    },
-    "hideSkipOverlay": {
-        "message": "5 saniyelik atlama animasyonunu gizle"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Küçük resimlerdeki düğmeleri gizle"
-    },
-    "hideThumbnails": {
-        "message": "Küçük resimleri gizle"
-    },
-    "hideViewsCount": {
-        "message": "Görüntüleme sayısını gizle"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Sesli arama düğmesini gizle"
-    },
-    "high": {
-        "message": "Yüksek"
-    },
-    "history": {
-        "message": "Geçmiş"
-    },
-    "home": {
-        "message": "Ana Sayfa"
-    },
-    "homeScreen": {
-        "message": "Ana Sayfa Ekranı"
-    },
-    "hover": {
-        "message": "Üzerine Gelmek"
-    },
-    "hoverOnVideoPage": {
-        "message": "Videonun Üzerine gelmek"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Video ne zaman yüklendi?"
-    },
-    "icons": {
-        "message": "Simgeler"
-    },
-    "iconsOnly": {
-        "message": "Yalnızca simgeler"
-    },
-    "importSettings": {
-        "message": "Ayarları içe aktar"
-    },
-    "improvedtubeButtons": {
-        "message": "ImprovedTube butonları"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "YouTube'da ImprovedTube Simgesi"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube dili"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube sürümü"
-    },
-    "improveLogo": {
-        "message": "Logoyu geliştir"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Oynatma hızını artır"
-    },
-    "increaseVolume": {
-        "message": "Sesi artır"
-    },
-    "indigo": {
-        "message": "Çivit"
-    },
-    "items": {
-        "message": "Öğeler"
-    },
-    "language": {
-        "message": "Dil"
-    },
-    "languages": {
-        "message": "Diller"
-    },
-    "layerAnimationScale": {
-        "message": "Katman animasyon ölçeği"
-    },
-    "layout": {
-        "message": "Düzen"
-    },
-    "legacyYoutube": {
-        "message": "Eski YouTube"
-    },
-    "library": {
-        "message": "Kütüphane"
-    },
-    "light": {
-        "message": "Açık"
-    },
-    "lightBlue": {
-        "message": "Açık mavi"
-    },
-    "lightGreen": {
-        "message": "Açık yeşil"
-    },
-    "like": {
-        "message": "Beğen"
-    },
-    "liked": {
-        "message": "Beğenildi"
-    },
-    "likes": {
-        "message": "Beğeniler"
-    },
-    "limitPageWidth": {
-        "message": "Sayfa genişliğini sınırla"
-    },
-    "list": {
-        "message": "Liste"
-    },
-    "liveChat": {
-        "message": "Canlı sohbet"
-    },
-    "liveChatType": {
-        "message": "Canlı sohbet türü"
-    },
-    "location": {
-        "message": "Konum"
-    },
-    "loop": {
-        "message": "Döngü"
-    },
-    "loudnessNormalization": {
-        "message": "Gürültü normalleştirme"
-    },
-    "low": {
-        "message": "Düşük"
-    },
-    "markWatchedVideos": {
-        "message": "İzlenen videoları işaretle"
-    },
-    "medium": {
-        "message": "Orta"
-    },
-    "mixer": {
-        "message": "Karıştırıcı"
-    },
-    "more": {
-        "message": "Daha fazla"
-    },
-    "mostViewedChannels": {
-        "message": "En çok izlenen kanallar"
-    },
-    "moveSidebarLeft": {
-        "message": "Kenar çubuğunu sola taşı"
-    },
-    "moveThumbnailsRight": {
-        "message": "Küçük resimleri sağa taşı"
-    },
-    "myColors": {
-        "message": "Renklerim"
-    },
-    "name": {
-        "message": "İsim"
-    },
-    "nativeMiniPlayer": {
-        "message": "Native mini oynatıcı"
-    },
-    "new": {
-        "message": "Yeni"
-    },
-    "nextVideo": {
-        "message": "Sonraki video"
-    },
-    "night": {
-        "message": "Gece"
-    },
-    "nightMode": {
-        "message": "Gece modu"
-    },
-    "noActiveFeatures": {
-        "message": "Aktif özellik yok"
-    },
-    "none": {
-        "message": "Yok"
-    },
-    "noOpenVideoTabs": {
-        "message": "Açık video sekmesi yok"
-    },
-    "off": {
-        "message": "Kapalı"
-    },
-    "ok": {
-        "message": "Tamam"
-    },
-    "old": {
-        "message": "Eski"
-    },
-    "onAllVideos": {
-        "message": "Tüm videolarda"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Yalnızca YouTube'da etkin"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "İkinci video açıldığında duraklat"
-    },
-    "onSubscribedChannels": {
-        "message": "Kapalı, abone olduğum kanallar hariç"
-    },
-    "openNewTab": {
-        "message": "Yeni sekmede aç"
-    },
-    "openPopupPlayer": {
-        "message": "Videoyu/oynatma listesini yeni pencerede aç"
-    },
-    "orange": {
-        "message": "Turuncu"
-    },
-    "other": {
-        "message": "Diğer"
-    },
-    "outline": {
-        "message": "Ana hat"
-    },
-    "overlay": {
-        "message": "Arayüz"
-    },
-    "permissions": {
-        "message": "İzinler"
-    },
-    "pictureInPicture": {
-        "message": "Resim içinde resim"
-    },
-    "pink": {
-        "message": "Pembe"
-    },
-    "plain": {
-        "message": "Sade"
-    },
-    "playAllButton": {
-        "message": "\"Tümünü oynat\"butonu"
-    },
-    "playbackSpeed": {
-        "message": "Oynatma hızı"
-    },
-    "player": {
-        "message": "Oynatıcı"
-    },
-    "playerColor": {
-        "message": "İlerleme çubuğu rengi"
-    },
-    "playerSize": {
-        "message": "Oynatıcı boyutu"
-    },
-    "playlist": {
-        "message": "Oynatma Listesi"
-    },
-    "playlists": {
-        "message": "Oynatma Listeleri"
-    },
-    "playPause": {
-        "message": "Oynat / Duraklat"
-    },
-    "popupPlayer": {
-        "message": "Açılır pencere oynatıcı"
-    },
-    "popupWindowButtons": {
-        "message": "Her küçük resme bir açılır oynatıcı düğmesi ekleyin"
-    },
-    "position": {
-        "message": "Pozisyon"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Herhangi bir tuşa bas veya farenin tekerleğini kullan."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Herhangi bir tuşa bas veya farenin tekerleğini kullan"
-    },
-    "previousVideo": {
-        "message": "Önceki video"
-    },
-    "primaryColor": {
-        "message": "Birincil renk"
-    },
-    "purple": {
-        "message": "Mor"
-    },
-    "quality": {
-        "message": "Kalite"
-    },
-    "raised": {
-        "message": "Kabarık"
-    },
-    "rateMe": {
-        "message": "Beni oyla"
-    },
-    "rateUs": {
-        "message": "Bizi oyla"
-    },
-    "red": {
-        "message": "Kırmızı"
-    },
-    "redDislikeButton": {
-        "message": "Beğenmeme düğmesinini kırmızı renkte göster"
-    },
-    "relatedVideos": {
-        "message": "İlgili videolar"
-    },
-    "remote": {
-        "message": "TV'de oynat"
-    },
-    "removeRelatedSearchResults": {
-        "message": "İlgili arama sonuçlarını kaldır"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Arama sonuçlarından Shorts reelini kaldır"
-    },
-    "repeat": {
-        "message": "Tekrarla"
-    },
-    "report": {
-        "message": "Raporla"
-    },
-    "reset": {
-        "message": "Sıfırla"
-    },
-    "resetAllSettings": {
-        "message": "Tüm ayarları sıfırla"
-    },
-    "resetAllShortcuts": {
-        "message": "Tüm kısayolları sıfırla"
-    },
-    "reverse": {
-        "message": "Ters"
-    },
-    "rotate": {
-        "message": "Döndür"
-    },
-    "save": {
-        "message": "Kaydet"
-    },
-    "saveAs": {
-        "message": "Farklı kaydet"
-    },
-    "schedule": {
-        "message": "Takvim"
-    },
-    "screen": {
-        "message": "Ekran"
-    },
-    "screenshot": {
-        "message": "Ekran görüntüsü"
-    },
-    "scrollBar": {
-        "message": "Kaydırma çubuğu"
-    },
-    "search": {
-        "message": "Ara"
-    },
-    "searchBarOnly": {
-        "message": "Yalnızca arama çubuğu"
-    },
-    "seekBackward10Seconds": {
-        "message": "10 saniye geriye git"
-    },
-    "seekForward10Seconds": {
-        "message": "10 saniye ileriye git"
-    },
-    "seekNextChapter": {
-        "message": "Sonraki Bölümü Ara"
-    },
-    "seekPreviousChapter": {
-        "message": "Önceki Bölümü Ara"
-    },
-    "settings": {
-        "message": "Ayarlar"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Ayarlar başarıyla içe aktarıldı"
-    },
-    "share": {
-        "message": "Paylaş"
-    },
-    "shortcuts": {
-        "message": "Kısayollar"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Fareyle üzerine gelindiğinde kartları göster"
-    },
-    "showChannelVideosCount": {
-        "message": "Kanalın video sayısını göster"
-    },
-    "showLess": {
-        "message": "Daha az göster"
-    },
-    "showMore": {
-        "message": "Daha fazla göster"
-    },
-    "showRemainingDuration": {
-        "message": "Videonun kalan süresini göster"
-    },
-    "showVersion": {
-        "message": "Versionu göster"
-    },
-    "shuffle": {
-        "message": "Karıştır"
-    },
-    "sidebar": {
-        "message": "Kenar çubuğu"
-    },
-    "softwareInformation": {
-        "message": "Yazılım bilgisi"
-    },
-    "spacebar": {
-        "message": "Boşluk Çubuğu"
-    },
-    "squaredUserImages": {
-        "message": "Kare kullanıcı görüntüleri"
-    },
-    "static": {
-        "message": "Statik"
-    },
-    "statsForNerds": {
-        "message": "Meraklılar için istatistikler"
-    },
-    "step": {
-        "message": "Adım"
-    },
-    "stop": {
-        "message": "Durdur"
-    },
-    "style": {
-        "message": "Stil"
-    },
-    "styles": {
-        "message": "Stiller"
-    },
-    "subscribe": {
-        "message": "Abone Ol"
-    },
-    "subscriptions": {
-        "message": "Abonelikler"
-    },
-    "subtitles": {
-        "message": "Altyazılar"
-    },
-    "sunset": {
-        "message": "Gün batımı"
-    },
-    "sunsetToSunrise": {
-        "message": "Gün batımından gün doğumuna"
-    },
-    "systemPeferenceDark": {
-        "message": "Sistem tercihi: Koyu"
-    },
-    "systemPeferenceLight": {
-        "message": "Sistem tercihi: açık"
-    },
-    "textColor": {
-        "message": "Yazı rengi"
-    },
-    "thanks": {
-        "message": "Teşekkürler"
-    },
-    "themes": {
-        "message": "Temalar"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Bu işlem, tüm çerezleri kaldıracaktır."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Bu işlem, izlenen tüm videoları kaldıracaktır."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Bu işlem, tüm YouTube çerezlerini kaldıracaktır."
-    },
-    "thisWillResetAllSettings": {
-        "message": "Bu işlem, tüm ayarları sıfırlayacaktır."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Bu işlem, tüm kısayolları sıfırlayacaktır."
-    },
-    "thumbnails": {
-        "message": "Küçük resimler"
-    },
-    "thumbnailsQuality": {
-        "message": "Küçük Resim Kalitesi"
-    },
-    "timeFrom": {
-        "message": "Şu zamandan"
-    },
-    "timeTo": {
-        "message": "Şu zamana"
-    },
-    "todayAt": {
-        "message": "Bugün"
-    },
-    "toggleAutoplay": {
-        "message": "Otomatik oynatmayı aç/kapat"
-    },
-    "toggleCards": {
-        "message": "Kartları aç/kapat"
-    },
-    "toggleControls": {
-        "message": "Kontrolleri aç/kapat"
-    },
-    "topChat": {
-        "message": "En İyi Sohbet Mesajları"
-    },
-    "trackWatchedVideos": {
-        "message": "İzlenen videoları takip edin"
-    },
-    "trailerAutoplay": {
-        "message": "Fragman otomatik oynatımı"
-    },
-    "translations": {
-        "message": "Çeviriler"
-    },
-    "transparentBackground": {
-        "message": "Saydam arka plan"
-    },
-    "trending": {
-        "message": "Trendler"
-    },
-    "tryToReloadThePage": {
-        "message": "Sayfayı yeniden yüklemeyi deneyin"
-    },
-    "type": {
-        "message": "Tip"
-    },
-    "upNextAutoplay": {
-        "message": "Sonraki otomatik oynatma"
-    },
-    "use24HourFormat": {
-        "message": "24 saat biçimini kullan"
-    },
-    "version": {
-        "message": "Sürüm"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Kategorinin adını almak için video açıklaması genişletilecek"
-    },
-    "videoFormats": {
-        "message": "Video formatları"
-    },
-    "videos": {
-        "message": "Videolar"
-    },
-    "viewMode": {
-        "message": "Görünüm Modu"
-    },
-    "volume": {
-        "message": "Ses"
-    },
-    "watchedVideos": {
-        "message": "İzlenen videolar"
-    },
-    "watchLater": {
-        "message": "Sonra izle"
-    },
-    "watchTime": {
-        "message": "İzleme zamanı"
-    },
-    "whenPaused": {
-        "message": "Duraklatıldığında"
-    },
-    "whenTabIsChanged": {
-        "message": "Sekme değiştirildiğinde"
-    },
-    "white": {
-        "message": "Beyaz"
-    },
-    "windowColor": {
-        "message": "Pencere rengi"
-    },
-    "windowOpacity": {
-        "message": "Pencere opaklığı"
-    },
-    "yellow": {
-        "message": "Sarı"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube Header (sol)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube Header (sağ)"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube ana sayfası"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube dili"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube, h.264 codec bileşeni için video kalitesini 1080p ile sınırlar"
-    }
+	"about": {
+		"message": "Hakkında"
+	},
+	"accept": {
+		"message": "Onayla"
+	},
+	"activate": {
+		"message": "Aktifleştir"
+	},
+	"activateCaptions": {
+		"message": "Altyazıları Aktifleştir"
+	},
+	"activated": {
+		"message": "Aktifleştirilmiş"
+	},
+	"activatedFeatures": {
+		"message": "Aktifleştirilmiş özellikler"
+	},
+	"activateFullscreen": {
+		"message": "Tam ekranı Aktifleştir"
+	},
+	"activeFeatures": {
+		"message": "Etkin özellikler"
+	},
+	"addScrollToTop": {
+		"message": "«Yukarı kaydır» ekle"
+	},
+	"ads": {
+		"message": "Reklamlar"
+	},
+	"all": {
+		"message": "Tümü"
+	},
+	"allow": {
+		"message": "İzin ver"
+	},
+	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
+		"message": "Tüm ayarlarınız silinir ve kurtarılamaz"
+	},
+	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+		"message": "Tüm kısayollarınız silinir ve kurtarılamaz"
+	},
+	"always": {
+		"message": "Sürekli"
+	},
+	"alwaysActive": {
+		"message": "Sürekli etkin"
+	},
+	"alwaysShowProgressBar": {
+		"message": "İlerleme çubuğunu sürekli göster"
+	},
+	"analyzer": {
+		"message": "Analiz Edici"
+	},
+	"animations": {
+		"message": "Animasyonlar"
+	},
+	"appearance": {
+		"message": "Görünüm"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Verileri dışa aktarmak istediğinizden emin misiniz?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Verileri içe aktarmak istediğinizden emin misiniz?"
+	},
+	"audio": {
+		"message": "Ses"
+	},
+	"audioFormats": {
+		"message": "Ses formatları"
+	},
+	"auto": {
+		"message": "Otomatik"
+	},
+	"autoFullscreen": {
+		"message": "Otomatik tam ekran"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Sekme değiştirildiğinde duraklat"
+	},
+	"autoplay": {
+		"message": "Otomatik oynat"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "AV1, VP8, VP9'u engelle"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Mümkün olduğunda CPU oluşturma işleminden kaçının"
+	},
+	"backgroundColor": {
+		"message": "Arkaplan rengi"
+	},
+	"backgroundOpacity": {
+		"message": "Arkaplan opaklığı"
+	},
+	"backupAndReset": {
+		"message": "Yedek & sıfırla"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Sistem renk şeması temelli"
+	},
+	"belowPlayer": {
+		"message": "Oynatıcının altında"
+	},
+	"black": {
+		"message": "Siyah"
+	},
+	"blockAll": {
+		"message": "Tümünü engelle"
+	},
+	"blockAv1": {
+		"message": "AV1'i engelle"
+	},
+	"blockH264": {
+		"message": "H.264'ü engelle"
+	},
+	"blocklist": {
+		"message": "Kara Liste"
+	},
+	"blockMusic": {
+		"message": "Sesi engelle"
+	},
+	"blockVp8": {
+		"message": "VP8'i engelle"
+	},
+	"blockVp9": {
+		"message": "VP9'u engelle"
+	},
+	"blue": {
+		"message": "Mavi"
+	},
+	"blueGray": {
+		"message": "Mavi gri"
+	},
+	"bluelight": {
+		"message": "Mavi Işık"
+	},
+	"brightness": {
+		"message": "Parlaklık"
+	},
+	"brown": {
+		"message": "Kahverengi"
+	},
+	"browser": {
+		"message": "Tarayıcı"
+	},
+	"browserVersion": {
+		"message": "Tarayıcı Sürümü"
+	},
+	"bubbles": {
+		"message": "Baloncuklar"
+	},
+	"bug": {
+		"message": "Hata"
+	},
+	"buttons": {
+		"message": "Butonlar"
+	},
+	"cancel": {
+		"message": "İptal"
+	},
+	"categories": {
+		"message": "Kategoriler"
+	},
+	"channel": {
+		"message": "Kanal"
+	},
+	"channels": {
+		"message": "Kanallar"
+	},
+	"characterEdgeStyle": {
+		"message": "Karakter kenar stili"
+	},
+	"clip": {
+		"message": "Klip"
+	},
+	"clipboard": {
+		"message": "Pano"
+	},
+	"codecH264": {
+		"message": "Kodek h.264"
+	},
+	"codecs": {
+		"message": "Kodekler"
+	},
+	"collapsed": {
+		"message": "Daraltılmış"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Abonelik bölümlerini daralt"
+	},
+	"comments": {
+		"message": "Yorumlar"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Kapatmadan önce uyar"
+	},
+	"cookies": {
+		"message": "Çerezler"
+	},
+	"cores": {
+		"message": "Çekirdekler"
+	},
+	"cropChapterTitles": {
+		"message": "Bölüm başlıklarını kırp"
+	},
+	"custom": {
+		"message": "Özel"
+	},
+	"customCss": {
+		"message": "Özel CSS"
+	},
+	"customJs": {
+		"message": "Özel JS"
+	},
+	"customMiniPlayer": {
+		"message": "Özel Mini Oynatıcı"
+	},
+	"cyan": {
+		"message": "Camgöbeği"
+	},
+	"dark": {
+		"message": "Koyu"
+	},
+	"darkTheme": {
+		"message": "Koyu tema"
+	},
+	"dateAndTime": {
+		"message": "Tarih & zaman"
+	},
+	"dawn": {
+		"message": "Şafak"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Oynatma hızını azalt"
+	},
+	"decreaseVolume": {
+		"message": "Sesi azalt"
+	},
+	"deepOrange": {
+		"message": "Koyu turuncu"
+	},
+	"deepPurple": {
+		"message": "Koyu mor"
+	},
+	"default": {
+		"message": "Varsayılan"
+	},
+	"defaultChannelTab": {
+		"message": "Varsayılan kanal sekmesi"
+	},
+	"defaultContentCountry": {
+		"message": "Varsayılan içerik ülkesi"
+	},
+	"defaultPlaybackSpeed": {
+		"message": "Varsayılan Oynatma Hızı"
+	},
+	"deleteWatchedVideos": {
+		"message": "İzlenen videoları sil"
+	},
+	"deleteYoutubeCookies": {
+		"message": "YouTube çerezleri sil"
+	},
+	"depressed": {
+		"message": "Bunalımlı"
+	},
+	"description": {
+		"message": "Açıklama"
+	},
+	"description_ext": {
+		"message": "YouTube'u düzenli+akıllı hale getirin! YouTube video renkli reklam hacmi atlama hızı kanal aracı stili HD reklamlar reklam engelleme reklam engelleyici etiketleri anahtar kelime oynatma listesi"
+	},
+	"desert": {
+		"message": "Çöl"
+	},
+	"details": {
+		"message": "Ayrıntılar"
+	},
+	"developerOptions": {
+		"message": "Geliştirici seçenekleri"
+	},
+	"device": {
+		"message": "Cihaz"
+	},
+	"dim": {
+		"message": "Karart"
+	},
+	"disabled": {
+		"message": "Devredışı"
+	},
+	"dislike": {
+		"message": "Beğenmeme"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Zayıfların gününü göster"
+	},
+	"donate": {
+		"message": "Bağış"
+	},
+	"doNotChange": {
+		"message": "Değiştirme"
+	},
+	"download": {
+		"message": "İndir"
+	},
+	"draggable": {
+		"message": "Sürüklenebilir"
+	},
+	"dropShadow": {
+		"message": "Düşen gölge"
+	},
+	"durationWithSpeed": {
+		"message": "Oynatma hızına göre kalan süreyi göster"
+	},
+	"email": {
+		"message": "Eposta"
+	},
+	"empty": {
+		"message": "Boş"
+	},
+	"enabled": {
+		"message": "Etkin"
+	},
+	"enabledForced": {
+		"message": "Etkin (Zorla)"
+	},
+	"expanded": {
+		"message": "Genişletilmiş"
+	},
+	"exportSettings": {
+		"message": "Ayarları dışa aktar"
+	},
+	"extension": {
+		"message": "Uzantı"
+	},
+	"ExtraButtons": {
+		"message": "Ekstra düğmeler"
+	},
+	"Feature_not_yet_available": {
+		"message": "Özellik mevcut değil"
+	},
+	"file": {
+		"message": "Dosya"
+	},
+	"filters": {
+		"message": "Filtreler"
+	},
+	"fitToWindow": {
+		"message": "Pencereye sığdır"
+	},
+	"flash": {
+		"message": "Flaş"
+	},
+	"font": {
+		"message": "Yazı Tipi"
+	},
+	"fontColor": {
+		"message": "Yazı Rengi"
+	},
+	"fontFamily": {
+		"message": "Font Ailesi"
+	},
+	"fontOpacity": {
+		"message": "Yazı tipi opaklığı"
+	},
+	"fontSize": {
+		"message": "Yazı Boyutu"
+	},
+	"footer": {
+		"message": "Altbilgi"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Oynatma hızını uygulamaya zorla"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(Müzik için bile oynatma hızını zorla?)"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "En başından itibaren zorunlu oynatma videosu"
+	},
+	"forcedTheaterMode": {
+		"message": "Sinema modunu zorla"
+	},
+	"forcedVolume": {
+		"message": "Sesi zorla"
+	},
+	"forceSDR": {
+		"message": "SDR Zorla"
+	},
+	"foundABug": {
+		"message": "Hata mı buldun?"
+	},
+	"fullWindow": {
+		"message": "Tam pencere"
+	},
+	"general": {
+		"message": "Genel"
+	},
+	"geoPreference": {
+		"message": "Coğrafi Tercih"
+	},
+	"goToSearchBox": {
+		"message": "Arama kutusuna git"
+	},
+	"green": {
+		"message": "Yeşil"
+	},
+	"grey": {
+		"message": "Gri"
+	},
+	"hardwareInformation": {
+		"message": "Donanım Bilgileri"
+	},
+	"hdThumbnail": {
+		"message": "HD küçük resim"
+	},
+	"header": {
+		"message": "Başlık"
+	},
+	"hidden": {
+		"message": "Gizli"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Video sayfasında gizli"
+	},
+	"hide_labels": {
+		"message": "İsimleri Gizle"
+	},
+	"Hide_sidebar": {
+		"message": "Kenar çubuğunu gizle"
+	},
+	"Hide_the_tabs_only": {
+		"message": "Yalnızca sekmeleri gizle"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Hareketli küçük resimleri gizle"
+	},
+	"hideAnnotations": {
+		"message": "Ek açıklamaları gizle"
+	},
+	"hideCards": {
+		"message": "Video Kartlarını gizle"
+	},
+	"hideCategories": {
+		"message": "Kategorileri gizle"
+	},
+	"hideCommentsCount": {
+		"message": "Yorum sayısını gizle"
+	},
+	"hideCountryCode": {
+		"message": "Ülke kodunu gizle"
+	},
+	"hideDate": {
+		"message": "Tarihi gizle"
+	},
+	"hideDetailButton": {
+		"message": "Ayrıntı Düğmesini Gizle"
+	},
+	"hideDetails": {
+		"message": "Detayları gizle"
+	},
+	"hideEndscreen": {
+		"message": "Ekran sonunu gizle"
+	},
+	"hideFeaturedContent": {
+		"message": "Öne çıkan içeriği gizle"
+	},
+	"hideFooter": {
+		"message": "Altbilgiyi gizle"
+	},
+	"hideGradientBottom": {
+		"message": "Oynatıcı çubuğunun etrafındaki gölgeyi gizle"
+	},
+	"hideHomePageShorts": {
+		"message": "Ana sayfa'dan Shorts'ları kaldır"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Oynatıcı kontrol çubuğunu gizle"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Oynatıcı kontrolleri çubuğu düğmelerini gizle"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Oynatıcı kontrol seçeneklerini gizle"
+	},
+	"hidePlaylist": {
+		"message": "Oynatma Listesi'ni gizle"
+	},
+	"hideRightButtons": {
+		"message": "Sağ butonları gizle"
+	},
+	"hideScrollForDetails": {
+		"message": "«Ayrıntılar için kaydır» gizle"
+	},
+	"hideSkipOverlay": {
+		"message": "5 saniyelik atlama animasyonunu gizle"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Küçük resimlerdeki düğmeleri gizle"
+	},
+	"hideThumbnails": {
+		"message": "Küçük resimleri gizle"
+	},
+	"hideViewsCount": {
+		"message": "Görüntüleme sayısını gizle"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Sesli arama düğmesini gizle"
+	},
+	"high": {
+		"message": "Yüksek"
+	},
+	"history": {
+		"message": "Geçmiş"
+	},
+	"home": {
+		"message": "Ana Sayfa"
+	},
+	"homeScreen": {
+		"message": "Ana Sayfa Ekranı"
+	},
+	"hover": {
+		"message": "Üzerine Gelmek"
+	},
+	"hoverOnVideoPage": {
+		"message": "Videonun Üzerine gelmek"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Video ne zaman yüklendi?"
+	},
+	"icons": {
+		"message": "Simgeler"
+	},
+	"iconsOnly": {
+		"message": "Yalnızca simgeler"
+	},
+	"importSettings": {
+		"message": "Ayarları içe aktar"
+	},
+	"improvedtubeButtons": {
+		"message": "ImprovedTube butonları"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "YouTube'da ImprovedTube Simgesi"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube dili"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube sürümü"
+	},
+	"improveLogo": {
+		"message": "Logoyu geliştir"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Oynatma hızını artır"
+	},
+	"increaseVolume": {
+		"message": "Sesi artır"
+	},
+	"indigo": {
+		"message": "Çivit"
+	},
+	"items": {
+		"message": "Öğeler"
+	},
+	"language": {
+		"message": "Dil"
+	},
+	"languages": {
+		"message": "Diller"
+	},
+	"layerAnimationScale": {
+		"message": "Katman animasyon ölçeği"
+	},
+	"layout": {
+		"message": "Düzen"
+	},
+	"legacyYoutube": {
+		"message": "Eski YouTube"
+	},
+	"library": {
+		"message": "Kütüphane"
+	},
+	"light": {
+		"message": "Açık"
+	},
+	"lightBlue": {
+		"message": "Açık mavi"
+	},
+	"lightGreen": {
+		"message": "Açık yeşil"
+	},
+	"like": {
+		"message": "Beğen"
+	},
+	"liked": {
+		"message": "Beğenildi"
+	},
+	"likes": {
+		"message": "Beğeniler"
+	},
+	"limitPageWidth": {
+		"message": "Sayfa genişliğini sınırla"
+	},
+	"list": {
+		"message": "Liste"
+	},
+	"liveChat": {
+		"message": "Canlı sohbet"
+	},
+	"liveChatType": {
+		"message": "Canlı sohbet türü"
+	},
+	"location": {
+		"message": "Konum"
+	},
+	"loop": {
+		"message": "Döngü"
+	},
+	"loudnessNormalization": {
+		"message": "Gürültü normalleştirme"
+	},
+	"low": {
+		"message": "Düşük"
+	},
+	"markWatchedVideos": {
+		"message": "İzlenen videoları işaretle"
+	},
+	"medium": {
+		"message": "Orta"
+	},
+	"mixer": {
+		"message": "Karıştırıcı"
+	},
+	"more": {
+		"message": "Daha fazla"
+	},
+	"mostViewedChannels": {
+		"message": "En çok izlenen kanallar"
+	},
+	"moveSidebarLeft": {
+		"message": "Kenar çubuğunu sola taşı"
+	},
+	"moveThumbnailsRight": {
+		"message": "Küçük resimleri sağa taşı"
+	},
+	"myColors": {
+		"message": "Renklerim"
+	},
+	"name": {
+		"message": "İsim"
+	},
+	"nativeMiniPlayer": {
+		"message": "Native mini oynatıcı"
+	},
+	"new": {
+		"message": "Yeni"
+	},
+	"nextVideo": {
+		"message": "Sonraki video"
+	},
+	"night": {
+		"message": "Gece"
+	},
+	"nightMode": {
+		"message": "Gece modu"
+	},
+	"noActiveFeatures": {
+		"message": "Aktif özellik yok"
+	},
+	"none": {
+		"message": "Yok"
+	},
+	"noOpenVideoTabs": {
+		"message": "Açık video sekmesi yok"
+	},
+	"off": {
+		"message": "Kapalı"
+	},
+	"ok": {
+		"message": "Tamam"
+	},
+	"old": {
+		"message": "Eski"
+	},
+	"onAllVideos": {
+		"message": "Tüm videolarda"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Yalnızca YouTube'da etkin"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "İkinci video açıldığında duraklat"
+	},
+	"onSubscribedChannels": {
+		"message": "Kapalı, abone olduğum kanallar hariç"
+	},
+	"openNewTab": {
+		"message": "Yeni sekmede aç"
+	},
+	"openPopupPlayer": {
+		"message": "Videoyu/oynatma listesini yeni pencerede aç"
+	},
+	"orange": {
+		"message": "Turuncu"
+	},
+	"other": {
+		"message": "Diğer"
+	},
+	"outline": {
+		"message": "Ana hat"
+	},
+	"overlay": {
+		"message": "Arayüz"
+	},
+	"permissions": {
+		"message": "İzinler"
+	},
+	"pictureInPicture": {
+		"message": "Resim içinde resim"
+	},
+	"pink": {
+		"message": "Pembe"
+	},
+	"plain": {
+		"message": "Sade"
+	},
+	"playAllButton": {
+		"message": "\"Tümünü oynat\"butonu"
+	},
+	"playbackSpeed": {
+		"message": "Oynatma hızı"
+	},
+	"player": {
+		"message": "Oynatıcı"
+	},
+	"playerColor": {
+		"message": "İlerleme çubuğu rengi"
+	},
+	"playerSize": {
+		"message": "Oynatıcı boyutu"
+	},
+	"playlist": {
+		"message": "Oynatma Listesi"
+	},
+	"playlists": {
+		"message": "Oynatma Listeleri"
+	},
+	"playPause": {
+		"message": "Oynat / Duraklat"
+	},
+	"popupPlayer": {
+		"message": "Açılır pencere oynatıcı"
+	},
+	"popupWindowButtons": {
+		"message": "Her küçük resme bir açılır oynatıcı düğmesi ekleyin"
+	},
+	"position": {
+		"message": "Pozisyon"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Herhangi bir tuşa bas veya farenin tekerleğini kullan."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Herhangi bir tuşa bas veya farenin tekerleğini kullan"
+	},
+	"previousVideo": {
+		"message": "Önceki video"
+	},
+	"primaryColor": {
+		"message": "Birincil renk"
+	},
+	"purple": {
+		"message": "Mor"
+	},
+	"quality": {
+		"message": "Kalite"
+	},
+	"raised": {
+		"message": "Kabarık"
+	},
+	"rateMe": {
+		"message": "Beni oyla"
+	},
+	"rateUs": {
+		"message": "Bizi oyla"
+	},
+	"red": {
+		"message": "Kırmızı"
+	},
+	"redDislikeButton": {
+		"message": "Beğenmeme düğmesinini kırmızı renkte göster"
+	},
+	"relatedVideos": {
+		"message": "İlgili videolar"
+	},
+	"remote": {
+		"message": "TV'de oynat"
+	},
+	"removeRelatedSearchResults": {
+		"message": "İlgili arama sonuçlarını kaldır"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Arama sonuçlarından Shorts reelini kaldır"
+	},
+	"repeat": {
+		"message": "Tekrarla"
+	},
+	"report": {
+		"message": "Raporla"
+	},
+	"reset": {
+		"message": "Sıfırla"
+	},
+	"resetAllSettings": {
+		"message": "Tüm ayarları sıfırla"
+	},
+	"resetAllShortcuts": {
+		"message": "Tüm kısayolları sıfırla"
+	},
+	"reverse": {
+		"message": "Ters"
+	},
+	"rotate": {
+		"message": "Döndür"
+	},
+	"save": {
+		"message": "Kaydet"
+	},
+	"saveAs": {
+		"message": "Farklı kaydet"
+	},
+	"schedule": {
+		"message": "Takvim"
+	},
+	"screen": {
+		"message": "Ekran"
+	},
+	"screenshot": {
+		"message": "Ekran görüntüsü"
+	},
+	"scrollBar": {
+		"message": "Kaydırma çubuğu"
+	},
+	"search": {
+		"message": "Ara"
+	},
+	"searchBarOnly": {
+		"message": "Yalnızca arama çubuğu"
+	},
+	"seekBackward10Seconds": {
+		"message": "10 saniye geriye git"
+	},
+	"seekForward10Seconds": {
+		"message": "10 saniye ileriye git"
+	},
+	"seekNextChapter": {
+		"message": "Sonraki Bölümü Ara"
+	},
+	"seekPreviousChapter": {
+		"message": "Önceki Bölümü Ara"
+	},
+	"settings": {
+		"message": "Ayarlar"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Ayarlar başarıyla içe aktarıldı"
+	},
+	"share": {
+		"message": "Paylaş"
+	},
+	"shortcuts": {
+		"message": "Kısayollar"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Fareyle üzerine gelindiğinde kartları göster"
+	},
+	"showChannelVideosCount": {
+		"message": "Kanalın video sayısını göster"
+	},
+	"showLess": {
+		"message": "Daha az göster"
+	},
+	"showMore": {
+		"message": "Daha fazla göster"
+	},
+	"showRemainingDuration": {
+		"message": "Videonun kalan süresini göster"
+	},
+	"showVersion": {
+		"message": "Versionu göster"
+	},
+	"shuffle": {
+		"message": "Karıştır"
+	},
+	"sidebar": {
+		"message": "Kenar çubuğu"
+	},
+	"softwareInformation": {
+		"message": "Yazılım bilgisi"
+	},
+	"spacebar": {
+		"message": "Boşluk Çubuğu"
+	},
+	"squaredUserImages": {
+		"message": "Kare kullanıcı görüntüleri"
+	},
+	"static": {
+		"message": "Statik"
+	},
+	"statsForNerds": {
+		"message": "Meraklılar için istatistikler"
+	},
+	"step": {
+		"message": "Adım"
+	},
+	"stop": {
+		"message": "Durdur"
+	},
+	"style": {
+		"message": "Stil"
+	},
+	"styles": {
+		"message": "Stiller"
+	},
+	"subscribe": {
+		"message": "Abone Ol"
+	},
+	"subscriptions": {
+		"message": "Abonelikler"
+	},
+	"subtitles": {
+		"message": "Altyazılar"
+	},
+	"sunset": {
+		"message": "Gün batımı"
+	},
+	"sunsetToSunrise": {
+		"message": "Gün batımından gün doğumuna"
+	},
+	"systemPeferenceDark": {
+		"message": "Sistem tercihi: Koyu"
+	},
+	"systemPeferenceLight": {
+		"message": "Sistem tercihi: açık"
+	},
+	"textColor": {
+		"message": "Yazı rengi"
+	},
+	"thanks": {
+		"message": "Teşekkürler"
+	},
+	"themes": {
+		"message": "Temalar"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Bu işlem, tüm çerezleri kaldıracaktır."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Bu işlem, izlenen tüm videoları kaldıracaktır."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Bu işlem, tüm YouTube çerezlerini kaldıracaktır."
+	},
+	"thisWillResetAllSettings": {
+		"message": "Bu işlem, tüm ayarları sıfırlayacaktır."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Bu işlem, tüm kısayolları sıfırlayacaktır."
+	},
+	"thumbnails": {
+		"message": "Küçük resimler"
+	},
+	"thumbnailsQuality": {
+		"message": "Küçük Resim Kalitesi"
+	},
+	"timeFrom": {
+		"message": "Şu zamandan"
+	},
+	"timeTo": {
+		"message": "Şu zamana"
+	},
+	"todayAt": {
+		"message": "Bugün"
+	},
+	"toggleAutoplay": {
+		"message": "Otomatik oynatmayı aç/kapat"
+	},
+	"toggleCards": {
+		"message": "Kartları aç/kapat"
+	},
+	"toggleControls": {
+		"message": "Kontrolleri aç/kapat"
+	},
+	"topChat": {
+		"message": "En İyi Sohbet Mesajları"
+	},
+	"trackWatchedVideos": {
+		"message": "İzlenen videoları takip edin"
+	},
+	"trailerAutoplay": {
+		"message": "Fragman otomatik oynatımı"
+	},
+	"translations": {
+		"message": "Çeviriler"
+	},
+	"transparentBackground": {
+		"message": "Saydam arka plan"
+	},
+	"trending": {
+		"message": "Trendler"
+	},
+	"tryToReloadThePage": {
+		"message": "Sayfayı yeniden yüklemeyi deneyin"
+	},
+	"type": {
+		"message": "Tip"
+	},
+	"upNextAutoplay": {
+		"message": "Sonraki otomatik oynatma"
+	},
+	"use24HourFormat": {
+		"message": "24 saat biçimini kullan"
+	},
+	"version": {
+		"message": "Sürüm"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Kategorinin adını almak için video açıklaması genişletilecek"
+	},
+	"videoFormats": {
+		"message": "Video formatları"
+	},
+	"videos": {
+		"message": "Videolar"
+	},
+	"viewMode": {
+		"message": "Görünüm Modu"
+	},
+	"volume": {
+		"message": "Ses"
+	},
+	"watchedVideos": {
+		"message": "İzlenen videolar"
+	},
+	"watchLater": {
+		"message": "Sonra izle"
+	},
+	"watchTime": {
+		"message": "İzleme zamanı"
+	},
+	"whenPaused": {
+		"message": "Duraklatıldığında"
+	},
+	"whenTabIsChanged": {
+		"message": "Sekme değiştirildiğinde"
+	},
+	"white": {
+		"message": "Beyaz"
+	},
+	"windowColor": {
+		"message": "Pencere rengi"
+	},
+	"windowOpacity": {
+		"message": "Pencere opaklığı"
+	},
+	"yellow": {
+		"message": "Sarı"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube Header (sol)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube Header (sağ)"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube ana sayfası"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube dili"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube, h.264 codec bileşeni için video kalitesini 1080p ile sınırlar"
+	}
 }

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -1,17 +1,17 @@
 {
-    "analyzer": {
-        "message": "Analyser"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Ви впевнені, що хочете імпортувати ці дані?"
-    },
-    "hideHomePageShorts": {
-        "message": "Видалити Shorts з головної сторінки"
-    },
-    "qualityWithoutFocus": {
-        "message": "Якість при неактивному вікні"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Видаліть карусель Shorts з результатів пошуку"
-    }
+	"analyzer": {
+		"message": "Analyser"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Ви впевнені, що хочете імпортувати ці дані?"
+	},
+	"hideHomePageShorts": {
+		"message": "Видалити Shorts з головної сторінки"
+	},
+	"qualityWithoutFocus": {
+		"message": "Якість при неактивному вікні"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Видаліть карусель Shorts з результатів пошуку"
+	}
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1,1028 +1,1028 @@
 {
-    "about": {
-        "message": "Về"
-    },
-    "accept": {
-        "message": "Chấp nhận"
-    },
-    "activate": {
-        "message": "Kích hoạt"
-    },
-    "activateCaptions": {
-        "message": "Kích hoạt phụ đề"
-    },
-    "activated": {
-        "message": "Đã kích hoạt"
-    },
-    "activatedFeatures": {
-        "message": "Các tính năng đã được kích hoạt"
-    },
-    "activateFullscreen": {
-        "message": "Kích hoạt toàn màn hình"
-    },
-    "activeFeatures": {
-        "message": "Các tính năng hoạt động"
-    },
-    "addScrollToTop": {
-        "message": "Thêm «Cuộn lên đầu»"
-    },
-    "ads": {
-        "message": "Quảng cáo"
-    },
-    "all": {
-        "message": "Tất cả"
-    },
-    "allow": {
-        "message": "Cho phép"
-    },
-    "always": {
-        "message": "Luôn luôn"
-    },
-    "alwaysActive": {
-        "message": "Luôn luôn hoạt động"
-    },
-    "alwaysShowProgressBar": {
-        "message": "Luôn hiển thị thanh tiến trình"
-    },
-    "amber": {
-        "message": "Hổ phách"
-    },
-    "analyzer": {
-        "message": "Bộ phân tích"
-    },
-    "animations": {
-        "message": "Hoạt ảnh"
-    },
-    "appearance": {
-        "message": "Diện mạo"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "Bạn có chắc chắn muốn xuất dữ liệu không?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "Bạn có chắc chắn muốn nhập dữ liệu không?"
-    },
-    "audio": {
-        "message": "Âm thanh"
-    },
-    "audioFormats": {
-        "message": "Định dạng âm thanh"
-    },
-    "auto": {
-        "message": "Tự động"
-    },
-    "autoFullscreen": {
-        "message": "Tự động toàn màn hình"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "Tự động dừng khi chuyển đổi tab"
-    },
-    "autoplay": {
-        "message": "Tự động phát"
-    },
-    "avoidAv1": {
-        "message": "Tránh AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "Tránh AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "Tránh AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "Tránh kết xuất bằng CPU khi có thể"
-    },
-    "backgroundColor": {
-        "message": "Màu nền"
-    },
-    "backgroundOpacity": {
-        "message": "Độ mờ của nền"
-    },
-    "backupAndReset": {
-        "message": "Sao lưu & thiết lập lại"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "Dựa trên bảng màu hệ thống"
-    },
-    "belowPlayer": {
-        "message": "Bên dưới trình phát"
-    },
-    "black": {
-        "message": "Đen"
-    },
-    "blockAll": {
-        "message": "Chặn tất cả"
-    },
-    "blockAv1": {
-        "message": "Chặn AV1"
-    },
-    "blockH264": {
-        "message": "Chặn H.264"
-    },
-    "blocklist": {
-        "message": "Danh sách đen"
-    },
-    "blockMusic": {
-        "message": "Chặn âm nhạc"
-    },
-    "blockVp8": {
-        "message": "Chặn VP8"
-    },
-    "blockVp9": {
-        "message": "Chặn VP9"
-    },
-    "blue": {
-        "message": "Xanh dương"
-    },
-    "blueGray": {
-        "message": "Xám xanh"
-    },
-    "bluelight": {
-        "message": "Sáng xanh"
-    },
-    "brown": {
-        "message": "Nâu"
-    },
-    "browser": {
-        "message": "Trình duyệt"
-    },
-    "browserVersion": {
-        "message": "Phiên bản trình duyệt"
-    },
-    "bubbles": {
-        "message": "Bong bóng"
-    },
-    "buttons": {
-        "message": "Nút"
-    },
-    "cancel": {
-        "message": "Huỷ bỏ"
-    },
-    "categories": {
-        "message": "Thể loại"
-    },
-    "channel": {
-        "message": "Kênh"
-    },
-    "channels": {
-        "message": "Kênh"
-    },
-    "characterEdgeStyle": {
-        "message": "Kiểu cạnh ký tự"
-    },
-    "clipboard": {
-        "message": "Bảng tạm"
-    },
-    "collapsed": {
-        "message": "Đã thu gọn"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "Thu gọn các phần đăng ký"
-    },
-    "comments": {
-        "message": "Bình luận"
-    },
-    "confirmationBeforeClosing": {
-        "message": "Xác nhận trước khi đóng cửa"
-    },
-    "cropChapterTitles": {
-        "message": "Cắt tiêu đề chương"
-    },
-    "custom": {
-        "message": "Tuỳ chỉnh"
-    },
-    "customCss": {
-        "message": "Mã CSS tuỳ chỉnh"
-    },
-    "customJs": {
-        "message": "Mã JS tuỳ chỉnh"
-    },
-    "customMiniPlayer": {
-        "message": "Trình phát Mini tuỳ chỉnh"
-    },
-    "cyan": {
-        "message": "Xanh lơ"
-    },
-    "dark": {
-        "message": "Tối"
-    },
-    "darkTheme": {
-        "message": "Chủ đề tối"
-    },
-    "dateAndTime": {
-        "message": "Ngày & giờ"
-    },
-    "dawn": {
-        "message": "Bình minh"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "Giảm tốc độ phát lại"
-    },
-    "decreaseVolume": {
-        "message": "Giảm âm lượng"
-    },
-    "deepOrange": {
-        "message": "Cam đậm"
-    },
-    "deepPurple": {
-        "message": "Tím đậm"
-    },
-    "default": {
-        "message": "Mặc định"
-    },
-    "defaultChannelTab": {
-        "message": "Tab kênh mặc định"
-    },
-    "defaultContentCountry": {
-        "message": "Quốc gia nội dung mặc định"
-    },
-    "deleteWatchedVideos": {
-        "message": "Xóa video đã xem"
-    },
-    "deleteYoutubeCookies": {
-        "message": "Xóa cookie của YouTube"
-    },
-    "depressed": {
-        "message": "Ẩn xuống"
-    },
-    "description": {
-        "message": "Mô tả"
-    },
-    "description_ext": {
-        "message": "Làm cho YouTube gọn gàng+thông minh! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
-    },
-    "desert": {
-        "message": "Sa mạc"
-    },
-    "details": {
-        "message": "Chi tiết"
-    },
-    "developerOptions": {
-        "message": "Tùy chọn nhà phát triển"
-    },
-    "device": {
-        "message": "Thiết bị"
-    },
-    "dim": {
-        "message": "Mờ"
-    },
-    "disabled": {
-        "message": "Vô hiệu hóa"
-    },
-    "dislike": {
-        "message": "Không thích"
-    },
-    "displayDayOfTheWeak": {
-        "message": "Hiển thị ngày trong tuần"
-    },
-    "doNotChange": {
-        "message": "Đừng thay đổi"
-    },
-    "download": {
-        "message": "Tải xuống"
-    },
-    "draggable": {
-        "message": "Có thể kéo"
-    },
-    "dropShadow": {
-        "message": "Bóng đổ"
-    },
-    "durationWithSpeed": {
-        "message": "Hiển thị thời gian còn lại tương đương với tốc độ phát hiện tại"
-    },
-    "empty": {
-        "message": "Trống"
-    },
-    "enabled": {
-        "message": "Đã bật"
-    },
-    "enabledForced": {
-        "message": "Đã bật (bắt buộc)"
-    },
-    "expanded": {
-        "message": "Đã mở rộng"
-    },
-    "exportSettings": {
-        "message": "Xuất cài đặt"
-    },
-    "extension": {
-        "message": "Phần mở rộng"
-    },
-    "file": {
-        "message": "Tập tin"
-    },
-    "filters": {
-        "message": "Bộ lọc"
-    },
-    "fitToWindow": {
-        "message": "Vừa với cửa sổ"
-    },
-    "font": {
-        "message": "Phông chữ"
-    },
-    "fontColor": {
-        "message": "Màu phông chữ"
-    },
-    "fontFamily": {
-        "message": "Họ phông chữ"
-    },
-    "fontOpacity": {
-        "message": "Độ mờ phông chữ"
-    },
-    "fontSize": {
-        "message": "Cỡ phông chữ"
-    },
-    "footer": {
-        "message": "Chân trang"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "Buộc tốc độ phát"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "Buộc tốc độ phát cho âm nhạc"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "Buộc phát video từ đầu"
-    },
-    "forcedTheaterMode": {
-        "message": "Buộc chế độ rạp hát"
-    },
-    "forcedVolume": {
-        "message": "Buộc mức âm lượng"
-    },
-    "forceSDR": {
-        "message": "Bắt buộc SDR"
-    },
-    "foundABug": {
-        "message": "Tìm thấy lỗi (bug)?"
-    },
-    "fullWindow": {
-        "message": "Toàn cửa sổ"
-    },
-    "general": {
-        "message": "Chung"
-    },
-    "geoPreference": {
-        "message": "Vị trí ưa thích"
-    },
-    "googleApiKey": {
-        "message": "Key API Google"
-    },
-    "goToSearchBox": {
-        "message": "Đi tới hộp tìm kiếm"
-    },
-    "green": {
-        "message": "Xanh lá cây"
-    },
-    "hardwareInformation": {
-        "message": "Thông tin phần cứng"
-    },
-    "hdThumbnail": {
-        "message": "Hình thu nhỏ HD"
-    },
-    "header": {
-        "message": "Phần đầu"
-    },
-    "hidden": {
-        "message": "Ẩn"
-    },
-    "hiddenOnVideoPage": {
-        "message": "Ẩn trên trang video"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "Ẩn hình thu nhỏ động"
-    },
-    "hideAnnotations": {
-        "message": "Ẩn chú thích"
-    },
-    "hideCards": {
-        "message": "Ẩn thẻ"
-    },
-    "hideCategories": {
-        "message": "Ẩn mục"
-    },
-    "hideCommentsCount": {
-        "message": "Ẩn số lượng bình luận"
-    },
-    "hideCountryCode": {
-        "message": "Ẩn mã quốc gia"
-    },
-    "hideDate": {
-        "message": "Ẩn ngày"
-    },
-    "hideDetailButton": {
-        "message": "Ẩn nút chi tiết"
-    },
-    "hideDetails": {
-        "message": "Ẩn chi tiết"
-    },
-    "hideEndscreen": {
-        "message": "Ẩn màn hình kết thúc"
-    },
-    "hideFeaturedContent": {
-        "message": "Ẩn nội dung nổi bật"
-    },
-    "hideFooter": {
-        "message": "Ẩn chân trang"
-    },
-    "hideGradientBottom": {
-        "message": "Ẩn bóng xung quanh thanh trình phát"
-    },
-    "hideHomePageShorts": {
-        "message": "Xóa Shorts trên trang chủ"
-    },
-    "hidePlayerControlsBar": {
-        "message": "Ẩn thanh điều khiển trình phát"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "Ẩn các nút trên thanh điều khiển trình phát"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "Ẩn các tùy chọn điều khiển trình phát"
-    },
-    "hidePlaylist": {
-        "message": "Ẩn danh sách phát"
-    },
-    "hideRightButtons": {
-        "message": "Ẩn các nút bên phải"
-    },
-    "hideScrollForDetails": {
-        "message": "Ẩn «Cuộn để biết chi tiết»"
-    },
-    "hideSkipOverlay": {
-        "message": "Ẩn hoạt ảnh bỏ qua 5 giây"
-    },
-    "hideThumbnailOverlay": {
-        "message": "Ẩn các nút trên hình thu nhỏ"
-    },
-    "hideThumbnails": {
-        "message": "Ẩn hình thu nhỏ"
-    },
-    "hideViewsCount": {
-        "message": "Ẩn số lượt xem"
-    },
-    "hideVoiceSearchButton": {
-        "message": "Ẩn nút tìm kiếm bằng giọng nói"
-    },
-    "high": {
-        "message": "Cao"
-    },
-    "history": {
-        "message": "Lịch sử"
-    },
-    "home": {
-        "message": "Nhà"
-    },
-    "hover": {
-        "message": "Di chuyển"
-    },
-    "hoverOnVideoPage": {
-        "message": "Di chuyển trên trang video"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "Video đã được tải lên cách đây bao lâu"
-    },
-    "icons": {
-        "message": "Biểu tượng"
-    },
-    "iconsOnly": {
-        "message": "Chỉ các biểu tượng"
-    },
-    "importSettings": {
-        "message": "Nhập cài đặt"
-    },
-    "improvedtubeButtons": {
-        "message": "Nút ImprovedTube"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "Biểu tượng ImprovedTube trên YouTube"
-    },
-    "improvedtubeLanguage": {
-        "message": "Ngôn ngữ của ImprovedTube"
-    },
-    "improvedtubeVersion": {
-        "message": "Phiên bản ImprovedTube"
-    },
-    "improveLogo": {
-        "message": "Logo đã sửa"
-    },
-    "increasePlaybackSpeed": {
-        "message": "Tăng tốc độ phát"
-    },
-    "increaseVolume": {
-        "message": "Tăng âm lượng"
-    },
-    "indigo": {
-        "message": "Chàm"
-    },
-    "language": {
-        "message": "Ngôn ngữ"
-    },
-    "languages": {
-        "message": "Ngôn ngữ"
-    },
-    "layerAnimationScale": {
-        "message": "Tỉ lệ lớp hoạt ảnh"
-    },
-    "library": {
-        "message": "Thư viện"
-    },
-    "light": {
-        "message": "Sáng"
-    },
-    "lightBlue": {
-        "message": "Xanh lam nhạt"
-    },
-    "lightGreen": {
-        "message": "Xanh lục nhạt"
-    },
-    "like": {
-        "message": "Thích"
-    },
-    "liked": {
-        "message": "Đã thích"
-    },
-    "likes": {
-        "message": "Thích"
-    },
-    "lime": {
-        "message": "Chanh"
-    },
-    "limitPageWidth": {
-        "message": "Giới hạn chiều rộng trang"
-    },
-    "list": {
-        "message": "Danh sách"
-    },
-    "liveChat": {
-        "message": "Trò chuyện trực tiếp"
-    },
-    "liveChatType": {
-        "message": "Loại trò chuyện trực tiếp"
-    },
-    "location": {
-        "message": "Địa điểm"
-    },
-    "loop": {
-        "message": "Vòng lặp"
-    },
-    "loudnessNormalization": {
-        "message": "Chuẩn hóa độ ồn"
-    },
-    "low": {
-        "message": "Thấp"
-    },
-    "markWatchedVideos": {
-        "message": "Đánh dấu video đã xem"
-    },
-    "medium": {
-        "message": "Trung bình"
-    },
-    "more": {
-        "message": "Thêm nữa"
-    },
-    "mostViewedChannels": {
-        "message": "Kênh được xem nhiều nhất"
-    },
-    "moveSidebarLeft": {
-        "message": "Di chuyển thanh bên sang trái"
-    },
-    "moveThumbnailsRight": {
-        "message": "Di chuyển hình thu nhỏ sang phải"
-    },
-    "myColors": {
-        "message": "Màu sắc của tôi"
-    },
-    "name": {
-        "message": "Tên"
-    },
-    "nativeMiniPlayer": {
-        "message": "Trình phát mini gốc"
-    },
-    "new": {
-        "message": "Mới"
-    },
-    "nextVideo": {
-        "message": "Video tiếp theo"
-    },
-    "night": {
-        "message": "Đêm"
-    },
-    "nightMode": {
-        "message": "Chế độ tối"
-    },
-    "noActiveFeatures": {
-        "message": "Không có tính năng hoạt động"
-    },
-    "none": {
-        "message": "Không có"
-    },
-    "noOpenVideoTabs": {
-        "message": "Không có tab video đang mở"
-    },
-    "normal": {
-        "message": "Bình thường"
-    },
-    "off": {
-        "message": "Tắt"
-    },
-    "old": {
-        "message": "Cũ"
-    },
-    "onAllVideos": {
-        "message": "Trên tất cả các video"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "Chỉ hoạt động trên YouTube"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "Chỉ một tab phát video"
-    },
-    "onSubscribedChannels": {
-        "message": "Trên các kênh đã đăng ký"
-    },
-    "openPopupPlayer": {
-        "message": "Mở video/danh sách phát trong một cửa sổ mới"
-    },
-    "orange": {
-        "message": "Cam"
-    },
-    "other": {
-        "message": "Khác"
-    },
-    "outline": {
-        "message": "Đường viền"
-    },
-    "overlay": {
-        "message": "Lớp phủ"
-    },
-    "permissions": {
-        "message": "Quyền"
-    },
-    "pictureInPicture": {
-        "message": "Ảnh trong ảnh"
-    },
-    "pink": {
-        "message": "Hồng"
-    },
-    "plain": {
-        "message": "Đơn giản"
-    },
-    "platform": {
-        "message": "Nền tảng"
-    },
-    "playAllButton": {
-        "message": "Nút \"Phát tất cả\""
-    },
-    "playbackSpeed": {
-        "message": "Tốc độ phát lại"
-    },
-    "player": {
-        "message": "Trình phát"
-    },
-    "playerColor": {
-        "message": "Màu trình phát"
-    },
-    "playerSize": {
-        "message": "Kích thước trình phát"
-    },
-    "playlist": {
-        "message": "Danh sách phát"
-    },
-    "playlists": {
-        "message": "Danh sách phát"
-    },
-    "playPause": {
-        "message": "Phát / Tạm dừng"
-    },
-    "popupPlayer": {
-        "message": "Trình phát nổi"
-    },
-    "popupWindowButtons": {
-        "message": "Nút cửa sổ nổi"
-    },
-    "position": {
-        "message": "Vị trí"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "Nhấn phím bất kỳ hoặc sử dụng lăn chuột."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "Nhấn phím bất kỳ hoặc sử dụng lăn chuột"
-    },
-    "previousVideo": {
-        "message": "Video trước"
-    },
-    "primaryColor": {
-        "message": "Màu chính"
-    },
-    "purple": {
-        "message": "Tím"
-    },
-    "quality": {
-        "message": "Chất lượng"
-    },
-    "raised": {
-        "message": "Nâng lên"
-    },
-    "rateMe": {
-        "message": "Đánh giá tôi"
-    },
-    "rateUs": {
-        "message": "Đánh giá chúng tôi"
-    },
-    "red": {
-        "message": "Đỏ"
-    },
-    "redDislikeButton": {
-        "message": "Nút không thích màu đỏ"
-    },
-    "relatedVideos": {
-        "message": "Các video liên quan"
-    },
-    "remote": {
-        "message": "Phát trên TV"
-    },
-    "removeRelatedSearchResults": {
-        "message": "Xóa kết quả tìm kiếm có liên quan"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "Xóa vòng lặp Shorts khỏi kết quả tìm kiếm"
-    },
-    "repeat": {
-        "message": "Lặp lại"
-    },
-    "report": {
-        "message": "Báo cáo"
-    },
-    "reset": {
-        "message": "Đặt lại"
-    },
-    "resetAllSettings": {
-        "message": "Đặt lại tất cả các thiết lập"
-    },
-    "resetAllShortcuts": {
-        "message": "Đặt lại tất cả các phím tắt"
-    },
-    "reverse": {
-        "message": "Đảo ngược"
-    },
-    "rotate": {
-        "message": "Quay"
-    },
-    "save": {
-        "message": "Lưu"
-    },
-    "saveAs": {
-        "message": "Lưu thành"
-    },
-    "schedule": {
-        "message": "Lịch trình"
-    },
-    "screen": {
-        "message": "Màn hình"
-    },
-    "screenshot": {
-        "message": "Ảnh chụp màn hình"
-    },
-    "scrollBar": {
-        "message": "Thanh cuộn"
-    },
-    "search": {
-        "message": "Tìm kiếm"
-    },
-    "searchBarOnly": {
-        "message": "Chỉ thanh tìm kiếm"
-    },
-    "seekBackward10Seconds": {
-        "message": "Tua lùi 10 giây"
-    },
-    "seekForward10Seconds": {
-        "message": "Tua tiến 10 giây"
-    },
-    "seekNextChapter": {
-        "message": "Tìm chương tiếp theo"
-    },
-    "seekPreviousChapter": {
-        "message": "Tìm kiếm chương trước"
-    },
-    "settings": {
-        "message": "Cài đặt"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "Đã nhập thành công cài đặt"
-    },
-    "share": {
-        "message": "Chia sẻ"
-    },
-    "shortcuts": {
-        "message": "Phím tắt"
-    },
-    "showCardsOnMouseHover": {
-        "message": "Hiển thị thẻ khi di chuột"
-    },
-    "showChannelVideosCount": {
-        "message": "Hiển thị số lượng video trên kênh"
-    },
-    "showLess": {
-        "message": "Hiện ít hơn"
-    },
-    "showMore": {
-        "message": "Hiện nhiều hơn"
-    },
-    "showRemainingDuration": {
-        "message": "Hiển thị thời lượng còn lại của video"
-    },
-    "showVersion": {
-        "message": "Hiển thị phiên bản"
-    },
-    "shuffle": {
-        "message": "Trộn"
-    },
-    "sidebar": {
-        "message": "Thanh bên"
-    },
-    "softwareInformation": {
-        "message": "Thông tin phần mềm"
-    },
-    "spacebar": {
-        "message": "Phím cách"
-    },
-    "squaredUserImages": {
-        "message": "Ảnh người dùng hình vuông"
-    },
-    "static": {
-        "message": "Tĩnh"
-    },
-    "statsForNerds": {
-        "message": "Hiển thị số liệu thống kê"
-    },
-    "step": {
-        "message": "Bước"
-    },
-    "stop": {
-        "message": "Dừng"
-    },
-    "style": {
-        "message": "Phong cách"
-    },
-    "styles": {
-        "message": "Phong cách"
-    },
-    "subscribe": {
-        "message": "Đăng ký"
-    },
-    "subscriptions": {
-        "message": "Đăng ký"
-    },
-    "subtitles": {
-        "message": "Phụ đề"
-    },
-    "sunset": {
-        "message": "Hoàng hôn"
-    },
-    "sunsetToSunrise": {
-        "message": "Hoàng hôn đến bình minh"
-    },
-    "systemPeferenceDark": {
-        "message": "Tùy chọn hệ thống: tối"
-    },
-    "systemPeferenceLight": {
-        "message": "Tùy chọn hệ thống: sáng"
-    },
-    "teal": {
-        "message": "Xanh mòng két"
-    },
-    "textColor": {
-        "message": "Màu văn bản"
-    },
-    "thanks": {
-        "message": "Cảm ơn"
-    },
-    "themes": {
-        "message": "Chủ đề"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "Điều này sẽ xóa tất cả cookie."
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "Thao tác này sẽ xóa tất cả video đã xem."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "Thao tác này sẽ xóa tất cả cookie của YouTube"
-    },
-    "thisWillResetAllSettings": {
-        "message": "Điều này sẽ đặt lại tất cả cài đặt."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "Thao tác này sẽ đặt lại tất cả phím tắt"
-    },
-    "thumbnails": {
-        "message": "Hình thu nhỏ"
-    },
-    "thumbnailsQuality": {
-        "message": "Chất lượng hình thu nhỏ"
-    },
-    "timeFrom": {
-        "message": "Thời gian từ"
-    },
-    "timeTo": {
-        "message": "Thời gian đến"
-    },
-    "todayAt": {
-        "message": "Hôm nay lúc"
-    },
-    "toggleAutoplay": {
-        "message": "Chuyển đổi tự động phát"
-    },
-    "toggleCards": {
-        "message": "Chuyển đổi thẻ"
-    },
-    "toggleControls": {
-        "message": "Chuyển đổi điều khiển trình phát"
-    },
-    "topChat": {
-        "message": "Trò chuyện hàng đầu"
-    },
-    "trackWatchedVideos": {
-        "message": "Theo dõi các video đã xem"
-    },
-    "trailerAutoplay": {
-        "message": "Tự động phát đoạn giới thiệu"
-    },
-    "translations": {
-        "message": "Bản dịch"
-    },
-    "transparentBackground": {
-        "message": "Nền trong suốt"
-    },
-    "trending": {
-        "message": "Xu hướng"
-    },
-    "tryToReloadThePage": {
-        "message": "Cố gắng tải lại trang"
-    },
-    "type": {
-        "message": "Gõ phím"
-    },
-    "upNextAutoplay": {
-        "message": "Tự động phát tiếp theo"
-    },
-    "use24HourFormat": {
-        "message": "Sử dụng định dạng 24 giờ"
-    },
-    "version": {
-        "message": "Phiên bản"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "Mô tả video sẽ được mở rộng để lấy tên của danh mục"
-    },
-    "videoFormats": {
-        "message": "Định dạng video"
-    },
-    "viewMode": {
-        "message": "Chế độ xem"
-    },
-    "volume": {
-        "message": "Âm lượng"
-    },
-    "watchLater": {
-        "message": "Xem sau"
-    },
-    "watchTime": {
-        "message": "Thời gian xem"
-    },
-    "whenPaused": {
-        "message": "Khi tạm dừng"
-    },
-    "whenTabIsChanged": {
-        "message": "Khi thay đổi tab"
-    },
-    "white": {
-        "message": "Trắng"
-    },
-    "windowColor": {
-        "message": "Màu cửa sổ"
-    },
-    "windowOpacity": {
-        "message": "Độ mờ cửa sổ"
-    },
-    "yellow": {
-        "message": "Vàng"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Tiêu đề YouTube (bên trái)"
-    },
-    "youtubeHeaderRight": {
-        "message": "Tiêu đề YouTube (bên phải)"
-    },
-    "youtubeHomePage": {
-        "message": "Trang chủ YouTube"
-    },
-    "youtubeLanguage": {
-        "message": "Ngôn ngữ YouTube"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "YouTube giới hạn chất lượng video 1080p cho h.264 codec"
-    }
+	"about": {
+		"message": "Về"
+	},
+	"accept": {
+		"message": "Chấp nhận"
+	},
+	"activate": {
+		"message": "Kích hoạt"
+	},
+	"activateCaptions": {
+		"message": "Kích hoạt phụ đề"
+	},
+	"activated": {
+		"message": "Đã kích hoạt"
+	},
+	"activatedFeatures": {
+		"message": "Các tính năng đã được kích hoạt"
+	},
+	"activateFullscreen": {
+		"message": "Kích hoạt toàn màn hình"
+	},
+	"activeFeatures": {
+		"message": "Các tính năng hoạt động"
+	},
+	"addScrollToTop": {
+		"message": "Thêm «Cuộn lên đầu»"
+	},
+	"ads": {
+		"message": "Quảng cáo"
+	},
+	"all": {
+		"message": "Tất cả"
+	},
+	"allow": {
+		"message": "Cho phép"
+	},
+	"always": {
+		"message": "Luôn luôn"
+	},
+	"alwaysActive": {
+		"message": "Luôn luôn hoạt động"
+	},
+	"alwaysShowProgressBar": {
+		"message": "Luôn hiển thị thanh tiến trình"
+	},
+	"amber": {
+		"message": "Hổ phách"
+	},
+	"analyzer": {
+		"message": "Bộ phân tích"
+	},
+	"animations": {
+		"message": "Hoạt ảnh"
+	},
+	"appearance": {
+		"message": "Diện mạo"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "Bạn có chắc chắn muốn xuất dữ liệu không?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "Bạn có chắc chắn muốn nhập dữ liệu không?"
+	},
+	"audio": {
+		"message": "Âm thanh"
+	},
+	"audioFormats": {
+		"message": "Định dạng âm thanh"
+	},
+	"auto": {
+		"message": "Tự động"
+	},
+	"autoFullscreen": {
+		"message": "Tự động toàn màn hình"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "Tự động dừng khi chuyển đổi tab"
+	},
+	"autoplay": {
+		"message": "Tự động phát"
+	},
+	"avoidAv1": {
+		"message": "Tránh AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "Tránh AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "Tránh AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "Tránh kết xuất bằng CPU khi có thể"
+	},
+	"backgroundColor": {
+		"message": "Màu nền"
+	},
+	"backgroundOpacity": {
+		"message": "Độ mờ của nền"
+	},
+	"backupAndReset": {
+		"message": "Sao lưu & thiết lập lại"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "Dựa trên bảng màu hệ thống"
+	},
+	"belowPlayer": {
+		"message": "Bên dưới trình phát"
+	},
+	"black": {
+		"message": "Đen"
+	},
+	"blockAll": {
+		"message": "Chặn tất cả"
+	},
+	"blockAv1": {
+		"message": "Chặn AV1"
+	},
+	"blockH264": {
+		"message": "Chặn H.264"
+	},
+	"blocklist": {
+		"message": "Danh sách đen"
+	},
+	"blockMusic": {
+		"message": "Chặn âm nhạc"
+	},
+	"blockVp8": {
+		"message": "Chặn VP8"
+	},
+	"blockVp9": {
+		"message": "Chặn VP9"
+	},
+	"blue": {
+		"message": "Xanh dương"
+	},
+	"blueGray": {
+		"message": "Xám xanh"
+	},
+	"bluelight": {
+		"message": "Sáng xanh"
+	},
+	"brown": {
+		"message": "Nâu"
+	},
+	"browser": {
+		"message": "Trình duyệt"
+	},
+	"browserVersion": {
+		"message": "Phiên bản trình duyệt"
+	},
+	"bubbles": {
+		"message": "Bong bóng"
+	},
+	"buttons": {
+		"message": "Nút"
+	},
+	"cancel": {
+		"message": "Huỷ bỏ"
+	},
+	"categories": {
+		"message": "Thể loại"
+	},
+	"channel": {
+		"message": "Kênh"
+	},
+	"channels": {
+		"message": "Kênh"
+	},
+	"characterEdgeStyle": {
+		"message": "Kiểu cạnh ký tự"
+	},
+	"clipboard": {
+		"message": "Bảng tạm"
+	},
+	"collapsed": {
+		"message": "Đã thu gọn"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "Thu gọn các phần đăng ký"
+	},
+	"comments": {
+		"message": "Bình luận"
+	},
+	"confirmationBeforeClosing": {
+		"message": "Xác nhận trước khi đóng cửa"
+	},
+	"cropChapterTitles": {
+		"message": "Cắt tiêu đề chương"
+	},
+	"custom": {
+		"message": "Tuỳ chỉnh"
+	},
+	"customCss": {
+		"message": "Mã CSS tuỳ chỉnh"
+	},
+	"customJs": {
+		"message": "Mã JS tuỳ chỉnh"
+	},
+	"customMiniPlayer": {
+		"message": "Trình phát Mini tuỳ chỉnh"
+	},
+	"cyan": {
+		"message": "Xanh lơ"
+	},
+	"dark": {
+		"message": "Tối"
+	},
+	"darkTheme": {
+		"message": "Chủ đề tối"
+	},
+	"dateAndTime": {
+		"message": "Ngày & giờ"
+	},
+	"dawn": {
+		"message": "Bình minh"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "Giảm tốc độ phát lại"
+	},
+	"decreaseVolume": {
+		"message": "Giảm âm lượng"
+	},
+	"deepOrange": {
+		"message": "Cam đậm"
+	},
+	"deepPurple": {
+		"message": "Tím đậm"
+	},
+	"default": {
+		"message": "Mặc định"
+	},
+	"defaultChannelTab": {
+		"message": "Tab kênh mặc định"
+	},
+	"defaultContentCountry": {
+		"message": "Quốc gia nội dung mặc định"
+	},
+	"deleteWatchedVideos": {
+		"message": "Xóa video đã xem"
+	},
+	"deleteYoutubeCookies": {
+		"message": "Xóa cookie của YouTube"
+	},
+	"depressed": {
+		"message": "Ẩn xuống"
+	},
+	"description": {
+		"message": "Mô tả"
+	},
+	"description_ext": {
+		"message": "Làm cho YouTube gọn gàng+thông minh! YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+	},
+	"desert": {
+		"message": "Sa mạc"
+	},
+	"details": {
+		"message": "Chi tiết"
+	},
+	"developerOptions": {
+		"message": "Tùy chọn nhà phát triển"
+	},
+	"device": {
+		"message": "Thiết bị"
+	},
+	"dim": {
+		"message": "Mờ"
+	},
+	"disabled": {
+		"message": "Vô hiệu hóa"
+	},
+	"dislike": {
+		"message": "Không thích"
+	},
+	"displayDayOfTheWeak": {
+		"message": "Hiển thị ngày trong tuần"
+	},
+	"doNotChange": {
+		"message": "Đừng thay đổi"
+	},
+	"download": {
+		"message": "Tải xuống"
+	},
+	"draggable": {
+		"message": "Có thể kéo"
+	},
+	"dropShadow": {
+		"message": "Bóng đổ"
+	},
+	"durationWithSpeed": {
+		"message": "Hiển thị thời gian còn lại tương đương với tốc độ phát hiện tại"
+	},
+	"empty": {
+		"message": "Trống"
+	},
+	"enabled": {
+		"message": "Đã bật"
+	},
+	"enabledForced": {
+		"message": "Đã bật (bắt buộc)"
+	},
+	"expanded": {
+		"message": "Đã mở rộng"
+	},
+	"exportSettings": {
+		"message": "Xuất cài đặt"
+	},
+	"extension": {
+		"message": "Phần mở rộng"
+	},
+	"file": {
+		"message": "Tập tin"
+	},
+	"filters": {
+		"message": "Bộ lọc"
+	},
+	"fitToWindow": {
+		"message": "Vừa với cửa sổ"
+	},
+	"font": {
+		"message": "Phông chữ"
+	},
+	"fontColor": {
+		"message": "Màu phông chữ"
+	},
+	"fontFamily": {
+		"message": "Họ phông chữ"
+	},
+	"fontOpacity": {
+		"message": "Độ mờ phông chữ"
+	},
+	"fontSize": {
+		"message": "Cỡ phông chữ"
+	},
+	"footer": {
+		"message": "Chân trang"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "Buộc tốc độ phát"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "Buộc tốc độ phát cho âm nhạc"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "Buộc phát video từ đầu"
+	},
+	"forcedTheaterMode": {
+		"message": "Buộc chế độ rạp hát"
+	},
+	"forcedVolume": {
+		"message": "Buộc mức âm lượng"
+	},
+	"forceSDR": {
+		"message": "Bắt buộc SDR"
+	},
+	"foundABug": {
+		"message": "Tìm thấy lỗi (bug)?"
+	},
+	"fullWindow": {
+		"message": "Toàn cửa sổ"
+	},
+	"general": {
+		"message": "Chung"
+	},
+	"geoPreference": {
+		"message": "Vị trí ưa thích"
+	},
+	"googleApiKey": {
+		"message": "Key API Google"
+	},
+	"goToSearchBox": {
+		"message": "Đi tới hộp tìm kiếm"
+	},
+	"green": {
+		"message": "Xanh lá cây"
+	},
+	"hardwareInformation": {
+		"message": "Thông tin phần cứng"
+	},
+	"hdThumbnail": {
+		"message": "Hình thu nhỏ HD"
+	},
+	"header": {
+		"message": "Phần đầu"
+	},
+	"hidden": {
+		"message": "Ẩn"
+	},
+	"hiddenOnVideoPage": {
+		"message": "Ẩn trên trang video"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "Ẩn hình thu nhỏ động"
+	},
+	"hideAnnotations": {
+		"message": "Ẩn chú thích"
+	},
+	"hideCards": {
+		"message": "Ẩn thẻ"
+	},
+	"hideCategories": {
+		"message": "Ẩn mục"
+	},
+	"hideCommentsCount": {
+		"message": "Ẩn số lượng bình luận"
+	},
+	"hideCountryCode": {
+		"message": "Ẩn mã quốc gia"
+	},
+	"hideDate": {
+		"message": "Ẩn ngày"
+	},
+	"hideDetailButton": {
+		"message": "Ẩn nút chi tiết"
+	},
+	"hideDetails": {
+		"message": "Ẩn chi tiết"
+	},
+	"hideEndscreen": {
+		"message": "Ẩn màn hình kết thúc"
+	},
+	"hideFeaturedContent": {
+		"message": "Ẩn nội dung nổi bật"
+	},
+	"hideFooter": {
+		"message": "Ẩn chân trang"
+	},
+	"hideGradientBottom": {
+		"message": "Ẩn bóng xung quanh thanh trình phát"
+	},
+	"hideHomePageShorts": {
+		"message": "Xóa Shorts trên trang chủ"
+	},
+	"hidePlayerControlsBar": {
+		"message": "Ẩn thanh điều khiển trình phát"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "Ẩn các nút trên thanh điều khiển trình phát"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "Ẩn các tùy chọn điều khiển trình phát"
+	},
+	"hidePlaylist": {
+		"message": "Ẩn danh sách phát"
+	},
+	"hideRightButtons": {
+		"message": "Ẩn các nút bên phải"
+	},
+	"hideScrollForDetails": {
+		"message": "Ẩn «Cuộn để biết chi tiết»"
+	},
+	"hideSkipOverlay": {
+		"message": "Ẩn hoạt ảnh bỏ qua 5 giây"
+	},
+	"hideThumbnailOverlay": {
+		"message": "Ẩn các nút trên hình thu nhỏ"
+	},
+	"hideThumbnails": {
+		"message": "Ẩn hình thu nhỏ"
+	},
+	"hideViewsCount": {
+		"message": "Ẩn số lượt xem"
+	},
+	"hideVoiceSearchButton": {
+		"message": "Ẩn nút tìm kiếm bằng giọng nói"
+	},
+	"high": {
+		"message": "Cao"
+	},
+	"history": {
+		"message": "Lịch sử"
+	},
+	"home": {
+		"message": "Nhà"
+	},
+	"hover": {
+		"message": "Di chuyển"
+	},
+	"hoverOnVideoPage": {
+		"message": "Di chuyển trên trang video"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "Video đã được tải lên cách đây bao lâu"
+	},
+	"icons": {
+		"message": "Biểu tượng"
+	},
+	"iconsOnly": {
+		"message": "Chỉ các biểu tượng"
+	},
+	"importSettings": {
+		"message": "Nhập cài đặt"
+	},
+	"improvedtubeButtons": {
+		"message": "Nút ImprovedTube"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "Biểu tượng ImprovedTube trên YouTube"
+	},
+	"improvedtubeLanguage": {
+		"message": "Ngôn ngữ của ImprovedTube"
+	},
+	"improvedtubeVersion": {
+		"message": "Phiên bản ImprovedTube"
+	},
+	"improveLogo": {
+		"message": "Logo đã sửa"
+	},
+	"increasePlaybackSpeed": {
+		"message": "Tăng tốc độ phát"
+	},
+	"increaseVolume": {
+		"message": "Tăng âm lượng"
+	},
+	"indigo": {
+		"message": "Chàm"
+	},
+	"language": {
+		"message": "Ngôn ngữ"
+	},
+	"languages": {
+		"message": "Ngôn ngữ"
+	},
+	"layerAnimationScale": {
+		"message": "Tỉ lệ lớp hoạt ảnh"
+	},
+	"library": {
+		"message": "Thư viện"
+	},
+	"light": {
+		"message": "Sáng"
+	},
+	"lightBlue": {
+		"message": "Xanh lam nhạt"
+	},
+	"lightGreen": {
+		"message": "Xanh lục nhạt"
+	},
+	"like": {
+		"message": "Thích"
+	},
+	"liked": {
+		"message": "Đã thích"
+	},
+	"likes": {
+		"message": "Thích"
+	},
+	"lime": {
+		"message": "Chanh"
+	},
+	"limitPageWidth": {
+		"message": "Giới hạn chiều rộng trang"
+	},
+	"list": {
+		"message": "Danh sách"
+	},
+	"liveChat": {
+		"message": "Trò chuyện trực tiếp"
+	},
+	"liveChatType": {
+		"message": "Loại trò chuyện trực tiếp"
+	},
+	"location": {
+		"message": "Địa điểm"
+	},
+	"loop": {
+		"message": "Vòng lặp"
+	},
+	"loudnessNormalization": {
+		"message": "Chuẩn hóa độ ồn"
+	},
+	"low": {
+		"message": "Thấp"
+	},
+	"markWatchedVideos": {
+		"message": "Đánh dấu video đã xem"
+	},
+	"medium": {
+		"message": "Trung bình"
+	},
+	"more": {
+		"message": "Thêm nữa"
+	},
+	"mostViewedChannels": {
+		"message": "Kênh được xem nhiều nhất"
+	},
+	"moveSidebarLeft": {
+		"message": "Di chuyển thanh bên sang trái"
+	},
+	"moveThumbnailsRight": {
+		"message": "Di chuyển hình thu nhỏ sang phải"
+	},
+	"myColors": {
+		"message": "Màu sắc của tôi"
+	},
+	"name": {
+		"message": "Tên"
+	},
+	"nativeMiniPlayer": {
+		"message": "Trình phát mini gốc"
+	},
+	"new": {
+		"message": "Mới"
+	},
+	"nextVideo": {
+		"message": "Video tiếp theo"
+	},
+	"night": {
+		"message": "Đêm"
+	},
+	"nightMode": {
+		"message": "Chế độ tối"
+	},
+	"noActiveFeatures": {
+		"message": "Không có tính năng hoạt động"
+	},
+	"none": {
+		"message": "Không có"
+	},
+	"noOpenVideoTabs": {
+		"message": "Không có tab video đang mở"
+	},
+	"normal": {
+		"message": "Bình thường"
+	},
+	"off": {
+		"message": "Tắt"
+	},
+	"old": {
+		"message": "Cũ"
+	},
+	"onAllVideos": {
+		"message": "Trên tất cả các video"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "Chỉ hoạt động trên YouTube"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "Chỉ một tab phát video"
+	},
+	"onSubscribedChannels": {
+		"message": "Trên các kênh đã đăng ký"
+	},
+	"openPopupPlayer": {
+		"message": "Mở video/danh sách phát trong một cửa sổ mới"
+	},
+	"orange": {
+		"message": "Cam"
+	},
+	"other": {
+		"message": "Khác"
+	},
+	"outline": {
+		"message": "Đường viền"
+	},
+	"overlay": {
+		"message": "Lớp phủ"
+	},
+	"permissions": {
+		"message": "Quyền"
+	},
+	"pictureInPicture": {
+		"message": "Ảnh trong ảnh"
+	},
+	"pink": {
+		"message": "Hồng"
+	},
+	"plain": {
+		"message": "Đơn giản"
+	},
+	"platform": {
+		"message": "Nền tảng"
+	},
+	"playAllButton": {
+		"message": "Nút \"Phát tất cả\""
+	},
+	"playbackSpeed": {
+		"message": "Tốc độ phát lại"
+	},
+	"player": {
+		"message": "Trình phát"
+	},
+	"playerColor": {
+		"message": "Màu trình phát"
+	},
+	"playerSize": {
+		"message": "Kích thước trình phát"
+	},
+	"playlist": {
+		"message": "Danh sách phát"
+	},
+	"playlists": {
+		"message": "Danh sách phát"
+	},
+	"playPause": {
+		"message": "Phát / Tạm dừng"
+	},
+	"popupPlayer": {
+		"message": "Trình phát nổi"
+	},
+	"popupWindowButtons": {
+		"message": "Nút cửa sổ nổi"
+	},
+	"position": {
+		"message": "Vị trí"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "Nhấn phím bất kỳ hoặc sử dụng lăn chuột."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "Nhấn phím bất kỳ hoặc sử dụng lăn chuột"
+	},
+	"previousVideo": {
+		"message": "Video trước"
+	},
+	"primaryColor": {
+		"message": "Màu chính"
+	},
+	"purple": {
+		"message": "Tím"
+	},
+	"quality": {
+		"message": "Chất lượng"
+	},
+	"raised": {
+		"message": "Nâng lên"
+	},
+	"rateMe": {
+		"message": "Đánh giá tôi"
+	},
+	"rateUs": {
+		"message": "Đánh giá chúng tôi"
+	},
+	"red": {
+		"message": "Đỏ"
+	},
+	"redDislikeButton": {
+		"message": "Nút không thích màu đỏ"
+	},
+	"relatedVideos": {
+		"message": "Các video liên quan"
+	},
+	"remote": {
+		"message": "Phát trên TV"
+	},
+	"removeRelatedSearchResults": {
+		"message": "Xóa kết quả tìm kiếm có liên quan"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "Xóa vòng lặp Shorts khỏi kết quả tìm kiếm"
+	},
+	"repeat": {
+		"message": "Lặp lại"
+	},
+	"report": {
+		"message": "Báo cáo"
+	},
+	"reset": {
+		"message": "Đặt lại"
+	},
+	"resetAllSettings": {
+		"message": "Đặt lại tất cả các thiết lập"
+	},
+	"resetAllShortcuts": {
+		"message": "Đặt lại tất cả các phím tắt"
+	},
+	"reverse": {
+		"message": "Đảo ngược"
+	},
+	"rotate": {
+		"message": "Quay"
+	},
+	"save": {
+		"message": "Lưu"
+	},
+	"saveAs": {
+		"message": "Lưu thành"
+	},
+	"schedule": {
+		"message": "Lịch trình"
+	},
+	"screen": {
+		"message": "Màn hình"
+	},
+	"screenshot": {
+		"message": "Ảnh chụp màn hình"
+	},
+	"scrollBar": {
+		"message": "Thanh cuộn"
+	},
+	"search": {
+		"message": "Tìm kiếm"
+	},
+	"searchBarOnly": {
+		"message": "Chỉ thanh tìm kiếm"
+	},
+	"seekBackward10Seconds": {
+		"message": "Tua lùi 10 giây"
+	},
+	"seekForward10Seconds": {
+		"message": "Tua tiến 10 giây"
+	},
+	"seekNextChapter": {
+		"message": "Tìm chương tiếp theo"
+	},
+	"seekPreviousChapter": {
+		"message": "Tìm kiếm chương trước"
+	},
+	"settings": {
+		"message": "Cài đặt"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "Đã nhập thành công cài đặt"
+	},
+	"share": {
+		"message": "Chia sẻ"
+	},
+	"shortcuts": {
+		"message": "Phím tắt"
+	},
+	"showCardsOnMouseHover": {
+		"message": "Hiển thị thẻ khi di chuột"
+	},
+	"showChannelVideosCount": {
+		"message": "Hiển thị số lượng video trên kênh"
+	},
+	"showLess": {
+		"message": "Hiện ít hơn"
+	},
+	"showMore": {
+		"message": "Hiện nhiều hơn"
+	},
+	"showRemainingDuration": {
+		"message": "Hiển thị thời lượng còn lại của video"
+	},
+	"showVersion": {
+		"message": "Hiển thị phiên bản"
+	},
+	"shuffle": {
+		"message": "Trộn"
+	},
+	"sidebar": {
+		"message": "Thanh bên"
+	},
+	"softwareInformation": {
+		"message": "Thông tin phần mềm"
+	},
+	"spacebar": {
+		"message": "Phím cách"
+	},
+	"squaredUserImages": {
+		"message": "Ảnh người dùng hình vuông"
+	},
+	"static": {
+		"message": "Tĩnh"
+	},
+	"statsForNerds": {
+		"message": "Hiển thị số liệu thống kê"
+	},
+	"step": {
+		"message": "Bước"
+	},
+	"stop": {
+		"message": "Dừng"
+	},
+	"style": {
+		"message": "Phong cách"
+	},
+	"styles": {
+		"message": "Phong cách"
+	},
+	"subscribe": {
+		"message": "Đăng ký"
+	},
+	"subscriptions": {
+		"message": "Đăng ký"
+	},
+	"subtitles": {
+		"message": "Phụ đề"
+	},
+	"sunset": {
+		"message": "Hoàng hôn"
+	},
+	"sunsetToSunrise": {
+		"message": "Hoàng hôn đến bình minh"
+	},
+	"systemPeferenceDark": {
+		"message": "Tùy chọn hệ thống: tối"
+	},
+	"systemPeferenceLight": {
+		"message": "Tùy chọn hệ thống: sáng"
+	},
+	"teal": {
+		"message": "Xanh mòng két"
+	},
+	"textColor": {
+		"message": "Màu văn bản"
+	},
+	"thanks": {
+		"message": "Cảm ơn"
+	},
+	"themes": {
+		"message": "Chủ đề"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "Điều này sẽ xóa tất cả cookie."
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "Thao tác này sẽ xóa tất cả video đã xem."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "Thao tác này sẽ xóa tất cả cookie của YouTube"
+	},
+	"thisWillResetAllSettings": {
+		"message": "Điều này sẽ đặt lại tất cả cài đặt."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "Thao tác này sẽ đặt lại tất cả phím tắt"
+	},
+	"thumbnails": {
+		"message": "Hình thu nhỏ"
+	},
+	"thumbnailsQuality": {
+		"message": "Chất lượng hình thu nhỏ"
+	},
+	"timeFrom": {
+		"message": "Thời gian từ"
+	},
+	"timeTo": {
+		"message": "Thời gian đến"
+	},
+	"todayAt": {
+		"message": "Hôm nay lúc"
+	},
+	"toggleAutoplay": {
+		"message": "Chuyển đổi tự động phát"
+	},
+	"toggleCards": {
+		"message": "Chuyển đổi thẻ"
+	},
+	"toggleControls": {
+		"message": "Chuyển đổi điều khiển trình phát"
+	},
+	"topChat": {
+		"message": "Trò chuyện hàng đầu"
+	},
+	"trackWatchedVideos": {
+		"message": "Theo dõi các video đã xem"
+	},
+	"trailerAutoplay": {
+		"message": "Tự động phát đoạn giới thiệu"
+	},
+	"translations": {
+		"message": "Bản dịch"
+	},
+	"transparentBackground": {
+		"message": "Nền trong suốt"
+	},
+	"trending": {
+		"message": "Xu hướng"
+	},
+	"tryToReloadThePage": {
+		"message": "Cố gắng tải lại trang"
+	},
+	"type": {
+		"message": "Gõ phím"
+	},
+	"upNextAutoplay": {
+		"message": "Tự động phát tiếp theo"
+	},
+	"use24HourFormat": {
+		"message": "Sử dụng định dạng 24 giờ"
+	},
+	"version": {
+		"message": "Phiên bản"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "Mô tả video sẽ được mở rộng để lấy tên của danh mục"
+	},
+	"videoFormats": {
+		"message": "Định dạng video"
+	},
+	"viewMode": {
+		"message": "Chế độ xem"
+	},
+	"volume": {
+		"message": "Âm lượng"
+	},
+	"watchLater": {
+		"message": "Xem sau"
+	},
+	"watchTime": {
+		"message": "Thời gian xem"
+	},
+	"whenPaused": {
+		"message": "Khi tạm dừng"
+	},
+	"whenTabIsChanged": {
+		"message": "Khi thay đổi tab"
+	},
+	"white": {
+		"message": "Trắng"
+	},
+	"windowColor": {
+		"message": "Màu cửa sổ"
+	},
+	"windowOpacity": {
+		"message": "Độ mờ cửa sổ"
+	},
+	"yellow": {
+		"message": "Vàng"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Tiêu đề YouTube (bên trái)"
+	},
+	"youtubeHeaderRight": {
+		"message": "Tiêu đề YouTube (bên phải)"
+	},
+	"youtubeHomePage": {
+		"message": "Trang chủ YouTube"
+	},
+	"youtubeLanguage": {
+		"message": "Ngôn ngữ YouTube"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "YouTube giới hạn chất lượng video 1080p cho h.264 codec"
+	}
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1,305 +1,305 @@
 {
-    "accept": {
-        "message": "接受"
-    },
-    "all": {
-        "message": "所有"
-    },
-    "always": {
-        "message": "總是"
-    },
-    "amber": {
-        "message": "琥珀色"
-    },
-    "animations": {
-        "message": "動畫"
-    },
-    "avoidAv1": {
-        "message": "忽略 AV1"
-    },
-    "avoidAv1Vp8Vp9": {
-        "message": "忽略 AV1, VP8, VP9"
-    },
-    "avoidAv1Vp9": {
-        "message": "忽略 AV1, VP9"
-    },
-    "avoidCpuRenderingWhenPossible": {
-        "message": "盡可能避免使用 CPU 渲染"
-    },
-    "backgroundOpacity": {
-        "message": "背景透明度"
-    },
-    "blockAv1": {
-        "message": "封鎖 AV1"
-    },
-    "blockH264": {
-        "message": "封鎖 H.264"
-    },
-    "blockMusic": {
-        "message": "封鎖音樂"
-    },
-    "blockVp8": {
-        "message": "封鎖 VP8"
-    },
-    "blockVp9": {
-        "message": "封鎖 VP9"
-    },
-    "brown": {
-        "message": "棕色"
-    },
-    "bug": {
-        "message": "問題"
-    },
-    "Buttons": {
-        "message": "按鈕"
-    },
-    "cancel": {
-        "message": "取消"
-    },
-    "clip": {
-        "message": "剪輯"
-    },
-    "codecs": {
-        "message": "編碼"
-    },
-    "custom": {
-        "message": "自訂"
-    },
-    "cyan": {
-        "message": "青色"
-    },
-    "dawn": {
-        "message": "黎明"
-    },
-    "deepOrange": {
-        "message": "深橙色"
-    },
-    "deepPurple": {
-        "message": "深紫色"
-    },
-    "deleteWatchedVideos": {
-        "message": "刪除已觀看的影片"
-    },
-    "depressed": {
-        "message": "內凹"
-    },
-    "description": {
-        "message": "描述"
-    },
-    "description_ext": {
-        "message": "讓 YouTube 更整潔、聰明！YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
-    },
-    "desert": {
-        "message": "沙漠"
-    },
-    "displayDayOfTheWeak": {
-        "message": "顯示星期幾"
-    },
-    "download": {
-        "message": "下載"
-    },
-    "dropShadow": {
-        "message": "投射陰影"
-    },
-    "durationWithSpeed": {
-        "message": "依據播放速度顯示剩餘時間"
-    },
-    "forcedPlaybackSpeedMusic": {
-        "message": "(即使對音樂也強制播放速度？)"
-    },
-    "forceSDR": {
-        "message": "強制使用標準動態範圍 (SDR)"
-    },
-    "googleApiKey": {
-        "message": "Google API 金鑰"
-    },
-    "hardwareInformation": {
-        "message": "硬體資訊"
-    },
-    "hideCategories": {
-        "message": "隱藏分類"
-    },
-    "hideCommentsCount": {
-        "message": "隱藏評論數量"
-    },
-    "hidePlayerControlsBarOptions": {
-        "message": "隱藏播放選項"
-    },
-    "hideThumbnails": {
-        "message": "隱藏縮圖"
-    },
-    "hideVoiceSearchButton": {
-        "message": "隱藏語音搜尋按鈕"
-    },
-    "high": {
-        "message": "高"
-    },
-    "improvedtubeButtons": {
-        "message": "ImprovedTube 按鈕"
-    },
-    "improvedtubeVersion": {
-        "message": "ImprovedTube 版本"
-    },
-    "increaseVolume": {
-        "message": "增加音量"
-    },
-    "layerAnimationScale": {
-        "message": "圖層動畫縮放"
-    },
-    "layout": {
-        "message": "版面配置"
-    },
-    "library": {
-        "message": "影片庫"
-    },
-    "liked": {
-        "message": "已喜歡"
-    },
-    "likes": {
-        "message": "喜歡"
-    },
-    "limitPageWidth": {
-        "message": "限制頁面寬度"
-    },
-    "loop": {
-        "message": "重複播放"
-    },
-    "low": {
-        "message": "低"
-    },
-    "medium": {
-        "message": "中"
-    },
-    "more": {
-        "message": "更多"
-    },
-    "mostViewedChannels": {
-        "message": "最多觀看的頻道"
-    },
-    "moveSidebarLeft": {
-        "message": "將側邊欄移至右方"
-    },
-    "moveThumbnailsRight": {
-        "message": "將預覽圖移至右方"
-    },
-    "nightMode": {
-        "message": "夜晚模式"
-    },
-    "normal": {
-        "message": "正常"
-    },
-    "off": {
-        "message": "關閉"
-    },
-    "ok": {
-        "message": "確定"
-    },
-    "other": {
-        "message": "其他"
-    },
-    "outline": {
-        "message": "外框"
-    },
-    "overlay": {
-        "message": "遮罩"
-    },
-    "platform": {
-        "message": "平台"
-    },
-    "playAllButton": {
-        "message": "\"播放全部\"按鈕"
-    },
-    "playbackSpeed": {
-        "message": "播放速度"
-    },
-    "player": {
-        "message": "播放器"
-    },
-    "playerSize": {
-        "message": "播放器大小"
-    },
-    "playlist": {
-        "message": "播放列表"
-    },
-    "position": {
-        "message": "位置"
-    },
-    "purple": {
-        "message": "紫色"
-    },
-    "raised": {
-        "message": "浮凸"
-    },
-    "rateMe": {
-        "message": "給我評分"
-    },
-    "remote": {
-        "message": "於電視上播放"
-    },
-    "report": {
-        "message": "回報"
-    },
-    "scrollBar": {
-        "message": "捲軸"
-    },
-    "seekBackward10Seconds": {
-        "message": "倒退10秒"
-    },
-    "share": {
-        "message": "分享"
-    },
-    "showRemainingDuration": {
-        "message": "顯示影片剩餘時間"
-    },
-    "showVersion": {
-        "message": "顯示版本"
-    },
-    "softwareInformation": {
-        "message": "軟體資訊"
-    },
-    "step": {
-        "message": "音量調整間隔"
-    },
-    "stop": {
-        "message": "停止"
-    },
-    "subscribe": {
-        "message": "訂閱"
-    },
-    "subtitles": {
-        "message": "字幕"
-    },
-    "thanks": {
-        "message": "感謝"
-    },
-    "thisWillRemoveAllWatchedVideos": {
-        "message": "這將移除全部播放過的影片。"
-    },
-    "thumbnailsQuality": {
-        "message": "縮圖品質"
-    },
-    "toggleAutoplay": {
-        "message": "切換自動播放"
-    },
-    "trackWatchedVideos": {
-        "message": "追蹤已觀看的影片"
-    },
-    "transparentBackground": {
-        "message": "透明背景"
-    },
-    "version": {
-        "message": "版本"
-    },
-    "viewMode": {
-        "message": "預設檢視模式"
-    },
-    "volume": {
-        "message": "音量"
-    },
-    "whenPaused": {
-        "message": "當暫停播放時"
-    },
-    "white": {
-        "message": "白色"
-    }
+	"accept": {
+		"message": "接受"
+	},
+	"all": {
+		"message": "所有"
+	},
+	"always": {
+		"message": "總是"
+	},
+	"amber": {
+		"message": "琥珀色"
+	},
+	"animations": {
+		"message": "動畫"
+	},
+	"avoidAv1": {
+		"message": "忽略 AV1"
+	},
+	"avoidAv1Vp8Vp9": {
+		"message": "忽略 AV1, VP8, VP9"
+	},
+	"avoidAv1Vp9": {
+		"message": "忽略 AV1, VP9"
+	},
+	"avoidCpuRenderingWhenPossible": {
+		"message": "盡可能避免使用 CPU 渲染"
+	},
+	"backgroundOpacity": {
+		"message": "背景透明度"
+	},
+	"blockAv1": {
+		"message": "封鎖 AV1"
+	},
+	"blockH264": {
+		"message": "封鎖 H.264"
+	},
+	"blockMusic": {
+		"message": "封鎖音樂"
+	},
+	"blockVp8": {
+		"message": "封鎖 VP8"
+	},
+	"blockVp9": {
+		"message": "封鎖 VP9"
+	},
+	"brown": {
+		"message": "棕色"
+	},
+	"bug": {
+		"message": "問題"
+	},
+	"Buttons": {
+		"message": "按鈕"
+	},
+	"cancel": {
+		"message": "取消"
+	},
+	"clip": {
+		"message": "剪輯"
+	},
+	"codecs": {
+		"message": "編碼"
+	},
+	"custom": {
+		"message": "自訂"
+	},
+	"cyan": {
+		"message": "青色"
+	},
+	"dawn": {
+		"message": "黎明"
+	},
+	"deepOrange": {
+		"message": "深橙色"
+	},
+	"deepPurple": {
+		"message": "深紫色"
+	},
+	"deleteWatchedVideos": {
+		"message": "刪除已觀看的影片"
+	},
+	"depressed": {
+		"message": "內凹"
+	},
+	"description": {
+		"message": "描述"
+	},
+	"description_ext": {
+		"message": "讓 YouTube 更整潔、聰明！YouTube video color ad skip volume speed channel tool style HD ads adblock adblocker tags keyword playlist"
+	},
+	"desert": {
+		"message": "沙漠"
+	},
+	"displayDayOfTheWeak": {
+		"message": "顯示星期幾"
+	},
+	"download": {
+		"message": "下載"
+	},
+	"dropShadow": {
+		"message": "投射陰影"
+	},
+	"durationWithSpeed": {
+		"message": "依據播放速度顯示剩餘時間"
+	},
+	"forcedPlaybackSpeedMusic": {
+		"message": "(即使對音樂也強制播放速度？)"
+	},
+	"forceSDR": {
+		"message": "強制使用標準動態範圍 (SDR)"
+	},
+	"googleApiKey": {
+		"message": "Google API 金鑰"
+	},
+	"hardwareInformation": {
+		"message": "硬體資訊"
+	},
+	"hideCategories": {
+		"message": "隱藏分類"
+	},
+	"hideCommentsCount": {
+		"message": "隱藏評論數量"
+	},
+	"hidePlayerControlsBarOptions": {
+		"message": "隱藏播放選項"
+	},
+	"hideThumbnails": {
+		"message": "隱藏縮圖"
+	},
+	"hideVoiceSearchButton": {
+		"message": "隱藏語音搜尋按鈕"
+	},
+	"high": {
+		"message": "高"
+	},
+	"improvedtubeButtons": {
+		"message": "ImprovedTube 按鈕"
+	},
+	"improvedtubeVersion": {
+		"message": "ImprovedTube 版本"
+	},
+	"increaseVolume": {
+		"message": "增加音量"
+	},
+	"layerAnimationScale": {
+		"message": "圖層動畫縮放"
+	},
+	"layout": {
+		"message": "版面配置"
+	},
+	"library": {
+		"message": "影片庫"
+	},
+	"liked": {
+		"message": "已喜歡"
+	},
+	"likes": {
+		"message": "喜歡"
+	},
+	"limitPageWidth": {
+		"message": "限制頁面寬度"
+	},
+	"loop": {
+		"message": "重複播放"
+	},
+	"low": {
+		"message": "低"
+	},
+	"medium": {
+		"message": "中"
+	},
+	"more": {
+		"message": "更多"
+	},
+	"mostViewedChannels": {
+		"message": "最多觀看的頻道"
+	},
+	"moveSidebarLeft": {
+		"message": "將側邊欄移至右方"
+	},
+	"moveThumbnailsRight": {
+		"message": "將預覽圖移至右方"
+	},
+	"nightMode": {
+		"message": "夜晚模式"
+	},
+	"normal": {
+		"message": "正常"
+	},
+	"off": {
+		"message": "關閉"
+	},
+	"ok": {
+		"message": "確定"
+	},
+	"other": {
+		"message": "其他"
+	},
+	"outline": {
+		"message": "外框"
+	},
+	"overlay": {
+		"message": "遮罩"
+	},
+	"platform": {
+		"message": "平台"
+	},
+	"playAllButton": {
+		"message": "\"播放全部\"按鈕"
+	},
+	"playbackSpeed": {
+		"message": "播放速度"
+	},
+	"player": {
+		"message": "播放器"
+	},
+	"playerSize": {
+		"message": "播放器大小"
+	},
+	"playlist": {
+		"message": "播放列表"
+	},
+	"position": {
+		"message": "位置"
+	},
+	"purple": {
+		"message": "紫色"
+	},
+	"raised": {
+		"message": "浮凸"
+	},
+	"rateMe": {
+		"message": "給我評分"
+	},
+	"remote": {
+		"message": "於電視上播放"
+	},
+	"report": {
+		"message": "回報"
+	},
+	"scrollBar": {
+		"message": "捲軸"
+	},
+	"seekBackward10Seconds": {
+		"message": "倒退10秒"
+	},
+	"share": {
+		"message": "分享"
+	},
+	"showRemainingDuration": {
+		"message": "顯示影片剩餘時間"
+	},
+	"showVersion": {
+		"message": "顯示版本"
+	},
+	"softwareInformation": {
+		"message": "軟體資訊"
+	},
+	"step": {
+		"message": "音量調整間隔"
+	},
+	"stop": {
+		"message": "停止"
+	},
+	"subscribe": {
+		"message": "訂閱"
+	},
+	"subtitles": {
+		"message": "字幕"
+	},
+	"thanks": {
+		"message": "感謝"
+	},
+	"thisWillRemoveAllWatchedVideos": {
+		"message": "這將移除全部播放過的影片。"
+	},
+	"thumbnailsQuality": {
+		"message": "縮圖品質"
+	},
+	"toggleAutoplay": {
+		"message": "切換自動播放"
+	},
+	"trackWatchedVideos": {
+		"message": "追蹤已觀看的影片"
+	},
+	"transparentBackground": {
+		"message": "透明背景"
+	},
+	"version": {
+		"message": "版本"
+	},
+	"viewMode": {
+		"message": "預設檢視模式"
+	},
+	"volume": {
+		"message": "音量"
+	},
+	"whenPaused": {
+		"message": "當暫停播放時"
+	},
+	"white": {
+		"message": "白色"
+	}
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,776 +1,773 @@
 {
-    "about": {
-        "message": "关于"
-    },
-    "activate": {
-        "message": "启用"
-    },
-    "activateCaptions": {
-        "message": "启用字幕"
-    },
-    "activated": {
-        "message": "启用"
-    },
-    "activatedFeatures": {
-        "message": "已启用功能"
-    },
-    "activateFullscreen": {
-        "message": "启用全屏"
-    },
-    "activeFeatures": {
-        "message": "启用功能"
-    },
-    "addScrollToTop": {
-        "message": "增加【返回顶部】按钮"
-    },
-    "ads": {
-        "message": "广告"
-    },
-    "allow": {
-        "message": "允许"
-    },
-    "alwaysActive": {
-        "message": "始终启用"
-    },
-    "alwaysShowProgressBar": {
-        "message": "始终显示进度条"
-    },
-    "analyzer": {
-        "message": "分析仪"
-    },
-    "appearance": {
-        "message": "外观"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "你确定想要导出数据吗?"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "你确定想要导入数据吗?"
-    },
-    "audio": {
-        "message": "音频"
-    },
-    "audioFormats": {
-        "message": "音频格式"
-    },
-    "auto": {
-        "message": "自动"
-    },
-    "autoFullscreen": {
-        "message": "自动全屏"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "切换标签时暂停播放"
-    },
-    "autoplay": {
-        "message": "自动播放"
-    },
-    "backgroundColor": {
-        "message": "背景颜色"
-    },
-    "backupAndReset": {
-        "message": "备份与恢复"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "使用系统配色"
-    },
-    "belowPlayer": {
-        "message": "在播放器下方"
-    },
-    "black": {
-        "message": "纯黑"
-    },
-    "blockAll": {
-        "message": "拦截所有"
-    },
-    "blocklist": {
-        "message": "黑名单"
-    },
-    "blue": {
-        "message": "蓝色"
-    },
-    "blueGray": {
-        "message": "蓝灰色"
-    },
-    "bluelight": {
-        "message": "色彩柔和度"
-    },
-    "browser": {
-        "message": "浏览器"
-    },
-    "browserVersion": {
-        "message": "浏览器版本"
-    },
-    "bubbles": {
-        "message": "网格"
-    },
-    "categories": {
-        "message": "分类"
-    },
-    "channel": {
-        "message": "频道"
-    },
-    "channels": {
-        "message": "频道"
-    },
-    "characterEdgeStyle": {
-        "message": "文字阴影风格"
-    },
-    "clipboard": {
-        "message": "粘贴板"
-    },
-    "codecH264": {
-        "message": "采用 h.264 编码"
-    },
-    "collapsed": {
-        "message": "收起"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "订阅区域显示展开/收起按钮"
-    },
-    "comments": {
-        "message": "评论"
-    },
-    "compact_spacing": {
-        "message": "compact spacing"
-    },
-    "confirmationBeforeClosing": {
-        "message": "页面关闭确认"
-    },
-    "cores": {
-        "message": "核心"
-    },
-    "cropChapterTitles": {
-        "message": "裁剪章节标题"
-    },
-    "customCss": {
-        "message": "自定义CSS"
-    },
-    "customJs": {
-        "message": "自定义JS"
-    },
-    "customMiniPlayer": {
-        "message": "自定义迷你播放器"
-    },
-    "dark": {
-        "message": "黑暗"
-    },
-    "darkTheme": {
-        "message": "夜间模式"
-    },
-    "dateAndTime": {
-        "message": "时间与日期"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "视频减速"
-    },
-    "decreaseVolume": {
-        "message": "降低音量"
-    },
-    "default": {
-        "message": "默认"
-    },
-    "defaultChannelTab": {
-        "message": "默认频道页"
-    },
-    "defaultContentCountry": {
-        "message": "默认内容国家"
-    },
-    "deleteYoutubeCookies": {
-        "message": "清空 YouTube cookies"
-    },
-    "details": {
-        "message": "细节信息"
-    },
-    "developerOptions": {
-        "message": "开发者选项"
-    },
-    "device": {
-        "message": "设备"
-    },
-    "dim": {
-        "message": "遮罩层厚度"
-    },
-    "disabled": {
-        "message": "停用"
-    },
-    "dislike": {
-        "message": "踩一下"
-    },
-    "donate": {
-        "message": "支持"
-    },
-    "doNotChange": {
-        "message": "不做改变"
-    },
-    "draggable": {
-        "message": "可拖动"
-    },
-    "empty": {
-        "message": "暂无"
-    },
-    "enabled": {
-        "message": "启用"
-    },
-    "enabledForced": {
-        "message": "强制启用"
-    },
-    "expanded": {
-        "message": "展开"
-    },
-    "exportSettings": {
-        "message": "导出设置"
-    },
-    "extension": {
-        "message": "扩展"
-    },
-    "file": {
-        "message": "文件"
-    },
-    "filters": {
-        "message": "滤镜"
-    },
-    "fitToWindow": {
-        "message": "窗口自适应"
-    },
-    "flash": {
-        "message": "闪光"
-    },
-    "font": {
-        "message": "字体"
-    },
-    "fontColor": {
-        "message": "字体颜色"
-    },
-    "fontFamily": {
-        "message": "字体"
-    },
-    "fontOpacity": {
-        "message": "字体透明度"
-    },
-    "fontSize": {
-        "message": "字体大小"
-    },
-    "footer": {
-        "message": "底部栏"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "强制设置播放速度"
-    },
-    "forcedTheaterMode": {
-        "message": "强制设置剧场模式"
-    },
-    "forcedVolume": {
-        "message": "强制修改音量"
-    },
-    "foundABug": {
-        "message": "遇到了Bug?"
-    },
-    "fullWindow": {
-        "message": "全屏"
-    },
-    "general": {
-        "message": "一般设置"
-    },
-    "geoPreference": {
-        "message": "地理偏好"
-    },
-    "goToSearchBox": {
-        "message": "转到搜索框"
-    },
-    "green": {
-        "message": "绿色"
-    },
-    "hdThumbnail": {
-        "message": "高清缩略图"
-    },
-    "header": {
-        "message": "顶部栏"
-    },
-    "hidden": {
-        "message": "隐藏"
-    },
-    "hiddenOnVideoPage": {
-        "message": "在视频播放页面时隐藏"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "隐藏动态缩略图"
-    },
-    "hideAnnotations": {
-        "message": "隐藏预览图"
-    },
-    "hideCards": {
-        "message": "隐藏信息卡片"
-    },
-    "hideCountryCode": {
-        "message": "隐藏国家代码"
-    },
-    "hideDate": {
-        "message": "隐藏日期"
-    },
-    "hideDetails": {
-        "message": "隐藏详细信息"
-    },
-    "hideEndscreen": {
-        "message": "隐藏结束画面"
-    },
-    "hideFeaturedContent": {
-        "message": "隐藏精选频道"
-    },
-    "hideFooter": {
-        "message": "隐藏底部栏"
-    },
-    "hideGradientBottom": {
-        "message": "隐藏底部渐变层"
-    },
-    "hideHomePageShorts": {
-        "message": "移除主页的 Shorts"
-    },
-    "hidePlayerControlsBar": {
-        "message": "隐藏播放器控制栏"
-    },
-    "hidePlaylist": {
-        "message": "隐藏播放列表"
-    },
-    "hideRightButtons": {
-        "message": "隐藏右侧按钮"
-    },
-    "hideScrollForDetails": {
-        "message": "隐藏 «滚动至详细信息»"
-    },
-    "hideSkipOverlay": {
-        "message": "隐藏跳过叠加"
-    },
-    "hideThumbnailOverlay": {
-        "message": "隐藏缩略图上的按钮"
-    },
-    "hideViewsCount": {
-        "message": "隐藏观看量"
-    },
-    "history": {
-        "message": "历史记录"
-    },
-    "home": {
-        "message": "首页"
-    },
-    "hover": {
-        "message": "悬浮"
-    },
-    "hoverOnVideoPage": {
-        "message": "在视频播放页面时悬浮显示"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "投稿于多久之前"
-    },
-    "icons": {
-        "message": "图标"
-    },
-    "iconsOnly": {
-        "message": "仅显示图标"
-    },
-    "importSettings": {
-        "message": "导入设置"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "在 YouTube 显示 ImprovedTube 图标"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube 语言"
-    },
-    "improveLogo": {
-        "message": "优化图标"
-    },
-    "increasePlaybackSpeed": {
-        "message": "视频加速"
-    },
-    "indigo": {
-        "message": "靛青色"
-    },
-    "items": {
-        "message": "项目"
-    },
-    "language": {
-        "message": "语言"
-    },
-    "languages": {
-        "message": "语言"
-    },
-    "legacyYoutube": {
-        "message": "旧版 YouTube"
-    },
-    "light": {
-        "message": "明亮"
-    },
-    "lightBlue": {
-        "message": "浅蓝色"
-    },
-    "lightGreen": {
-        "message": "浅绿色"
-    },
-    "like": {
-        "message": "顶一下"
-    },
-    "lime": {
-        "message": "石灰色"
-    },
-    "list": {
-        "message": "列表"
-    },
-    "liveChat": {
-        "message": "实时聊天窗"
-    },
-    "liveChatType": {
-        "message": "实时聊天窗类型"
-    },
-    "location": {
-        "message": "地点"
-    },
-    "loudnessNormalization": {
-        "message": "音量标准化"
-    },
-    "markWatchedVideos": {
-        "message": "标记为已观看"
-    },
-    "mixer": {
-        "message": "混音器"
-    },
-    "myColors": {
-        "message": "自定义颜色"
-    },
-    "name": {
-        "message": "名字"
-    },
-    "nativeMiniPlayer": {
-        "message": "原版迷你播放器"
-    },
-    "new": {
-        "message": "新的"
-    },
-    "nextVideo": {
-        "message": "上一个视频"
-    },
-    "night": {
-        "message": "夜色"
-    },
-    "noActiveFeatures": {
-        "message": "没有已启用的功能"
-    },
-    "none": {
-        "message": "无"
-    },
-    "noOpenVideoTabs": {
-        "message": "没有已打开的视频标签"
-    },
-    "old": {
-        "message": "旧版"
-    },
-    "onAllVideos": {
-        "message": "在所有视频"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "仅在 YouTube 上启用"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "同时仅播放一个"
-    },
-    "onSubscribedChannels": {
-        "message": "在订阅频道"
-    },
-    "openPopupPlayer": {
-        "message": "在新窗口打开视频/播放列表"
-    },
-    "orange": {
-        "message": "橙色"
-    },
-    "os": {
-        "message": "操作系统"
-    },
-    "permissions": {
-        "message": "许可"
-    },
-    "pictureInPicture": {
-        "message": "画中画"
-    },
-    "pink": {
-        "message": "粉色"
-    },
-    "plain": {
-        "message": "野外"
-    },
-    "player_fit_to_win_button": {
-        "message": "player fit to win button"
-    },
-    "player_rotate_button": {
-        "message": "player rotate button"
-    },
-    "playerColor": {
-        "message": "播放器颜色"
-    },
-    "playlists": {
-        "message": "稍后观看"
-    },
-    "playPause": {
-        "message": "播放/暂停"
-    },
-    "popupPlayer": {
-        "message": "弹出播放器"
-    },
-    "popupWindowButtons": {
-        "message": "添加弹出播放器按钮"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "按下任意键或滚动鼠标滚轴."
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "按下任意键或鼠标滚轴."
-    },
-    "previousVideo": {
-        "message": "下一个视频"
-    },
-    "primaryColor": {
-        "message": "主色调"
-    },
-    "quality": {
-        "message": "画质"
-    },
-    "rateUs": {
-        "message": "给我们评价"
-    },
-    "red": {
-        "message": "红色"
-    },
-    "redDislikeButton": {
-        "message": "将【踩一下】设置为红色"
-    },
-    "relatedVideos": {
-        "message": "相关视频"
-    },
-    "removeRelatedSearchResults": {
-        "message": "隐藏搜索相关结果"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "删除搜索结果中的 Shorts 轮播"
-    },
-    "repeat": {
-        "message": "循环"
-    },
-    "reset": {
-        "message": "重置"
-    },
-    "resetAllSettings": {
-        "message": "重置所有设置"
-    },
-    "resetAllShortcuts": {
-        "message": "重置所有快捷键"
-    },
-    "reverse": {
-        "message": "逆序"
-    },
-    "rotate": {
-        "message": "旋转"
-    },
-    "save": {
-        "message": "保存"
-    },
-    "saveAs": {
-        "message": "另存为"
-    },
-    "schedule": {
-        "message": "定时开/关"
-    },
-    "screen": {
-        "message": "屏幕"
-    },
-    "screenshot": {
-        "message": "截图"
-    },
-    "search": {
-        "message": "搜索"
-    },
-    "searchBarOnly": {
-        "message": "仅搜索栏"
-    },
-    "seekForward10Seconds": {
-        "message": "快进10秒"
-    },
-    "seekNextChapter": {
-        "message": "寻找下一章"
-    },
-    "seekPreviousChapter": {
-        "message": "寻找上一章"
-    },
-    "settings": {
-        "message": "ImprovedTube 设置"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "设置导入成功"
-    },
-    "shortcuts": {
-        "message": "快捷键"
-    },
-    "showCardsOnMouseHover": {
-        "message": "鼠标悬浮时显示信息卡片"
-    },
-    "showChannelVideosCount": {
-        "message": "显示频道内视频数"
-    },
-    "showLess": {
-        "message": "显示较少"
-    },
-    "showMore": {
-        "message": "展示更多"
-    },
-    "shuffle": {
-        "message": "随机"
-    },
-    "sidebar": {
-        "message": "侧边栏"
-    },
-    "spacebar": {
-        "message": "空格"
-    },
-    "squaredUserImages": {
-        "message": "方形用户头像"
-    },
-    "static": {
-        "message": "静态"
-    },
-    "statsForNerds": {
-        "message": "显示专业信息"
-    },
-    "style": {
-        "message": "样式"
-    },
-    "styles": {
-        "message": "样式"
-    },
-    "subscriptions": {
-        "message": "订阅内容"
-    },
-    "sunset": {
-        "message": "晚霞"
-    },
-    "sunsetToSunrise": {
-        "message": "日落到日出"
-    },
-    "systemPeferenceDark": {
-        "message": "系统偏好: 深色"
-    },
-    "systemPeferenceLight": {
-        "message": "系统偏好: 浅色"
-    },
-    "teal": {
-        "message": "蓝绿色"
-    },
-    "textColor": {
-        "message": "文字颜色"
-    },
-    "themes": {
-        "message": "主题"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "将清空所有 cookies."
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "将清空所有 YouTube cookies"
-    },
-    "thisWillResetAllSettings": {
-        "message": "将重置所有设置."
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "将会重置所有快捷键"
-    },
-    "thumbnails": {
-        "message": "缩略图"
-    },
-    "timeFrom": {
-        "message": "开始时间"
-    },
-    "timeTo": {
-        "message": "结束时间"
-    },
-    "todayAt": {
-        "message": "截止今天"
-    },
-    "toggleCards": {
-        "message": "切换卡片"
-    },
-    "toggleControls": {
-        "message": "Toggle controls"
-    },
-    "topChat": {
-        "message": "热门聊天"
-    },
-    "trailerAutoplay": {
-        "message": "自动播放预告片"
-    },
-    "translations": {
-        "message": "翻译"
-    },
-    "trending": {
-        "message": "时下流行"
-    },
-    "tryToReloadThePage": {
-        "message": "尝试刷新页面"
-    },
-    "turnOff": {
-        "message": "关闭时间"
-    },
-    "turnOn": {
-        "message": "开启时间"
-    },
-    "type": {
-        "message": "类型"
-    },
-    "upNextAutoplay": {
-        "message": "自动播放下一视频"
-    },
-    "use24HourFormat": {
-        "message": "使用24小时制"
-    },
-    "video": {
-        "message": "视频"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "扩展视频简介到分类"
-    },
-    "videoFormats": {
-        "message": "视频格式"
-    },
-    "videos": {
-        "message": "视频"
-    },
-    "watchLater": {
-        "message": "稍后观看"
-    },
-    "watchTime": {
-        "message": "观看时间"
-    },
-    "whenTabIsChanged": {
-        "message": "切换标签时"
-    },
-    "windowColor": {
-        "message": "窗口颜色"
-    },
-    "windowOpacity": {
-        "message": "窗口透明度"
-    },
-    "yellow": {
-        "message": "黄色"
-    },
-    "youtubeHeaderLeft": {
-        "message": "Youtube标题（左）"
-    },
-    "youtubeHeaderRight": {
-        "message": "Youtube标题（右）"
-    },
-    "youtubeHomePage": {
-        "message": "YouTube默认主页"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube 语言"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "采用 H.264 编解码时，YouTube 会将视频画质设为 1080p"
-    }
+	"about": {
+		"message": "关于"
+	},
+	"activate": {
+		"message": "启用"
+	},
+	"activateCaptions": {
+		"message": "启用字幕"
+	},
+	"activated": {
+		"message": "启用"
+	},
+	"activatedFeatures": {
+		"message": "已启用功能"
+	},
+	"activateFullscreen": {
+		"message": "启用全屏"
+	},
+	"activeFeatures": {
+		"message": "启用功能"
+	},
+	"addScrollToTop": {
+		"message": "增加【返回顶部】按钮"
+	},
+	"ads": {
+		"message": "广告"
+	},
+	"allow": {
+		"message": "允许"
+	},
+	"alwaysActive": {
+		"message": "始终启用"
+	},
+	"alwaysShowProgressBar": {
+		"message": "始终显示进度条"
+	},
+	"analyzer": {
+		"message": "分析仪"
+	},
+	"appearance": {
+		"message": "外观"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "你确定想要导出数据吗?"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "你确定想要导入数据吗?"
+	},
+	"audio": {
+		"message": "音频"
+	},
+	"audioFormats": {
+		"message": "音频格式"
+	},
+	"auto": {
+		"message": "自动"
+	},
+	"autoFullscreen": {
+		"message": "自动全屏"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "切换标签时暂停播放"
+	},
+	"autoplay": {
+		"message": "自动播放"
+	},
+	"backgroundColor": {
+		"message": "背景颜色"
+	},
+	"backupAndReset": {
+		"message": "备份与恢复"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "使用系统配色"
+	},
+	"belowPlayer": {
+		"message": "在播放器下方"
+	},
+	"black": {
+		"message": "纯黑"
+	},
+	"blockAll": {
+		"message": "拦截所有"
+	},
+	"blocklist": {
+		"message": "黑名单"
+	},
+	"blue": {
+		"message": "蓝色"
+	},
+	"blueGray": {
+		"message": "蓝灰色"
+	},
+	"bluelight": {
+		"message": "色彩柔和度"
+	},
+	"browser": {
+		"message": "浏览器"
+	},
+	"browserVersion": {
+		"message": "浏览器版本"
+	},
+	"bubbles": {
+		"message": "网格"
+	},
+	"categories": {
+		"message": "分类"
+	},
+	"channel": {
+		"message": "频道"
+	},
+	"channels": {
+		"message": "频道"
+	},
+	"characterEdgeStyle": {
+		"message": "文字阴影风格"
+	},
+	"clipboard": {
+		"message": "粘贴板"
+	},
+	"codecH264": {
+		"message": "采用 h.264 编码"
+	},
+	"collapsed": {
+		"message": "收起"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "订阅区域显示展开/收起按钮"
+	},
+	"comments": {
+		"message": "评论"
+	},
+	"compact_spacing": {
+		"message": "compact spacing"
+	},
+	"confirmationBeforeClosing": {
+		"message": "页面关闭确认"
+	},
+	"cores": {
+		"message": "核心"
+	},
+	"cropChapterTitles": {
+		"message": "裁剪章节标题"
+	},
+	"customCss": {
+		"message": "自定义CSS"
+	},
+	"customJs": {
+		"message": "自定义JS"
+	},
+	"customMiniPlayer": {
+		"message": "自定义迷你播放器"
+	},
+	"dark": {
+		"message": "黑暗"
+	},
+	"darkTheme": {
+		"message": "夜间模式"
+	},
+	"dateAndTime": {
+		"message": "时间与日期"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "视频减速"
+	},
+	"decreaseVolume": {
+		"message": "降低音量"
+	},
+	"default": {
+		"message": "默认"
+	},
+	"defaultChannelTab": {
+		"message": "默认频道页"
+	},
+	"defaultContentCountry": {
+		"message": "默认内容国家"
+	},
+	"deleteYoutubeCookies": {
+		"message": "清空 YouTube cookies"
+	},
+	"details": {
+		"message": "细节信息"
+	},
+	"developerOptions": {
+		"message": "开发者选项"
+	},
+	"device": {
+		"message": "设备"
+	},
+	"dim": {
+		"message": "遮罩层厚度"
+	},
+	"disabled": {
+		"message": "停用"
+	},
+	"dislike": {
+		"message": "踩一下"
+	},
+	"donate": {
+		"message": "支持"
+	},
+	"doNotChange": {
+		"message": "不做改变"
+	},
+	"draggable": {
+		"message": "可拖动"
+	},
+	"empty": {
+		"message": "暂无"
+	},
+	"enabled": {
+		"message": "启用"
+	},
+	"enabledForced": {
+		"message": "强制启用"
+	},
+	"expanded": {
+		"message": "展开"
+	},
+	"exportSettings": {
+		"message": "导出设置"
+	},
+	"extension": {
+		"message": "扩展"
+	},
+	"file": {
+		"message": "文件"
+	},
+	"filters": {
+		"message": "滤镜"
+	},
+	"fitToWindow": {
+		"message": "窗口自适应"
+	},
+	"flash": {
+		"message": "闪光"
+	},
+	"font": {
+		"message": "字体"
+	},
+	"fontColor": {
+		"message": "字体颜色"
+	},
+	"fontFamily": {
+		"message": "字体"
+	},
+	"fontOpacity": {
+		"message": "字体透明度"
+	},
+	"fontSize": {
+		"message": "字体大小"
+	},
+	"footer": {
+		"message": "底部栏"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "强制设置播放速度"
+	},
+	"forcedTheaterMode": {
+		"message": "强制设置剧场模式"
+	},
+	"forcedVolume": {
+		"message": "强制修改音量"
+	},
+	"foundABug": {
+		"message": "遇到了Bug?"
+	},
+	"fullWindow": {
+		"message": "全屏"
+	},
+	"general": {
+		"message": "一般设置"
+	},
+	"geoPreference": {
+		"message": "地理偏好"
+	},
+	"goToSearchBox": {
+		"message": "转到搜索框"
+	},
+	"green": {
+		"message": "绿色"
+	},
+	"hdThumbnail": {
+		"message": "高清缩略图"
+	},
+	"header": {
+		"message": "顶部栏"
+	},
+	"hidden": {
+		"message": "隐藏"
+	},
+	"hiddenOnVideoPage": {
+		"message": "在视频播放页面时隐藏"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "隐藏动态缩略图"
+	},
+	"hideAnnotations": {
+		"message": "隐藏预览图"
+	},
+	"hideCards": {
+		"message": "隐藏信息卡片"
+	},
+	"hideCountryCode": {
+		"message": "隐藏国家代码"
+	},
+	"hideDate": {
+		"message": "隐藏日期"
+	},
+	"hideDetails": {
+		"message": "隐藏详细信息"
+	},
+	"hideEndscreen": {
+		"message": "隐藏结束画面"
+	},
+	"hideFeaturedContent": {
+		"message": "隐藏精选频道"
+	},
+	"hideFooter": {
+		"message": "隐藏底部栏"
+	},
+	"hideGradientBottom": {
+		"message": "隐藏底部渐变层"
+	},
+	"hideHomePageShorts": {
+		"message": "移除主页的 Shorts"
+	},
+	"hidePlayerControlsBar": {
+		"message": "隐藏播放器控制栏"
+	},
+	"hidePlaylist": {
+		"message": "隐藏播放列表"
+	},
+	"hideRightButtons": {
+		"message": "隐藏右侧按钮"
+	},
+	"hideScrollForDetails": {
+		"message": "隐藏 «滚动至详细信息»"
+	},
+	"hideSkipOverlay": {
+		"message": "隐藏跳过叠加"
+	},
+	"hideThumbnailOverlay": {
+		"message": "隐藏缩略图上的按钮"
+	},
+	"hideViewsCount": {
+		"message": "隐藏观看量"
+	},
+	"history": {
+		"message": "历史记录"
+	},
+	"home": {
+		"message": "首页"
+	},
+	"hover": {
+		"message": "悬浮"
+	},
+	"hoverOnVideoPage": {
+		"message": "在视频播放页面时悬浮显示"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "投稿于多久之前"
+	},
+	"icons": {
+		"message": "图标"
+	},
+	"iconsOnly": {
+		"message": "仅显示图标"
+	},
+	"importSettings": {
+		"message": "导入设置"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "在 YouTube 显示 ImprovedTube 图标"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube 语言"
+	},
+	"improveLogo": {
+		"message": "优化图标"
+	},
+	"increasePlaybackSpeed": {
+		"message": "视频加速"
+	},
+	"indigo": {
+		"message": "靛青色"
+	},
+	"items": {
+		"message": "项目"
+	},
+	"language": {
+		"message": "语言"
+	},
+	"languages": {
+		"message": "语言"
+	},
+	"legacyYoutube": {
+		"message": "旧版 YouTube"
+	},
+	"light": {
+		"message": "明亮"
+	},
+	"lightBlue": {
+		"message": "浅蓝色"
+	},
+	"lightGreen": {
+		"message": "浅绿色"
+	},
+	"like": {
+		"message": "顶一下"
+	},
+	"lime": {
+		"message": "石灰色"
+	},
+	"list": {
+		"message": "列表"
+	},
+	"liveChat": {
+		"message": "实时聊天窗"
+	},
+	"liveChatType": {
+		"message": "实时聊天窗类型"
+	},
+	"location": {
+		"message": "地点"
+	},
+	"loudnessNormalization": {
+		"message": "音量标准化"
+	},
+	"markWatchedVideos": {
+		"message": "标记为已观看"
+	},
+	"mixer": {
+		"message": "混音器"
+	},
+	"myColors": {
+		"message": "自定义颜色"
+	},
+	"name": {
+		"message": "名字"
+	},
+	"nativeMiniPlayer": {
+		"message": "原版迷你播放器"
+	},
+	"new": {
+		"message": "新的"
+	},
+	"nextVideo": {
+		"message": "上一个视频"
+	},
+	"night": {
+		"message": "夜色"
+	},
+	"noActiveFeatures": {
+		"message": "没有已启用的功能"
+	},
+	"none": {
+		"message": "无"
+	},
+	"noOpenVideoTabs": {
+		"message": "没有已打开的视频标签"
+	},
+	"old": {
+		"message": "旧版"
+	},
+	"onAllVideos": {
+		"message": "在所有视频"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "仅在 YouTube 上启用"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "同时仅播放一个"
+	},
+	"onSubscribedChannels": {
+		"message": "在订阅频道"
+	},
+	"openPopupPlayer": {
+		"message": "在新窗口打开视频/播放列表"
+	},
+	"orange": {
+		"message": "橙色"
+	},
+	"os": {
+		"message": "操作系统"
+	},
+	"permissions": {
+		"message": "许可"
+	},
+	"pictureInPicture": {
+		"message": "画中画"
+	},
+	"pink": {
+		"message": "粉色"
+	},
+	"plain": {
+		"message": "野外"
+	},
+	"player_fit_to_win_button": {
+		"message": "player fit to win button"
+	},
+	"player_rotate_button": {
+		"message": "player rotate button"
+	},
+	"playerColor": {
+		"message": "播放器颜色"
+	},
+	"playlists": {
+		"message": "稍后观看"
+	},
+	"playPause": {
+		"message": "播放/暂停"
+	},
+	"popupPlayer": {
+		"message": "弹出播放器"
+	},
+	"popupWindowButtons": {
+		"message": "添加弹出播放器按钮"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "按下任意键或滚动鼠标滚轴."
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "按下任意键或鼠标滚轴."
+	},
+	"previousVideo": {
+		"message": "下一个视频"
+	},
+	"primaryColor": {
+		"message": "主色调"
+	},
+	"quality": {
+		"message": "画质"
+	},
+	"rateUs": {
+		"message": "给我们评价"
+	},
+	"red": {
+		"message": "红色"
+	},
+	"redDislikeButton": {
+		"message": "将【踩一下】设置为红色"
+	},
+	"relatedVideos": {
+		"message": "相关视频"
+	},
+	"removeRelatedSearchResults": {
+		"message": "隐藏搜索相关结果"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "删除搜索结果中的 Shorts 轮播"
+	},
+	"repeat": {
+		"message": "循环"
+	},
+	"reset": {
+		"message": "重置"
+	},
+	"resetAllSettings": {
+		"message": "重置所有设置"
+	},
+	"resetAllShortcuts": {
+		"message": "重置所有快捷键"
+	},
+	"reverse": {
+		"message": "逆序"
+	},
+	"rotate": {
+		"message": "旋转"
+	},
+	"save": {
+		"message": "保存"
+	},
+	"saveAs": {
+		"message": "另存为"
+	},
+	"schedule": {
+		"message": "定时开/关"
+	},
+	"screen": {
+		"message": "屏幕"
+	},
+	"screenshot": {
+		"message": "截图"
+	},
+	"search": {
+		"message": "搜索"
+	},
+	"searchBarOnly": {
+		"message": "仅搜索栏"
+	},
+	"seekForward10Seconds": {
+		"message": "快进10秒"
+	},
+	"seekNextChapter": {
+		"message": "寻找下一章"
+	},
+	"seekPreviousChapter": {
+		"message": "寻找上一章"
+	},
+	"settings": {
+		"message": "ImprovedTube 设置"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "设置导入成功"
+	},
+	"shortcuts": {
+		"message": "快捷键"
+	},
+	"showCardsOnMouseHover": {
+		"message": "鼠标悬浮时显示信息卡片"
+	},
+	"showChannelVideosCount": {
+		"message": "显示频道内视频数"
+	},
+	"showLess": {
+		"message": "显示较少"
+	},
+	"showMore": {
+		"message": "展示更多"
+	},
+	"shuffle": {
+		"message": "随机"
+	},
+	"sidebar": {
+		"message": "侧边栏"
+	},
+	"spacebar": {
+		"message": "空格"
+	},
+	"squaredUserImages": {
+		"message": "方形用户头像"
+	},
+	"static": {
+		"message": "静态"
+	},
+	"statsForNerds": {
+		"message": "显示专业信息"
+	},
+	"style": {
+		"message": "样式"
+	},
+	"styles": {
+		"message": "样式"
+	},
+	"subscriptions": {
+		"message": "订阅内容"
+	},
+	"sunset": {
+		"message": "晚霞"
+	},
+	"sunsetToSunrise": {
+		"message": "日落到日出"
+	},
+	"systemPeferenceDark": {
+		"message": "系统偏好: 深色"
+	},
+	"systemPeferenceLight": {
+		"message": "系统偏好: 浅色"
+	},
+	"teal": {
+		"message": "蓝绿色"
+	},
+	"textColor": {
+		"message": "文字颜色"
+	},
+	"themes": {
+		"message": "主题"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "将清空所有 cookies."
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "将清空所有 YouTube cookies"
+	},
+	"thisWillResetAllSettings": {
+		"message": "将重置所有设置."
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "将会重置所有快捷键"
+	},
+	"thumbnails": {
+		"message": "缩略图"
+	},
+	"timeFrom": {
+		"message": "开始时间"
+	},
+	"timeTo": {
+		"message": "结束时间"
+	},
+	"todayAt": {
+		"message": "截止今天"
+	},
+	"toggleCards": {
+		"message": "切换卡片"
+	},
+	"topChat": {
+		"message": "热门聊天"
+	},
+	"trailerAutoplay": {
+		"message": "自动播放预告片"
+	},
+	"translations": {
+		"message": "翻译"
+	},
+	"trending": {
+		"message": "时下流行"
+	},
+	"tryToReloadThePage": {
+		"message": "尝试刷新页面"
+	},
+	"turnOff": {
+		"message": "关闭时间"
+	},
+	"turnOn": {
+		"message": "开启时间"
+	},
+	"type": {
+		"message": "类型"
+	},
+	"upNextAutoplay": {
+		"message": "自动播放下一视频"
+	},
+	"use24HourFormat": {
+		"message": "使用24小时制"
+	},
+	"video": {
+		"message": "视频"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "扩展视频简介到分类"
+	},
+	"videoFormats": {
+		"message": "视频格式"
+	},
+	"videos": {
+		"message": "视频"
+	},
+	"watchLater": {
+		"message": "稍后观看"
+	},
+	"watchTime": {
+		"message": "观看时间"
+	},
+	"whenTabIsChanged": {
+		"message": "切换标签时"
+	},
+	"windowColor": {
+		"message": "窗口颜色"
+	},
+	"windowOpacity": {
+		"message": "窗口透明度"
+	},
+	"yellow": {
+		"message": "黄色"
+	},
+	"youtubeHeaderLeft": {
+		"message": "Youtube标题（左）"
+	},
+	"youtubeHeaderRight": {
+		"message": "Youtube标题（右）"
+	},
+	"youtubeHomePage": {
+		"message": "YouTube默认主页"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube 语言"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "采用 H.264 编解码时，YouTube 会将视频画质设为 1080p"
+	}
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,776 +1,776 @@
 {
-    "about": {
-        "message": "關於"
-    },
-    "activate": {
-        "message": "啟用"
-    },
-    "activateCaptions": {
-        "message": "開啟字幕"
-    },
-    "activated": {
-        "message": "已啟用"
-    },
-    "activatedFeatures": {
-        "message": "已啟用功能"
-    },
-    "activateFullscreen": {
-        "message": "開啟全螢幕"
-    },
-    "activeFeatures": {
-        "message": "已啟用功能"
-    },
-    "addScrollToTop": {
-        "message": "新增「回到頂部」按鈕"
-    },
-    "ads": {
-        "message": "廣告"
-    },
-    "allow": {
-        "message": "允許"
-    },
-    "alwaysActive": {
-        "message": "始終有效"
-    },
-    "alwaysShowProgressBar": {
-        "message": "一律顯示進度條"
-    },
-    "analyzer": {
-        "message": "觀看紀錄"
-    },
-    "appearance": {
-        "message": "外觀"
-    },
-    "areYouSureYouWantToExportTheData": {
-        "message": "您確定要匯出資料嗎？"
-    },
-    "areYouSureYouWantToImportTheData": {
-        "message": "確定要匯入資料嗎？"
-    },
-    "audio": {
-        "message": "音訊"
-    },
-    "audioFormats": {
-        "message": "音訊格式"
-    },
-    "auto": {
-        "message": "自動"
-    },
-    "autoFullscreen": {
-        "message": "自動全螢幕"
-    },
-    "autopauseWhenSwitchingTabs": {
-        "message": "切換分頁時自動暫停"
-    },
-    "autoplay": {
-        "message": "自動播放"
-    },
-    "backgroundColor": {
-        "message": "背景顏色"
-    },
-    "backupAndReset": {
-        "message": "備份 & 重設"
-    },
-    "baseOnSystemColorScheme": {
-        "message": "使用系統配色方案"
-    },
-    "belowPlayer": {
-        "message": "於播放器底下"
-    },
-    "black": {
-        "message": "黑色"
-    },
-    "blockAll": {
-        "message": "封鎖全部"
-    },
-    "blocklist": {
-        "message": "黑名單"
-    },
-    "blue": {
-        "message": "藍色"
-    },
-    "blueGray": {
-        "message": "藍灰色"
-    },
-    "bluelight": {
-        "message": "藍光"
-    },
-    "browser": {
-        "message": "瀏覽器"
-    },
-    "browserVersion": {
-        "message": "瀏覽器版本"
-    },
-    "bubbles": {
-        "message": "氣泡"
-    },
-    "buttons": {
-        "message": "按鈕"
-    },
-    "categories": {
-        "message": "類別"
-    },
-    "channel": {
-        "message": "頻道"
-    },
-    "channels": {
-        "message": "頻道"
-    },
-    "characterEdgeStyle": {
-        "message": "字型邊緣型式"
-    },
-    "clipboard": {
-        "message": "剪貼簿"
-    },
-    "codecH264": {
-        "message": "使用 H.264 解碼"
-    },
-    "collapsed": {
-        "message": "折疊"
-    },
-    "collapseOfSubscriptionSections": {
-        "message": "折疊訂閱區塊"
-    },
-    "comments": {
-        "message": "評論"
-    },
-    "confirmationBeforeClosing": {
-        "message": "關閉前先確認"
-    },
-    "cores": {
-        "message": "核心數"
-    },
-    "cropChapterTitles": {
-        "message": "截斷章節名稱"
-    },
-    "customCss": {
-        "message": "自訂 CSS"
-    },
-    "customJs": {
-        "message": "自訂 JS"
-    },
-    "customMiniPlayer": {
-        "message": "自訂迷你播放器"
-    },
-    "dark": {
-        "message": "暗黑"
-    },
-    "darkTheme": {
-        "message": "暗黑主題"
-    },
-    "dateAndTime": {
-        "message": "日期和時間"
-    },
-    "decreasePlaybackSpeed": {
-        "message": "降低播放速度"
-    },
-    "decreaseVolume": {
-        "message": "減輕音量"
-    },
-    "default": {
-        "message": "預設"
-    },
-    "defaultChannelTab": {
-        "message": "預設頻道標籤"
-    },
-    "defaultContentCountry": {
-        "message": "預設國家"
-    },
-    "deleteYoutubeCookies": {
-        "message": "刪除 YouTube cookies"
-    },
-    "details": {
-        "message": "細節"
-    },
-    "developerOptions": {
-        "message": "開發人員選項"
-    },
-    "device": {
-        "message": "裝置"
-    },
-    "dim": {
-        "message": "光線暗度"
-    },
-    "disabled": {
-        "message": "關閉"
-    },
-    "dislike": {
-        "message": "不喜歡"
-    },
-    "donate": {
-        "message": "捐贈"
-    },
-    "doNotChange": {
-        "message": "不要改變"
-    },
-    "draggable": {
-        "message": "可拖動"
-    },
-    "empty": {
-        "message": "空白"
-    },
-    "enabled": {
-        "message": "啟用"
-    },
-    "enabledForced": {
-        "message": "強制啟用"
-    },
-    "expanded": {
-        "message": "擴充套件"
-    },
-    "exportSettings": {
-        "message": "匯出設定"
-    },
-    "extension": {
-        "message": "擴充元件"
-    },
-    "file": {
-        "message": "檔案"
-    },
-    "filters": {
-        "message": "濾鏡"
-    },
-    "fitToWindow": {
-        "message": "依視窗大小縮放"
-    },
-    "flash": {
-        "message": "是否使用 Flash"
-    },
-    "font": {
-        "message": "字型"
-    },
-    "fontColor": {
-        "message": "字型顏色"
-    },
-    "fontFamily": {
-        "message": "字型"
-    },
-    "fontOpacity": {
-        "message": "字型透明度"
-    },
-    "fontSize": {
-        "message": "字型大小"
-    },
-    "footer": {
-        "message": "頁尾"
-    },
-    "forcedPlaybackSpeed": {
-        "message": "強制播放速度"
-    },
-    "forcedPlayVideoFromTheBeginning": {
-        "message": "強制從頭播放"
-    },
-    "forcedTheaterMode": {
-        "message": "強制劇院模式"
-    },
-    "forcedVolume": {
-        "message": "強制播放音量"
-    },
-    "foundABug": {
-        "message": "遇到問題了嗎?"
-    },
-    "fullWindow": {
-        "message": "全螢幕"
-    },
-    "general": {
-        "message": "一般"
-    },
-    "geoPreference": {
-        "message": "地理位置偏好"
-    },
-    "goToSearchBox": {
-        "message": "轉到搜尋框"
-    },
-    "green": {
-        "message": "綠色"
-    },
-    "hdThumbnail": {
-        "message": "HD 縮圖"
-    },
-    "header": {
-        "message": "標頭"
-    },
-    "hidden": {
-        "message": "隱藏"
-    },
-    "hiddenOnVideoPage": {
-        "message": "於影片頁面自動隱藏"
-    },
-    "hideAnimatedThumbnails": {
-        "message": "隱藏動態的縮圖"
-    },
-    "hideAnnotations": {
-        "message": "隱藏註解"
-    },
-    "hideCards": {
-        "message": "隱藏資訊卡"
-    },
-    "hideCountryCode": {
-        "message": "隱藏國家代號"
-    },
-    "hideDate": {
-        "message": "隱藏日期"
-    },
-    "hideDetailButton": {
-        "message": "隱藏詳細資訊按鈕"
-    },
-    "hideDetails": {
-        "message": "隱藏詳細資訊"
-    },
-    "hideEndscreen": {
-        "message": "隱藏結束畫面"
-    },
-    "hideFeaturedContent": {
-        "message": "隱藏精選影片"
-    },
-    "hideFooter": {
-        "message": "隱藏頁尾"
-    },
-    "hideGradientBottom": {
-        "message": "隱藏底部漸層圖層"
-    },
-    "hideHomePageShorts": {
-        "message": "移除主頁的 Shorts"
-    },
-    "hidePlayerControlsBar": {
-        "message": "隱藏播放器控制欄"
-    },
-    "hidePlayerControlsBarButtons": {
-        "message": "隱藏播放列按鈕"
-    },
-    "hidePlaylist": {
-        "message": "隱藏播放清單"
-    },
-    "hideRightButtons": {
-        "message": "隱藏右側按鈕"
-    },
-    "hideScrollForDetails": {
-        "message": "隱藏「向下捲動即可檢視詳細資訊」"
-    },
-    "hideSkipOverlay": {
-        "message": "隱藏「跳至區段」按鈕"
-    },
-    "hideThumbnailOverlay": {
-        "message": "隱藏縮圖上的按鈕"
-    },
-    "hideViewsCount": {
-        "message": "隱藏觀看次數"
-    },
-    "history": {
-        "message": "觀看記錄"
-    },
-    "home": {
-        "message": "首頁"
-    },
-    "hover": {
-        "message": "滑鼠暫留時顯示"
-    },
-    "hoverOnVideoPage": {
-        "message": "於影片頁面滑鼠暫留時顯示"
-    },
-    "howLongAgoTheVideoWasUploaded": {
-        "message": "顯示影片上傳時間"
-    },
-    "icons": {
-        "message": "圖示"
-    },
-    "iconsOnly": {
-        "message": "只有圖示"
-    },
-    "importSettings": {
-        "message": "匯入設定"
-    },
-    "improvedtubeIconOnYoutube": {
-        "message": "於 YouTube 中顯示 ImprovedTube 圖示"
-    },
-    "improvedtubeLanguage": {
-        "message": "ImprovedTube 語言"
-    },
-    "improveLogo": {
-        "message": "改進 YouTube 圖示"
-    },
-    "increasePlaybackSpeed": {
-        "message": "加快播放速度"
-    },
-    "indigo": {
-        "message": "靛青"
-    },
-    "items": {
-        "message": "專案"
-    },
-    "language": {
-        "message": "語言"
-    },
-    "languages": {
-        "message": "語言"
-    },
-    "legacyYoutube": {
-        "message": "舊版 YouTube"
-    },
-    "light": {
-        "message": "淺色"
-    },
-    "lightBlue": {
-        "message": "淺藍色"
-    },
-    "lightGreen": {
-        "message": "淺綠色"
-    },
-    "like": {
-        "message": "喜歡"
-    },
-    "lime": {
-        "message": "萊姆色"
-    },
-    "list": {
-        "message": "清單"
-    },
-    "liveChat": {
-        "message": "直播聊天室"
-    },
-    "liveChatType": {
-        "message": "直播聊天室類型"
-    },
-    "location": {
-        "message": "地區"
-    },
-    "loudnessNormalization": {
-        "message": "音量標準化"
-    },
-    "markWatchedVideos": {
-        "message": "標記已觀看影片"
-    },
-    "mixer": {
-        "message": "音量混合器"
-    },
-    "myColors": {
-        "message": "自訂主色"
-    },
-    "name": {
-        "message": "名稱"
-    },
-    "nativeMiniPlayer": {
-        "message": "原生迷你播放器"
-    },
-    "new": {
-        "message": "新增"
-    },
-    "nextVideo": {
-        "message": "下一個影片"
-    },
-    "night": {
-        "message": "夜晚"
-    },
-    "noActiveFeatures": {
-        "message": "無已啟用功能"
-    },
-    "none": {
-        "message": "無"
-    },
-    "noOpenVideoTabs": {
-        "message": "無已開啟之影片頁面"
-    },
-    "old": {
-        "message": "舊版"
-    },
-    "onAllVideos": {
-        "message": "於所有影片中"
-    },
-    "onlyActiveOnYoutube": {
-        "message": "僅適用於 YouTube 網站"
-    },
-    "onlyOnePlayerInstancePlaying": {
-        "message": "同時間僅限播放單一影片"
-    },
-    "onSubscribedChannels": {
-        "message": "於已訂閱的頻道中"
-    },
-    "openPopupPlayer": {
-        "message": "開啟影片或播放清單於新視窗中"
-    },
-    "orange": {
-        "message": "橘色"
-    },
-    "os": {
-        "message": "作業系統"
-    },
-    "permissions": {
-        "message": "權限"
-    },
-    "pictureInPicture": {
-        "message": "子母畫面"
-    },
-    "pink": {
-        "message": "粉紅色"
-    },
-    "plain": {
-        "message": "樸素"
-    },
-    "player_fit_to_win_button": {
-        "message": "4x3 Proportion"
-    },
-    "playerColor": {
-        "message": "影片進度條顏色"
-    },
-    "playlists": {
-        "message": "播放清單"
-    },
-    "playPause": {
-        "message": "播放/暫停"
-    },
-    "popupPlayer": {
-        "message": "彈出播放器"
-    },
-    "popupWindowButtons": {
-        "message": "新增彈出播放器按鈕"
-    },
-    "pressAnyKeyOrScroll": {
-        "message": "按任意鍵或使用滑鼠滾輪。"
-    },
-    "pressAnyKeyOrUseMouseWheel": {
-        "message": "按任意鍵或使用滑鼠滾輪。"
-    },
-    "previousVideo": {
-        "message": "回到之前的影片"
-    },
-    "primaryColor": {
-        "message": "主要顏色"
-    },
-    "quality": {
-        "message": "品質"
-    },
-    "rateUs": {
-        "message": "評分"
-    },
-    "red": {
-        "message": "紅色"
-    },
-    "redDislikeButton": {
-        "message": "將「不喜歡」數量以紅色顯示"
-    },
-    "relatedVideos": {
-        "message": "推薦影片"
-    },
-    "removeRelatedSearchResults": {
-        "message": "移除搜尋相關結果"
-    },
-    "removeShortsReelSearchResults": {
-        "message": "刪除搜尋結果中的 Shorts 輪播"
-    },
-    "repeat": {
-        "message": "重複播放"
-    },
-    "reset": {
-        "message": "重設"
-    },
-    "resetAllSettings": {
-        "message": "重設所有設定"
-    },
-    "resetAllShortcuts": {
-        "message": "重設所有快捷鍵"
-    },
-    "reverse": {
-        "message": "回播"
-    },
-    "rotate": {
-        "message": "旋轉影片"
-    },
-    "save": {
-        "message": "儲存"
-    },
-    "saveAs": {
-        "message": "另存為"
-    },
-    "schedule": {
-        "message": "排程"
-    },
-    "screen": {
-        "message": "螢幕"
-    },
-    "screenshot": {
-        "message": "截圖"
-    },
-    "search": {
-        "message": "搜尋"
-    },
-    "searchBarOnly": {
-        "message": "僅顯示搜尋列"
-    },
-    "seekForward10Seconds": {
-        "message": "前進10秒"
-    },
-    "seekNextChapter": {
-        "message": "跳至下一章節"
-    },
-    "seekPreviousChapter": {
-        "message": "跳至前一章節"
-    },
-    "settings": {
-        "message": "設定"
-    },
-    "settingsSuccessfullyImported": {
-        "message": "已成功匯入設定"
-    },
-    "shortcuts": {
-        "message": "快捷鍵"
-    },
-    "showCardsOnMouseHover": {
-        "message": "滑鼠暫留時顯示資訊卡"
-    },
-    "showChannelVideosCount": {
-        "message": "顯示頻道影片數量"
-    },
-    "showLess": {
-        "message": "顯示更少"
-    },
-    "showMore": {
-        "message": "顯示更多"
-    },
-    "shuffle": {
-        "message": "隨機播放"
-    },
-    "sidebar": {
-        "message": "側邊欄"
-    },
-    "spacebar": {
-        "message": "空白鍵"
-    },
-    "squaredUserImages": {
-        "message": "方形使用者圖示"
-    },
-    "static": {
-        "message": "靜止"
-    },
-    "statsForNerds": {
-        "message": "顯示「統計資料」按鈕"
-    },
-    "style": {
-        "message": "樣式"
-    },
-    "styles": {
-        "message": "樣式"
-    },
-    "subscriptions": {
-        "message": "訂閱內容"
-    },
-    "sunset": {
-        "message": "日落"
-    },
-    "sunsetToSunrise": {
-        "message": "日出至入落"
-    },
-    "systemPeferenceDark": {
-        "message": "系統預設: 暗黑模式"
-    },
-    "systemPeferenceLight": {
-        "message": "系統預設: 白天模式"
-    },
-    "teal": {
-        "message": "藍綠色"
-    },
-    "textColor": {
-        "message": "文字顏色"
-    },
-    "themes": {
-        "message": "主題"
-    },
-    "thisWillRemoveAllCookies": {
-        "message": "這將刪除所有的 cookies。"
-    },
-    "thisWillRemoveAllYouTubeCookies": {
-        "message": "這將刪除所有 YouTube Cookies。"
-    },
-    "thisWillResetAllSettings": {
-        "message": "這將重設所有設定。"
-    },
-    "thisWillResetAllShortcuts": {
-        "message": "這將重設所有快捷鍵。"
-    },
-    "thumbnails": {
-        "message": "縮圖"
-    },
-    "timeFrom": {
-        "message": "開始時間"
-    },
-    "timeTo": {
-        "message": "結束時間"
-    },
-    "todayAt": {
-        "message": "自今日"
-    },
-    "toggleCards": {
-        "message": "啟用結束畫面"
-    },
-    "toggleControls": {
-        "message": "開關播放器控制"
-    },
-    "topChat": {
-        "message": "重點聊天室訊息"
-    },
-    "trailerAutoplay": {
-        "message": "預告片自動播放"
-    },
-    "translations": {
-        "message": "翻譯"
-    },
-    "trending": {
-        "message": "發燒影片"
-    },
-    "tryToReloadThePage": {
-        "message": "嘗試重新整理頁面"
-    },
-    "type": {
-        "message": "種類"
-    },
-    "upNextAutoplay": {
-        "message": "自動播放下一個影片"
-    },
-    "use24HourFormat": {
-        "message": "使用24小時格式"
-    },
-    "video": {
-        "message": "影片"
-    },
-    "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "影片敘述將自動展開以顯示影片分類名稱"
-    },
-    "videoFormats": {
-        "message": "影片格式"
-    },
-    "videos": {
-        "message": "影片"
-    },
-    "watchLater": {
-        "message": "稍後觀看"
-    },
-    "watchTime": {
-        "message": "已觀看時間"
-    },
-    "whenTabIsChanged": {
-        "message": "當分頁改變時"
-    },
-    "windowColor": {
-        "message": "視窗顏色"
-    },
-    "windowOpacity": {
-        "message": "視窗透明度"
-    },
-    "yellow": {
-        "message": "黃色"
-    },
-    "youtubeHeaderLeft": {
-        "message": "YouTube 標頭 (左)"
-    },
-    "youtubeHeaderRight": {
-        "message": "YouTube 標頭 (右)"
-    },
-    "youtubeHomePage": {
-        "message": "預設的 YouTube 首頁"
-    },
-    "youtubeLanguage": {
-        "message": "YouTube 語言"
-    },
-    "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "使用 H.264 編碼時，YouTube 會將畫質限制為 1080p 內。"
-    }
+	"about": {
+		"message": "關於"
+	},
+	"activate": {
+		"message": "啟用"
+	},
+	"activateCaptions": {
+		"message": "開啟字幕"
+	},
+	"activated": {
+		"message": "已啟用"
+	},
+	"activatedFeatures": {
+		"message": "已啟用功能"
+	},
+	"activateFullscreen": {
+		"message": "開啟全螢幕"
+	},
+	"activeFeatures": {
+		"message": "已啟用功能"
+	},
+	"addScrollToTop": {
+		"message": "新增「回到頂部」按鈕"
+	},
+	"ads": {
+		"message": "廣告"
+	},
+	"allow": {
+		"message": "允許"
+	},
+	"alwaysActive": {
+		"message": "始終有效"
+	},
+	"alwaysShowProgressBar": {
+		"message": "一律顯示進度條"
+	},
+	"analyzer": {
+		"message": "觀看紀錄"
+	},
+	"appearance": {
+		"message": "外觀"
+	},
+	"areYouSureYouWantToExportTheData": {
+		"message": "您確定要匯出資料嗎？"
+	},
+	"areYouSureYouWantToImportTheData": {
+		"message": "確定要匯入資料嗎？"
+	},
+	"audio": {
+		"message": "音訊"
+	},
+	"audioFormats": {
+		"message": "音訊格式"
+	},
+	"auto": {
+		"message": "自動"
+	},
+	"autoFullscreen": {
+		"message": "自動全螢幕"
+	},
+	"autopauseWhenSwitchingTabs": {
+		"message": "切換分頁時自動暫停"
+	},
+	"autoplay": {
+		"message": "自動播放"
+	},
+	"backgroundColor": {
+		"message": "背景顏色"
+	},
+	"backupAndReset": {
+		"message": "備份 & 重設"
+	},
+	"baseOnSystemColorScheme": {
+		"message": "使用系統配色方案"
+	},
+	"belowPlayer": {
+		"message": "於播放器底下"
+	},
+	"black": {
+		"message": "黑色"
+	},
+	"blockAll": {
+		"message": "封鎖全部"
+	},
+	"blocklist": {
+		"message": "黑名單"
+	},
+	"blue": {
+		"message": "藍色"
+	},
+	"blueGray": {
+		"message": "藍灰色"
+	},
+	"bluelight": {
+		"message": "藍光"
+	},
+	"browser": {
+		"message": "瀏覽器"
+	},
+	"browserVersion": {
+		"message": "瀏覽器版本"
+	},
+	"bubbles": {
+		"message": "氣泡"
+	},
+	"buttons": {
+		"message": "按鈕"
+	},
+	"categories": {
+		"message": "類別"
+	},
+	"channel": {
+		"message": "頻道"
+	},
+	"channels": {
+		"message": "頻道"
+	},
+	"characterEdgeStyle": {
+		"message": "字型邊緣型式"
+	},
+	"clipboard": {
+		"message": "剪貼簿"
+	},
+	"codecH264": {
+		"message": "使用 H.264 解碼"
+	},
+	"collapsed": {
+		"message": "折疊"
+	},
+	"collapseOfSubscriptionSections": {
+		"message": "折疊訂閱區塊"
+	},
+	"comments": {
+		"message": "評論"
+	},
+	"confirmationBeforeClosing": {
+		"message": "關閉前先確認"
+	},
+	"cores": {
+		"message": "核心數"
+	},
+	"cropChapterTitles": {
+		"message": "截斷章節名稱"
+	},
+	"customCss": {
+		"message": "自訂 CSS"
+	},
+	"customJs": {
+		"message": "自訂 JS"
+	},
+	"customMiniPlayer": {
+		"message": "自訂迷你播放器"
+	},
+	"dark": {
+		"message": "暗黑"
+	},
+	"darkTheme": {
+		"message": "暗黑主題"
+	},
+	"dateAndTime": {
+		"message": "日期和時間"
+	},
+	"decreasePlaybackSpeed": {
+		"message": "降低播放速度"
+	},
+	"decreaseVolume": {
+		"message": "減輕音量"
+	},
+	"default": {
+		"message": "預設"
+	},
+	"defaultChannelTab": {
+		"message": "預設頻道標籤"
+	},
+	"defaultContentCountry": {
+		"message": "預設國家"
+	},
+	"deleteYoutubeCookies": {
+		"message": "刪除 YouTube cookies"
+	},
+	"details": {
+		"message": "細節"
+	},
+	"developerOptions": {
+		"message": "開發人員選項"
+	},
+	"device": {
+		"message": "裝置"
+	},
+	"dim": {
+		"message": "光線暗度"
+	},
+	"disabled": {
+		"message": "關閉"
+	},
+	"dislike": {
+		"message": "不喜歡"
+	},
+	"donate": {
+		"message": "捐贈"
+	},
+	"doNotChange": {
+		"message": "不要改變"
+	},
+	"draggable": {
+		"message": "可拖動"
+	},
+	"empty": {
+		"message": "空白"
+	},
+	"enabled": {
+		"message": "啟用"
+	},
+	"enabledForced": {
+		"message": "強制啟用"
+	},
+	"expanded": {
+		"message": "擴充套件"
+	},
+	"exportSettings": {
+		"message": "匯出設定"
+	},
+	"extension": {
+		"message": "擴充元件"
+	},
+	"file": {
+		"message": "檔案"
+	},
+	"filters": {
+		"message": "濾鏡"
+	},
+	"fitToWindow": {
+		"message": "依視窗大小縮放"
+	},
+	"flash": {
+		"message": "是否使用 Flash"
+	},
+	"font": {
+		"message": "字型"
+	},
+	"fontColor": {
+		"message": "字型顏色"
+	},
+	"fontFamily": {
+		"message": "字型"
+	},
+	"fontOpacity": {
+		"message": "字型透明度"
+	},
+	"fontSize": {
+		"message": "字型大小"
+	},
+	"footer": {
+		"message": "頁尾"
+	},
+	"forcedPlaybackSpeed": {
+		"message": "強制播放速度"
+	},
+	"forcedPlayVideoFromTheBeginning": {
+		"message": "強制從頭播放"
+	},
+	"forcedTheaterMode": {
+		"message": "強制劇院模式"
+	},
+	"forcedVolume": {
+		"message": "強制播放音量"
+	},
+	"foundABug": {
+		"message": "遇到問題了嗎?"
+	},
+	"fullWindow": {
+		"message": "全螢幕"
+	},
+	"general": {
+		"message": "一般"
+	},
+	"geoPreference": {
+		"message": "地理位置偏好"
+	},
+	"goToSearchBox": {
+		"message": "轉到搜尋框"
+	},
+	"green": {
+		"message": "綠色"
+	},
+	"hdThumbnail": {
+		"message": "HD 縮圖"
+	},
+	"header": {
+		"message": "標頭"
+	},
+	"hidden": {
+		"message": "隱藏"
+	},
+	"hiddenOnVideoPage": {
+		"message": "於影片頁面自動隱藏"
+	},
+	"hideAnimatedThumbnails": {
+		"message": "隱藏動態的縮圖"
+	},
+	"hideAnnotations": {
+		"message": "隱藏註解"
+	},
+	"hideCards": {
+		"message": "隱藏資訊卡"
+	},
+	"hideCountryCode": {
+		"message": "隱藏國家代號"
+	},
+	"hideDate": {
+		"message": "隱藏日期"
+	},
+	"hideDetailButton": {
+		"message": "隱藏詳細資訊按鈕"
+	},
+	"hideDetails": {
+		"message": "隱藏詳細資訊"
+	},
+	"hideEndscreen": {
+		"message": "隱藏結束畫面"
+	},
+	"hideFeaturedContent": {
+		"message": "隱藏精選影片"
+	},
+	"hideFooter": {
+		"message": "隱藏頁尾"
+	},
+	"hideGradientBottom": {
+		"message": "隱藏底部漸層圖層"
+	},
+	"hideHomePageShorts": {
+		"message": "移除主頁的 Shorts"
+	},
+	"hidePlayerControlsBar": {
+		"message": "隱藏播放器控制欄"
+	},
+	"hidePlayerControlsBarButtons": {
+		"message": "隱藏播放列按鈕"
+	},
+	"hidePlaylist": {
+		"message": "隱藏播放清單"
+	},
+	"hideRightButtons": {
+		"message": "隱藏右側按鈕"
+	},
+	"hideScrollForDetails": {
+		"message": "隱藏「向下捲動即可檢視詳細資訊」"
+	},
+	"hideSkipOverlay": {
+		"message": "隱藏「跳至區段」按鈕"
+	},
+	"hideThumbnailOverlay": {
+		"message": "隱藏縮圖上的按鈕"
+	},
+	"hideViewsCount": {
+		"message": "隱藏觀看次數"
+	},
+	"history": {
+		"message": "觀看記錄"
+	},
+	"home": {
+		"message": "首頁"
+	},
+	"hover": {
+		"message": "滑鼠暫留時顯示"
+	},
+	"hoverOnVideoPage": {
+		"message": "於影片頁面滑鼠暫留時顯示"
+	},
+	"howLongAgoTheVideoWasUploaded": {
+		"message": "顯示影片上傳時間"
+	},
+	"icons": {
+		"message": "圖示"
+	},
+	"iconsOnly": {
+		"message": "只有圖示"
+	},
+	"importSettings": {
+		"message": "匯入設定"
+	},
+	"improvedtubeIconOnYoutube": {
+		"message": "於 YouTube 中顯示 ImprovedTube 圖示"
+	},
+	"improvedtubeLanguage": {
+		"message": "ImprovedTube 語言"
+	},
+	"improveLogo": {
+		"message": "改進 YouTube 圖示"
+	},
+	"increasePlaybackSpeed": {
+		"message": "加快播放速度"
+	},
+	"indigo": {
+		"message": "靛青"
+	},
+	"items": {
+		"message": "專案"
+	},
+	"language": {
+		"message": "語言"
+	},
+	"languages": {
+		"message": "語言"
+	},
+	"legacyYoutube": {
+		"message": "舊版 YouTube"
+	},
+	"light": {
+		"message": "淺色"
+	},
+	"lightBlue": {
+		"message": "淺藍色"
+	},
+	"lightGreen": {
+		"message": "淺綠色"
+	},
+	"like": {
+		"message": "喜歡"
+	},
+	"lime": {
+		"message": "萊姆色"
+	},
+	"list": {
+		"message": "清單"
+	},
+	"liveChat": {
+		"message": "直播聊天室"
+	},
+	"liveChatType": {
+		"message": "直播聊天室類型"
+	},
+	"location": {
+		"message": "地區"
+	},
+	"loudnessNormalization": {
+		"message": "音量標準化"
+	},
+	"markWatchedVideos": {
+		"message": "標記已觀看影片"
+	},
+	"mixer": {
+		"message": "音量混合器"
+	},
+	"myColors": {
+		"message": "自訂主色"
+	},
+	"name": {
+		"message": "名稱"
+	},
+	"nativeMiniPlayer": {
+		"message": "原生迷你播放器"
+	},
+	"new": {
+		"message": "新增"
+	},
+	"nextVideo": {
+		"message": "下一個影片"
+	},
+	"night": {
+		"message": "夜晚"
+	},
+	"noActiveFeatures": {
+		"message": "無已啟用功能"
+	},
+	"none": {
+		"message": "無"
+	},
+	"noOpenVideoTabs": {
+		"message": "無已開啟之影片頁面"
+	},
+	"old": {
+		"message": "舊版"
+	},
+	"onAllVideos": {
+		"message": "於所有影片中"
+	},
+	"onlyActiveOnYoutube": {
+		"message": "僅適用於 YouTube 網站"
+	},
+	"onlyOnePlayerInstancePlaying": {
+		"message": "同時間僅限播放單一影片"
+	},
+	"onSubscribedChannels": {
+		"message": "於已訂閱的頻道中"
+	},
+	"openPopupPlayer": {
+		"message": "開啟影片或播放清單於新視窗中"
+	},
+	"orange": {
+		"message": "橘色"
+	},
+	"os": {
+		"message": "作業系統"
+	},
+	"permissions": {
+		"message": "權限"
+	},
+	"pictureInPicture": {
+		"message": "子母畫面"
+	},
+	"pink": {
+		"message": "粉紅色"
+	},
+	"plain": {
+		"message": "樸素"
+	},
+	"player_fit_to_win_button": {
+		"message": "4x3 Proportion"
+	},
+	"playerColor": {
+		"message": "影片進度條顏色"
+	},
+	"playlists": {
+		"message": "播放清單"
+	},
+	"playPause": {
+		"message": "播放/暫停"
+	},
+	"popupPlayer": {
+		"message": "彈出播放器"
+	},
+	"popupWindowButtons": {
+		"message": "新增彈出播放器按鈕"
+	},
+	"pressAnyKeyOrScroll": {
+		"message": "按任意鍵或使用滑鼠滾輪。"
+	},
+	"pressAnyKeyOrUseMouseWheel": {
+		"message": "按任意鍵或使用滑鼠滾輪。"
+	},
+	"previousVideo": {
+		"message": "回到之前的影片"
+	},
+	"primaryColor": {
+		"message": "主要顏色"
+	},
+	"quality": {
+		"message": "品質"
+	},
+	"rateUs": {
+		"message": "評分"
+	},
+	"red": {
+		"message": "紅色"
+	},
+	"redDislikeButton": {
+		"message": "將「不喜歡」數量以紅色顯示"
+	},
+	"relatedVideos": {
+		"message": "推薦影片"
+	},
+	"removeRelatedSearchResults": {
+		"message": "移除搜尋相關結果"
+	},
+	"removeShortsReelSearchResults": {
+		"message": "刪除搜尋結果中的 Shorts 輪播"
+	},
+	"repeat": {
+		"message": "重複播放"
+	},
+	"reset": {
+		"message": "重設"
+	},
+	"resetAllSettings": {
+		"message": "重設所有設定"
+	},
+	"resetAllShortcuts": {
+		"message": "重設所有快捷鍵"
+	},
+	"reverse": {
+		"message": "回播"
+	},
+	"rotate": {
+		"message": "旋轉影片"
+	},
+	"save": {
+		"message": "儲存"
+	},
+	"saveAs": {
+		"message": "另存為"
+	},
+	"schedule": {
+		"message": "排程"
+	},
+	"screen": {
+		"message": "螢幕"
+	},
+	"screenshot": {
+		"message": "截圖"
+	},
+	"search": {
+		"message": "搜尋"
+	},
+	"searchBarOnly": {
+		"message": "僅顯示搜尋列"
+	},
+	"seekForward10Seconds": {
+		"message": "前進10秒"
+	},
+	"seekNextChapter": {
+		"message": "跳至下一章節"
+	},
+	"seekPreviousChapter": {
+		"message": "跳至前一章節"
+	},
+	"settings": {
+		"message": "設定"
+	},
+	"settingsSuccessfullyImported": {
+		"message": "已成功匯入設定"
+	},
+	"shortcuts": {
+		"message": "快捷鍵"
+	},
+	"showCardsOnMouseHover": {
+		"message": "滑鼠暫留時顯示資訊卡"
+	},
+	"showChannelVideosCount": {
+		"message": "顯示頻道影片數量"
+	},
+	"showLess": {
+		"message": "顯示更少"
+	},
+	"showMore": {
+		"message": "顯示更多"
+	},
+	"shuffle": {
+		"message": "隨機播放"
+	},
+	"sidebar": {
+		"message": "側邊欄"
+	},
+	"spacebar": {
+		"message": "空白鍵"
+	},
+	"squaredUserImages": {
+		"message": "方形使用者圖示"
+	},
+	"static": {
+		"message": "靜止"
+	},
+	"statsForNerds": {
+		"message": "顯示「統計資料」按鈕"
+	},
+	"style": {
+		"message": "樣式"
+	},
+	"styles": {
+		"message": "樣式"
+	},
+	"subscriptions": {
+		"message": "訂閱內容"
+	},
+	"sunset": {
+		"message": "日落"
+	},
+	"sunsetToSunrise": {
+		"message": "日出至入落"
+	},
+	"systemPeferenceDark": {
+		"message": "系統預設: 暗黑模式"
+	},
+	"systemPeferenceLight": {
+		"message": "系統預設: 白天模式"
+	},
+	"teal": {
+		"message": "藍綠色"
+	},
+	"textColor": {
+		"message": "文字顏色"
+	},
+	"themes": {
+		"message": "主題"
+	},
+	"thisWillRemoveAllCookies": {
+		"message": "這將刪除所有的 cookies。"
+	},
+	"thisWillRemoveAllYouTubeCookies": {
+		"message": "這將刪除所有 YouTube Cookies。"
+	},
+	"thisWillResetAllSettings": {
+		"message": "這將重設所有設定。"
+	},
+	"thisWillResetAllShortcuts": {
+		"message": "這將重設所有快捷鍵。"
+	},
+	"thumbnails": {
+		"message": "縮圖"
+	},
+	"timeFrom": {
+		"message": "開始時間"
+	},
+	"timeTo": {
+		"message": "結束時間"
+	},
+	"todayAt": {
+		"message": "自今日"
+	},
+	"toggleCards": {
+		"message": "啟用結束畫面"
+	},
+	"toggleControls": {
+		"message": "開關播放器控制"
+	},
+	"topChat": {
+		"message": "重點聊天室訊息"
+	},
+	"trailerAutoplay": {
+		"message": "預告片自動播放"
+	},
+	"translations": {
+		"message": "翻譯"
+	},
+	"trending": {
+		"message": "發燒影片"
+	},
+	"tryToReloadThePage": {
+		"message": "嘗試重新整理頁面"
+	},
+	"type": {
+		"message": "種類"
+	},
+	"upNextAutoplay": {
+		"message": "自動播放下一個影片"
+	},
+	"use24HourFormat": {
+		"message": "使用24小時格式"
+	},
+	"video": {
+		"message": "影片"
+	},
+	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
+		"message": "影片敘述將自動展開以顯示影片分類名稱"
+	},
+	"videoFormats": {
+		"message": "影片格式"
+	},
+	"videos": {
+		"message": "影片"
+	},
+	"watchLater": {
+		"message": "稍後觀看"
+	},
+	"watchTime": {
+		"message": "已觀看時間"
+	},
+	"whenTabIsChanged": {
+		"message": "當分頁改變時"
+	},
+	"windowColor": {
+		"message": "視窗顏色"
+	},
+	"windowOpacity": {
+		"message": "視窗透明度"
+	},
+	"yellow": {
+		"message": "黃色"
+	},
+	"youtubeHeaderLeft": {
+		"message": "YouTube 標頭 (左)"
+	},
+	"youtubeHeaderRight": {
+		"message": "YouTube 標頭 (右)"
+	},
+	"youtubeHomePage": {
+		"message": "預設的 YouTube 首頁"
+	},
+	"youtubeLanguage": {
+		"message": "YouTube 語言"
+	},
+	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
+		"message": "使用 H.264 編碼時，YouTube 會將畫質限制為 1080p 內。"
+	}
 }


### PR DESCRIPTION
Spaces to tabs.
Bad entries fixed.
Moved remaining text to locales.
Ton of duplicates removed, 800KB -> 670KB.
Next patch will rename all keys to correspond with skeleton component entries, this way all the redundant skeleton.text entries can be removed.